### PR TITLE
[FIX] ScrollGradient 컴포넌트 위치 고정

### DIFF
--- a/src/components/common/ScrollGradient.tsx
+++ b/src/components/common/ScrollGradient.tsx
@@ -12,10 +12,14 @@ function ScrollGradient() {
 export default ScrollGradient;
 
 const ScrollGradientLayout = styled.div`
+	position: sticky;
+	bottom: 0;
+	z-index: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
 `;
 
 const ScrollGradientTop = styled.div`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- ScrollGradient 컴포넌트가 사용되는 모든 부분에서 하단에 위치하여서, 해당 컴포넌트 단에서 위치를 하단으로 고정하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- `position: sticky` 라는 속성에 대해 알았다. 
'요소는 처음에 문서의 정상적인 레이아웃 흐름에 따라 배치지만, 사용자가 스크롤할 때 요소가 **지정된 위치에 도달하면 요소는 화면에 고정**됩니다. 이 고정 위치는 상단, 하단, 왼쪽, 오른쪽 등의 방향을 기준으로 지정할 수 있습니다.'

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 해당 부분 업데이트 하여 사용해주시면 됩니다 감사합니다!

## 관련 이슈

close #70 

