### PR TITLE
[FIX] stylelint rem 단위 추가

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -27,8 +27,8 @@
       "padding-right": ["rem"],
       "padding-top": ["rem"],
       "padding-bottom": ["rem"],
-      "letter-spacing": ["em"],
-      "word-spacing": ["em"],
+      "letter-spacing": ["em", "rem"],
+      "word-spacing": ["em", "rem"],
       "/^border/": ["px"]
     },
 

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,8 +15,8 @@
     ],
     "color-named": "never",
     "declaration-property-unit-allowed-list": {
-      "width": ["%", "vw"],
-      "height": ["%", "vh"],
+      "width": ["%", "vw", "rem"],
+      "height": ["%", "vh", "rem"],
       "font-size": ["rem", "%"],
       "margin": ["rem"],
       "margin-left": ["rem"],


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- stylelint width / height에 rem 단위를 추가했습니다


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

-  letter-spacing, word-spacing도 em만 설정되어있어서 rem 단위 필요할 것 같으면 확인 부탁드립니다!

## 관련 이슈

close #13