### PR TITLE
[FEAT] 스크롤 하단(gradient 적용) 공통 컴포넌트 생성

### DIFF
--- a/src/components/common/ScrollGradient.tsx
+++ b/src/components/common/ScrollGradient.tsx
@@ -23,7 +23,7 @@ const ScrollGradientTop = styled.div`
 	width: 100%;
 	height: 2.2rem;
 
-	background: linear-gradient(180deg, rgb(255 255 255 / 0%) 0%, #fff 65.91%);
+	background: linear-gradient(180deg, rgb(255 255 255 / 0%) 0%, ${({ theme }) => theme.palette.Grey.White} 65.91%);
 `;
 
 const ScrollGradientBottom = styled.div`

--- a/src/components/common/ScrollGradient.tsx
+++ b/src/components/common/ScrollGradient.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+function ScrollGradient() {
+	return (
+		<ScrollGradientLayout>
+			<ScrollGradientTop />
+			<ScrollGradientBottom />
+		</ScrollGradientLayout>
+	);
+}
+
+export default ScrollGradient;
+
+const ScrollGradientLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+`;
+
+const ScrollGradientTop = styled.div`
+	flex-shrink: 0;
+	width: 100%;
+	height: 2.2rem;
+
+	background: linear-gradient(180deg, rgb(255 255 255 / 0%) 0%, #fff 65.91%);
+`;
+
+const ScrollGradientBottom = styled.div`
+	flex-shrink: 0;
+	width: 100%;
+	height: 1.2rem;
+
+	background: ${({ theme }) => theme.palette.Grey.White};
+`;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -6,6 +6,7 @@ import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInPr
 import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import NavBar from '@/components/common/NavBar';
+import ScrollGradient from '@/components/common/ScrollGradient';
 import TextboxDailydate from '@/components/common/textbox/TextboxDailydate';
 import TextboxInput from '@/components/common/textbox/TextboxInput';
 import TextInputDesc from '@/components/common/textbox/TextInputDesc';
@@ -18,6 +19,9 @@ function Today() {
 	return (
 		<>
 			<NavBar />
+
+			<ScrollGradient />
+
 			<BtnTask btnType={1} isDescription />
 
 			<p>Done</p>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 스크롤 하단에 gradient를 통해 구분하는 부분이 공통으로 적용되는 부분이라, `common/` 에 컴포넌트 생성하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- linear-gradient를 설정해도 안보인다면 배경색을 깔아보자..! 그림자도 흰색, 배경도 흰색이라 적용 안되는 줄 알았다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 스크롤 적용되는 부분의 밑에 적용하여 사용해주시면 됩니다! width는 자동으로 맞춰집니다!

## 관련 이슈

close #68 

## 스크린샷 (선택)

연두색 부분입니다!

<img width="908" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/128016888/0121b0a4-989d-4ee1-9aa0-fb1ab3503ba1">
