### PR TITLE
[BUILD] CI/CD 구성

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -3,12 +3,14 @@ name: Front Deployment
 on:
   push:
     branches:
-      - develop
       - main
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   ci:
-    if: github.ref == 'refs/heads/develop'
+    if: github.event_name == 'pull_request' && github.ref == 'refs/heads/develop'
     name: Build and Test for Develop
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -4,12 +4,36 @@ on:
   push:
     branches:
       - develop
+      - main
 
 jobs:
-  build-and-deploy:
-    name: Build and Deploy to AWS S3
+  ci:
+    if: github.ref == 'refs/heads/develop'
+    name: Build and Test for Develop
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build project
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test
+
+  cd:
+    if: github.ref == 'refs/heads/main'
+    name: Build and Deploy to AWS S3 for Main
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -37,5 +61,4 @@ jobs:
         run: aws s3 sync dist s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete --cache-control "max-age=31536000"
 
       - name: Invalidate AWS CloudFront Distribution
-        if: github.ref == 'refs/heads/develop'
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths "/*"

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,0 +1,41 @@
+name: Front Deployment
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy to AWS S3
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build project
+        run: yarn build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Upload build to AWS S3
+        run: aws s3 sync dist s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete --cache-control "max-age=31536000"
+
+      - name: Invalidate AWS CloudFront Distribution
+        if: github.ref == 'refs/heads/develop'
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths "/*"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- s3 버킷, cloudfront에 자동으로 배포되도록 ci/cd 설정을 완료하였습니다.
- 관련 시크릿키 깃헙에 추가해두었습니다!
  -  `AWS_S3_BUCKET_NAME`
  - `AWS_S3_ACCESS_KEY_ID`
  - `AWS_S3_SECRET_ACCESS_KEY_ID`
  - `AWS_CLOUDFRONT_ID`
- **`develop` 브랜치에 push 한 경우에만**(PR 머지) 동작하도록 설정하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- IAM을 사용하지 않고도 s3 배포가 가능하다는 점을 알았다. 근데 보안 측면에서 더 우수하다고 하여 등록하였습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 엑세스 키, 시크릿 키는 **노출이 되면 새로 발급받아야함 & 모르는 사이 큰 금액 청구될 수 있음** 이니 주의 부탁드립니다! (노션 공유계정 공간에 올려두겠습니다.)
- 깃헙에 올라간 파일에는 주석 제거해두었습니다! 코드 관련한 부분은 밑에 주석부분 참고해주세요!
```yaml
name: Front Deployment

on:
  push:
    branches:
      - develop

jobs:
  build-and-deploy:
    name: Build and Deploy to AWS S3
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3
      
      - name: Setup Node.js
        uses: actions/setup-node@v2
        with:
          node-version: '20' 
          cache: 'yarn' 

      - name: Install dependencies
        run: yarn install --frozen-lockfile

      - name: Build project
        run: yarn build 

        # AWS credentials 설정 : 깃헙 액션이 aws 리소스에 접근할 수 있도록 구성
      - name: Configure AWS credentials
        uses: aws-actions/configure-aws-credentials@v1
        with: # secrets.AWS_S3_ACCESS_KEY_ID & secrets.AWS_S3_SECRET_ACCESS_KEY_ID는 깃헙 시크릿키에 저장
          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
          aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY_ID }}
          aws-region: ap-northeast-2

        # aws s3로 빌드 업로드
      - name: Upload build to AWS S3
        run: aws s3 sync dist s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete --cache-control "max-age=31536000"
        # aws s3 sync : 빌드 디렉토리(dist)의 내용을 s3 버킷으로 동기화
        # --delete 옵션: s3 버킷에는 없는 로컬 파일 삭제 -> 버킷 내용 로컬과 동일하게 만듦
        # --cache-control: 브라우저니 cloudFront같은 CDN에서 파일 캐싱하는 방법 결정
                # "max-age=31536000": 파일 한번 다운로드되면 1년동안 서버에 요청x. 캐시에서 불러옴
         # => 새로운 빌드가 s3 버킷으로 전송 -> 웹사이트 업데이트

        # aws cloudFront 모든 캐시 무효화 (이전 버전 파일이 캐시에 남아있을 수 있으므로) ("/*" 로 설정했으므로 모든 파일 무효화)
      - name: Invalidate AWS CloudFront Distribution
        if: github.ref == 'refs/heads/develop' # develop에 푸시할때만 실행되도록 설정
        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths "/*"

```

## 관련 이슈

close #18 

## 스크린샷 (선택)

**Actions** 탭에서 다음과 같이 각 단계 로그 확인이 가능합니다. 오류 시 해당 부분 참고하여 수정하시면 됩니다!

<img width="467" alt="스크린샷 2024-07-05 01 20 25" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/128016888/ca1a725b-e95b-4ce2-b6a4-adf4f624142e">
