### PR TITLE
[FEAT] 마감기한 공통컴포넌트 - 지연 상태일때의 스타일 추가

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -10,10 +10,11 @@ interface BtnDateProps {
 	date?: string;
 	time?: string;
 	size?: string;
+	isDelayed?: boolean;
 }
 
 function BtnDate(props: BtnDateProps) {
-	const { date = '마감 기한', time = '마감 시간', size = 'big' } = props;
+	const { date = '마감 기한', time = '마감 시간', size = 'big', isDelayed = false } = props;
 	const [isPressed, setIsPressed] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
 
@@ -34,14 +35,15 @@ function BtnDate(props: BtnDateProps) {
 			isPressed={isPressed}
 			isClicked={isClicked}
 			size={size}
+			isDelayed={isDelayed}
 			isDefaultDate={isDefaultDate}
 			isDefaultTime={isDefaultTime}
 			onMouseDown={handleMouseDown}
 			onMouseUp={handleMouseUp}
 		>
-			<BtnDateText icon={<CalanderIcon />} text={date} isDefault={isDefaultDate} size={size} />
-			<LineIcon size={size} />
-			<BtnDateText icon={<ClockIcon />} text={time} isDefault={isDefaultTime} size={size} />
+			<BtnDateText icon={<CalanderIcon isDelayed={isDelayed} />} text={date} isDefault={isDefaultDate} size={size} />
+			<LineIcon size={size} isDelayed={isDelayed} />
+			<BtnDateText icon={<ClockIcon isDelayed={isDelayed} />} text={time} isDefault={isDefaultTime} size={size} />
 			<XIcon isClicked={isClicked} />
 		</BtnDateLayout>
 	);
@@ -58,34 +60,47 @@ const XIcon = styled((props: React.SVGProps<SVGSVGElement> & { isClicked: boolea
 	height: 2rem;
 `;
 
-const CalanderIcon = styled(Icons.Icn_calander, { target: 'CalanderIcon' })`
+const CalanderIcon = styled(Icons.Icn_calander, { target: 'CalanderIcon' })<{ isDelayed: boolean }>`
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 1.4rem;
 	height: 1.4rem;
+
+	path {
+		stroke: ${({ isDelayed, theme }) => (isDelayed ? theme.palette.Orange.Orange4 : 'currentColor')};
+	}
 `;
 
-const ClockIcon = styled(Icons.Icn_date_clock, { target: 'ClockIcon' })`
+const ClockIcon = styled(Icons.Icn_date_clock, { target: 'ClockIcon' })<{ isDelayed: boolean }>`
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 1.4rem;
 	height: 1.4rem;
+
+	path {
+		stroke: ${({ isDelayed, theme }) => (isDelayed ? theme.palette.Orange.Orange4 : 'currentColor')};
+	}
 `;
 
-const LineIcon = styled(Icons.Icn_line, { target: 'LineIcon' })<{ size: string }>`
+const LineIcon = styled(Icons.Icn_line, { target: 'LineIcon' })<{ size: string; isDelayed: boolean }>`
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 0.1rem;
 	height: ${({ size }) => (size === 'big' ? '2.2rem' : '1.2rem')};
+
+	line {
+		stroke: ${({ isDelayed, theme }) => (isDelayed ? theme.palette.Orange.Orange5 : 'currentColor')};
+	}
 `;
 
 const BtnDateLayout = styled.div<{
 	isPressed: boolean;
 	isClicked: boolean;
 	size: string;
+	isDelayed: boolean;
 	isDefaultDate: boolean;
 	isDefaultTime: boolean;
 }>`
@@ -102,13 +117,22 @@ const BtnDateLayout = styled.div<{
 	border-color: ${({ isClicked, theme }) => (isClicked ? theme.palette.Primary : theme.palette.Grey.Grey3)};
 	border-radius: 8px;
 
+	${({ isDelayed, theme }) =>
+		isDelayed &&
+		css`
+			background: ${theme.palette.Orange.Orange1};
+			border-color: ${theme.palette.Orange.Orange5};
+
+			pointer-events: none;
+		`}
+
 	${({ isClicked, size, theme }) =>
 		isClicked &&
 		css`
 			padding-right: ${size === 'big' ? '0.6rem' : '0.2rem'};
 
 			border-color: ${theme.palette.Primary};
-			border-width: 2px;
+			border-width: ${size === 'big' ? '2px' : '1px'};
 		`}
 
 	${({ isPressed, theme }) =>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -25,6 +25,7 @@ function Today() {
 			<TextInputTime time="total" />
 			<TextInputStaging />
 			<BtnDate date="2024.07.11" size="big" />
+			<BtnDate date="2024.07.11" size="small" isDelayed />
 			<BtnStagingDate />
 			<TargetArea />
 		</>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 마감기한 공통 컴포넌트에서, 지연 상태일때의 스타일이 추가되어서 props에 `isDelayed`를 이용해 구현하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- `isDelayed`일때는(: 지연상태) hover / pressed / clicked가 발생하면 안된다. 이 경우를 하나하나 상태 엮어서 스타일링 해야하나 했는데, **`pointer-events: none;`** 라는 것을 이용하면 다음 이벤트들이 막아진다는 것을 알았다!
 
## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- size가 small일때만 사용되는 스타일링이지만, size 역시 props로 넘겨받기에 따로 제한을 걸어두지는 않았습니다! 제한을 거는 것이 좋을 지 코멘트 부탁드려요! 

## 관련 이슈

close #59 

## 스크린샷 (선택)

https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/128016888/b65443d6-96e0-42c8-96f2-6448e6926f03


