### PR TITLE
[FEAT] 대시보드 뷰 task 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
 
+import BtnTask from '@/components/common/BtnTask/BtnTask';
+import ScrollGradient from '@/components/common/ScrollGradient';
+
 interface DashboardTaskProps {
 	text: string;
 }
@@ -14,7 +17,16 @@ function DashboardTask({ text }: DashboardTaskProps) {
 					<NumberText>개</NumberText>
 				</NumberTextBox>
 			</TextBox>
-			<ScrollArea />
+			<ScrollArea>
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<ScrollGradient />
+			</ScrollArea>
 		</TaskLayout>
 	);
 }

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -4,14 +4,27 @@ import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
 
 interface DashboardTaskProps {
-	text: string;
+	text: 'upcoming' | 'postponed' | 'inprogress';
 }
 
 function DashboardTask({ text }: DashboardTaskProps) {
+	const DASHBOARD_TASK_TYPE = {
+		UPCOMING: '다가오는 할 일',
+		POSTPONED: '지연된 할 일',
+		INPROGRESS: '진행중인 할 일',
+	};
+	let taskStatus = '';
+	if (text === 'upcoming') {
+		taskStatus = DASHBOARD_TASK_TYPE.UPCOMING;
+	} else if (text === 'postponed') {
+		taskStatus = DASHBOARD_TASK_TYPE.POSTPONED;
+	} else if (text === 'inprogress') {
+		taskStatus = DASHBOARD_TASK_TYPE.INPROGRESS;
+	}
 	return (
 		<TaskLayout>
 			<TextBox>
-				<TaskText text={text}>{text}</TaskText>
+				<TaskText text={text}>{taskStatus}</TaskText>
 				<NumberTextBox>
 					<Number>2</Number>
 					<NumberText>개</NumberText>

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -1,0 +1,81 @@
+import styled from '@emotion/styled';
+
+interface DashboardTaskProps {
+	text: string;
+}
+
+function DashboardTask({ text }: DashboardTaskProps) {
+	return (
+		<TaskLayout>
+			<TextBox>
+				<TaskText text={text}>{text}</TaskText>
+				<NumberTextBox>
+					<Number>2</Number>
+					<NumberText>개</NumberText>
+				</NumberTextBox>
+			</TextBox>
+			<ScrollArea />
+		</TaskLayout>
+	);
+}
+export default DashboardTask;
+
+const TaskLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	align-self: stretch;
+	width: 41.7rem;
+	height: 41rem;
+
+	border: 1px solid #dedede;
+	border-radius: 12px;
+`;
+
+const TextBox = styled.span`
+	display: flex;
+	justify-content: space-between;
+	width: 41.7rem;
+	height: 7rem;
+`;
+
+const TaskText = styled.div<{ text: string }>`
+	display: flex;
+	align-items: flex-start;
+	min-width: 11.8rem;
+	padding: 1.8rem 0 2rem 2.2rem;
+
+	${({ theme }) => theme.fontTheme.HEADLINE_02};
+	color: ${({ theme }) => theme.palette.Grey.Black};
+`;
+
+const NumberTextBox = styled.div`
+	display: flex;
+	align-items: center;
+	width: 3.8rem;
+	height: 4rem;
+	margin: 1.5rem 2.2rem 1.5rem 0;
+`;
+
+const Number = styled.p`
+	${({ theme }) => theme.fontTheme.TITLE_02};
+	color: ${({ theme }) => theme.palette.Grey.Grey8};
+`;
+
+const NumberText = styled.p`
+	${({ theme }) => theme.fontTheme.HEADLINE_02}
+	color: ${({ theme }) => theme.palette.Grey.Grey7}
+`;
+
+const ScrollArea = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	align-items: stretch;
+	box-sizing: border-box;
+	width: 41.7rem;
+	height: 33.9rem;
+	padding: 0 0.7rem;
+	overflow: scroll;
+`;

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -2,17 +2,14 @@ import styled from '@emotion/styled';
 
 import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
+import DASHBOARD_TASK_TYPE from '@/constants/dashboardTask';
+import TODAY from '@/constants/tasksToday';
 
 interface DashboardTaskProps {
 	text: 'upcoming' | 'postponed' | 'inprogress';
 }
 
 function DashboardTask({ text }: DashboardTaskProps) {
-	const DASHBOARD_TASK_TYPE = {
-		UPCOMING: '다가오는 할 일',
-		POSTPONED: '지연된 할 일',
-		INPROGRESS: '진행중인 할 일',
-	};
 	let taskStatus = '';
 	if (text === 'upcoming') {
 		taskStatus = DASHBOARD_TASK_TYPE.UPCOMING;
@@ -26,7 +23,7 @@ function DashboardTask({ text }: DashboardTaskProps) {
 			<TextBox>
 				<TaskText text={text}>{taskStatus}</TaskText>
 				<NumberTextBox>
-					<Number>2</Number>
+					<Number>{TODAY.data.tasks.length}</Number>
 					<NumberText>개</NumberText>
 				</NumberTextBox>
 			</TextBox>
@@ -53,7 +50,7 @@ const TaskLayout = styled.div`
 	width: 41.7rem;
 	height: 41rem;
 
-	border: 1px solid #dedede;
+	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;
 `;
 

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -18,13 +18,13 @@ function DashboardTask({ text }: DashboardTaskProps) {
 				</NumberTextBox>
 			</TextBox>
 			<ScrollArea>
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
-				<BtnTask btnType={2} status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
+				<BtnTask btnType="target" status="Done" isDescription={false} />
 				<ScrollGradient />
 			</ScrollArea>
 		</TaskLayout>
@@ -56,8 +56,8 @@ const TaskText = styled.div<{ text: string }>`
 	align-items: flex-start;
 	min-width: 11.8rem;
 	padding: 1.8rem 0 2rem 2.2rem;
-
 	${({ theme }) => theme.fontTheme.HEADLINE_02};
+
 	color: ${({ theme }) => theme.palette.Grey.Black};
 `;
 

--- a/src/constants/dashboardTask.ts
+++ b/src/constants/dashboardTask.ts
@@ -1,0 +1,7 @@
+const DASHBOARD_TASK_TYPE = {
+	UPCOMING: '다가오는 할 일',
+	POSTPONED: '지연된 할 일',
+	INPROGRESS: '진행중인 할 일',
+};
+
+export default DASHBOARD_TASK_TYPE;

--- a/src/constants/tasksToday.ts
+++ b/src/constants/tasksToday.ts
@@ -1,0 +1,26 @@
+const TODAY = {
+	code: 'success',
+	data: {
+		tasks: [
+			{
+				id: 1,
+				name: 'task name',
+				deadLine: {
+					date: '2024-06-30',
+					time: '12:30',
+				},
+			},
+			{
+				id: 2,
+				name: 'task name',
+				deadLine: {
+					date: '2024-06-30',
+					time: '12:30',
+				},
+			},
+		],
+	},
+	message: null,
+};
+
+export default TODAY;

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import DashboardTask from '@/components/DashboardPage/DashboardTask';
 import TaskSummary from '@/components/DashboardPage/TaskSummary';
 import PERIOD from '@/constants/tasksPeriod';
 
@@ -27,6 +28,7 @@ function DashBoard() {
 
 	return (
 		<DashBoardWrapper>
+			<DashboardTask text="upcoming" />
 			<TaskSummaryWrapper>
 				{SUMMARY_INFO.map((info) => (
 					<TaskSummary key={info.name} text={info.text} data={info.data} unit={info.unit} />


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 대시보드 뷰의 task 컴포넌트를 구현했습니다.
- 다가오는 할 일 / 지연된 할 일 / 진행중인 할 일 텍스트는 text를 prop으로 받아 작성하시면 됩니다. 혹시라도 더 좋은 방법이 있다면 알려주세요!
- Btntask 컴포넌트가 박스 사이즈를 넘어가면 무한 스크롤이 생성되도록 구현하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 그라디언트 속성을 어떻게 줄 수 있을지 감이 잘 안왔는데 지원이가 태그를 넣기만 하면 바로 적용되도록 공통 컴포넌트를 잘 빼주어서 편리하게 사용할 수 있었습니다. 기억 속 잊혀졌던 z-index와 sticky 속성, 그리고 bottom 을 0으로 주어 컴포넌트의 하단에 그라디언트를 잘 줄 수 있었습니다.
- 스크롤바를 처음 넣어봐서 감도 안오고 잔뜩 겁먹었었는데 생각보다 별게 아니었습니다. 심지어 커스텀할 일도 없었음... overflow를 scroll로 주면 되는거였습니다.. 레전드 간단. . 슛~! 슛!!🚀

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- task 개수는 api를 연동해야 해서 우선은 하드코딩으로 때려박았습니다. (사실 다가오는 일 / 지연 / 진행 중 별로 상수 데이터를 어떻게 가져올 수 있을지 감이 안와서 하드코딩한 부분도 있는데 뷰 구현 담당자가 상수 데이터로 박아놓는게 좋은 것 같다면 관련하여 피드백 함께 부탁드리면 반영해보도록 하겠습니다!)

## 관련 이슈

close #64

## 스크린샷

`구현한 컴포넌트(파란 박스 영역 안)`

<img width="650" alt="대시보드 task 컴포넌트" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/151596186/7b260b39-c53a-4a75-a87d-272da3f76c3d">

`구현 영상`


https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/151596186/d188fade-74ca-476e-8902-adfe01ff1c18





