### PR TITLE
[FEAT] StagingArea 퍼블리싱

### DIFF
--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -2,16 +2,15 @@ import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
-import BtnDate from '../BtnDate/BtnDate';
-import StatusDoneBtn from '../button/statusBtn/StatusDoneBtn';
-import StatusInProgressBtn from '../button/statusBtn/StatusInProgressBtn';
-import StatusStagingBtn from '../button/statusBtn/StatusStagingBtn';
-import StatusTodoBtn from '../button/statusBtn/StatusTodoBtn';
-
 import Icons from '@/assets/svg/index';
+import BtnDate from '@/components/common/BtnDate/BtnDate';
+import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
+import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
+import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
+import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 
 interface BtnTaskProps {
-	btnType: number;
+	btnType: 'staging' | 'target' | 'delayed';
 	status?: string;
 	isDescription?: boolean;
 }
@@ -21,7 +20,7 @@ interface BorderColorProps {
 	isClicked: boolean;
 	iconHovered: boolean;
 	theme: Theme;
-	btnType: number;
+	btnType: string;
 }
 
 function BtnTask(props: BtnTaskProps) {
@@ -65,7 +64,7 @@ function BtnTask(props: BtnTaskProps) {
 	};
 
 	const renderStatusButton = () => {
-		if (btnType === 3) {
+		if (btnType === 'delayed') {
 			return <StagingIconHoverIndicator />;
 		}
 
@@ -73,11 +72,11 @@ function BtnTask(props: BtnTaskProps) {
 			return <IconHoverIndicator />;
 		}
 
-		if (btnType === 1) {
+		if (btnType === 'staging') {
 			return <StatusStagingBtn />;
 		}
 
-		if (btnType === 2) {
+		if (btnType === 'target') {
 			switch (status) {
 				case 'Done':
 					return <StatusDoneBtn />;
@@ -104,7 +103,7 @@ function BtnTask(props: BtnTaskProps) {
 					{isDescription && <IconFile />}
 					넛쉘 UT 진행하기
 				</BtnTaskTextWrapper>
-				<BtnDate date="2024.07.11" time="22:22" size="small" isDelayed={btnType === 3} />
+				<BtnDate date="2024.07.11" time="22:22" size="small" isDelayed={btnType === 'delayed'} />
 			</BtnTaskContainer>
 			<IconHoverContainer
 				onClick={handleIconClick}
@@ -125,7 +124,7 @@ const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: B
 	const clickColor = theme.palette.Primary;
 	const orangeColor = theme.palette.Orange.Orange8;
 	let borderColor = defaultColor;
-	if (btnType === 3) {
+	if (btnType === 'delayed') {
 		borderColor = orangeColor;
 	} else if (iconHovered || isHovered) {
 		borderColor = hoverColor;
@@ -141,7 +140,7 @@ const BtnTaskLayout = styled('div', { target: 'BtnTaskLayout' })<{
 	isClicked: boolean;
 	isHovered: boolean;
 	iconHovered: boolean;
-	btnType: number;
+	btnType: string;
 }>`
 	display: flex;
 	align-items: center;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -46,7 +46,7 @@ const StagingAreaLayout = styled.div`
 	align-items: center;
 	padding: 0 0.7rem;
 
-	border-right: 1px solid #e4e4e4;
+	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 0 12px 12px 0;
 `;
 

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
 
-import BtnTask from '../BtnTask/BtnTask';
-import ScrollGradient from '../ScrollGradient';
-import TextInputStaging from '../textbox/TextInputStaging';
-
-import StagingAreaSetting from './StagingAreaSetting';
+import BtnTask from '@/components/common/BtnTask/BtnTask';
+import ScrollGradient from '@/components/common/ScrollGradient';
+import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
+import TextInputStaging from '@/components/common/textbox/TextInputStaging';
 
 function StagingArea() {
 	return (
@@ -15,19 +14,17 @@ function StagingArea() {
 					<StagingAreaTaskContainer>
 						<StagingAreaSetting />
 						<BtnTaskContainer>
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
-							<BtnTask btnType={1} />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
+							<BtnTask btnType="staging" />
 							<ScrollGradient />
 						</BtnTaskContainer>
 					</StagingAreaTaskContainer>

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -42,9 +42,9 @@ export default StagingArea;
 
 const StagingAreaLayout = styled.div`
 	display: inline-flex;
-	gap: 8px;
+	gap: 0.8rem;
 	align-items: center;
-	padding: 0 7px;
+	padding: 0 0.7rem;
 
 	border-right: 1px solid #e4e4e4;
 	border-radius: 0 12px 12px 0;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled';
+
+import BtnTask from '../BtnTask/BtnTask';
+import TextInputStaging from '../textbox/TextInputStaging';
+
+import StagingAreaSetting from './StagingAreaSetting';
+
+function StagingArea() {
+	return (
+		<StagingAreaLayout>
+			<StagingAreaContainer>
+				<StagingAreaUpContainer>
+					<StagingAreaTitle>쏟아내기</StagingAreaTitle>
+					<StagingAreaTaskContainer>
+						<StagingAreaSetting />
+						<BtnTaskContainer>
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+							<BtnTask btnType={1} />
+						</BtnTaskContainer>
+					</StagingAreaTaskContainer>
+				</StagingAreaUpContainer>
+				<TextInputStaging />
+			</StagingAreaContainer>
+		</StagingAreaLayout>
+	);
+}
+
+export default StagingArea;
+
+const StagingAreaLayout = styled.div`
+	display: inline-flex;
+	gap: 8px;
+	align-items: center;
+	padding: 0 7px;
+
+	border-right: 1px solid #e4e4e4;
+	border-radius: 0 12px 12px 0;
+`;
+
+const StagingAreaContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	height: 76.8rem;
+	padding-bottom: 2.8rem;
+`;
+
+const StagingAreaUpContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	align-self: stretch;
+`;
+
+const StagingAreaTitle = styled.div`
+	display: flex;
+	gap: 0.8rem;
+	align-items: center;
+	justify-content: center;
+	padding: 2.8rem 3.6rem 2.1rem 1.2rem;
+	${({ theme }) => theme.fontTheme.HEADLINE_02};
+`;
+
+const StagingAreaTaskContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 1.3rem;
+	align-items: flex-start;
+	align-self: stretch;
+`;
+
+const BtnTaskContainer = styled.div`
+	width: 100%;
+	height: 54.6rem;
+	overflow: scroll;
+`;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import BtnTask from '../BtnTask/BtnTask';
+import ScrollGradient from '../ScrollGradient';
 import TextInputStaging from '../textbox/TextInputStaging';
 
 import StagingAreaSetting from './StagingAreaSetting';
@@ -27,6 +28,7 @@ function StagingArea() {
 							<BtnTask btnType={1} />
 							<BtnTask btnType={1} />
 							<BtnTask btnType={1} />
+							<ScrollGradient />
 						</BtnTaskContainer>
 					</StagingAreaTaskContainer>
 				</StagingAreaUpContainer>
@@ -83,6 +85,6 @@ const StagingAreaTaskContainer = styled.div`
 
 const BtnTaskContainer = styled.div`
 	width: 100%;
-	height: 54.6rem;
+	height: 56.7rem;
 	overflow: scroll;
 `;

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
+import TextBtn from '../button/textBtn/TextBtn';
+
+interface StagingAreaSettingProps {
+	// 전체 / 지연인지 클릭이벤트?
+}
+
+function StagingAreaSetting(props: StagingAreaSettingProps) {
+	const [activeButton, setActiveButton] = useState<'전체' | '취소'>('전체');
+
+	const handleButtonClick = (button: '전체' | '취소') => {
+		setActiveButton(button);
+	};
+
+	return (
+		<StagingAreaSettingLayout>
+			<TextBtnContainer>
+				<TextBtn
+					size="small"
+					text="전체"
+					color={activeButton === '전체' ? 'BLUE' : 'WHITE'}
+					mode={activeButton === '전체' ? 'DEFAULT' : 'LIGHT'}
+					isHover
+					isPressed
+					onClick={() => handleButtonClick('전체')}
+				/>
+				<TextBtn
+					size="small"
+					text="취소"
+					color={activeButton === '취소' ? 'BLUE' : 'WHITE'}
+					mode={activeButton === '취소' ? 'DEFAULT' : 'LIGHT'}
+					isHover
+					isPressed
+					onClick={() => handleButtonClick('취소')}
+				/>
+			</TextBtnContainer>
+			<ArrangeBtn type="set" mode="DISABLED" color="WHITE" size="small" />
+		</StagingAreaSettingLayout>
+	);
+}
+
+export default StagingAreaSetting;
+
+const StagingAreaSettingLayout = styled.div`
+	display: flex;
+	align-items: center;
+	align-self: stretch;
+	justify-content: space-between;
+`;
+
+const TextBtnContainer = styled.div`
+	display: flex;
+	gap: 4px;
+	align-items: center;
+	padding-left: 0.4rem;
+`;

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -1,14 +1,10 @@
+import styled from '@emotion/styled';
 import { useState } from 'react';
-import styled from 'styled-components';
 
 import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
 import TextBtn from '../button/textBtn/TextBtn';
 
-interface StagingAreaSettingProps {
-	// 전체 / 지연인지 클릭이벤트?
-}
-
-function StagingAreaSetting(props: StagingAreaSettingProps) {
+function StagingAreaSetting() {
 	const [activeButton, setActiveButton] = useState<'전체' | '취소'>('전체');
 
 	const handleButtonClick = (button: '전체' | '취소') => {

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -53,7 +53,7 @@ const StagingAreaSettingLayout = styled.div`
 
 const TextBtnContainer = styled.div`
 	display: flex;
-	gap: 4px;
+	gap: 0.4rem;
 	align-items: center;
 	padding-left: 0.4rem;
 `;

--- a/src/components/common/button/EnterBtn.tsx
+++ b/src/components/common/button/EnterBtn.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import Icons from '@/assets/svg/index';
 
 interface EnterBtnProps {
-	isDisabled: boolean;
+	isDisabled?: boolean;
 }
 
-function EnterBtn({ isDisabled }: EnterBtnProps) {
+function EnterBtn({ isDisabled = false }: EnterBtnProps) {
 	return (
 		<EnterBtnLayout isDisabled={isDisabled} disabled={isDisabled}>
 			<StyledIcon />

--- a/src/components/common/button/textBtn/TextBtn.tsx
+++ b/src/components/common/button/textBtn/TextBtn.tsx
@@ -6,7 +6,7 @@ import { smallSize, bigSize } from './textBtnStyle';
 
 import { TextBtnType } from '@/types/textBtnType';
 
-function TextBtn({ size, text, color, mode, isHover, isPressed }: TextBtnType) {
+function TextBtn({ size, text, color, mode, isHover, isPressed, onClick }: TextBtnType) {
 	const StyledTextBtn = styled.div<{
 		size: string;
 		color: 'BLUE' | 'WHITE' | 'BLACK';
@@ -38,8 +38,9 @@ function TextBtn({ size, text, color, mode, isHover, isPressed }: TextBtnType) {
 				}
 			`}
 	`;
+
 	return (
-		<StyledTextBtn size={size} color={color} mode={mode} isHover={isHover} isPressed={isPressed}>
+		<StyledTextBtn size={size} color={color} mode={mode} isHover={isHover} isPressed={isPressed} onClick={onClick}>
 			{text}
 		</StyledTextBtn>
 	);

--- a/src/components/common/button/textBtn/textBtnStyle.ts
+++ b/src/components/common/button/textBtn/textBtnStyle.ts
@@ -15,7 +15,7 @@ export const smallSize = css`
 	height: 2.6rem;
 
 	${textButtonCss}
-	${theme.fontTheme.CAPTION_01}
+	${theme.fontTheme.CAPTION_02}
 `;
 
 export const bigSize = css`

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 
+import BtnStagingDate from '../BtnDate/BtnStagingDate';
+import EnterBtn from '../button/EnterBtn';
+
 function TextInputStaging() {
 	return (
 		<StagingLayout>
 			<TextArea placeholder="해야하는 일들을 쏟아내보세요." />
 			<BtnWrapper>
-				<TmpBtn />
-				<TmpBtn />
+				<BtnStagingDate />
+				<EnterBtn />
 			</BtnWrapper>
 		</StagingLayout>
 	);
@@ -34,6 +37,7 @@ const TextArea = styled.textarea`
 	&:focus {
 		outline: none;
 	}
+	resize: none;
 `;
 
 const BtnWrapper = styled.div`
@@ -44,11 +48,4 @@ const BtnWrapper = styled.div`
 	height: fit-content;
 `;
 
-/** 임시 버튼 */
-const TmpBtn = styled.div`
-	width: 5rem;
-	height: 2.2rem;
-
-	background-color: ${({ theme }) => theme.palette.Grey.Grey6};
-`;
 export default TextInputStaging;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -7,6 +7,7 @@ import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStaging
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import NavBar from '@/components/common/NavBar';
 import ScrollGradient from '@/components/common/ScrollGradient';
+import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TextboxDailydate from '@/components/common/textbox/TextboxDailydate';
 import TextboxInput from '@/components/common/textbox/TextboxInput';
 import TextInputDesc from '@/components/common/textbox/TextInputDesc';
@@ -21,6 +22,8 @@ function Today() {
 			<NavBar />
 
 			<ScrollGradient />
+
+			<StagingArea />
 
 			<BtnTask btnType={1} isDescription />
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -25,17 +25,17 @@ function Today() {
 
 			<StagingArea />
 
-			<BtnTask btnType={1} isDescription />
+			<BtnTask btnType="staging" isDescription />
 
 			<p>Done</p>
-			<BtnTask btnType={2} status="Done" />
+			<BtnTask btnType="target" status="Done" />
 			<p>InProgress</p>
-			<BtnTask btnType={2} status="InProgress" />
+			<BtnTask btnType="target" status="InProgress" />
 			<p>Todo(default)</p>
-			<BtnTask btnType={2} />
+			<BtnTask btnType="target" />
 
 			<p>Staging</p>
-			<BtnTask btnType={3} />
+			<BtnTask btnType="delayed" />
 
 			<p>Done</p>
 			<StatusDoneBtn />

--- a/src/types/textBtnType.ts
+++ b/src/types/textBtnType.ts
@@ -5,4 +5,5 @@ export interface TextBtnType {
 	text: string;
 	isHover: boolean;
 	isPressed: boolean;
+	onClick?: () => void;
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- StagingArea(: 쏟아내기) 부분을 퍼블리싱했습니다!
- 구현 과정에서 **기존 컴포넌트들의 변경 사항**이 있습니다.
  - `TextBtn.tsx` 버튼에 클릭이벤트를 추가하여 **전체<->취소** 버튼 등의 커스텀 가능하도록 하였습니다!
  - `TextInputStaging.tsx` 버튼의 임시버튼을 생성 완료된 버튼컴포넌트를 이용해 변경하였습니다!

- **수정 필요한 사항: `ArrangeBtn`의 hover일때와 기본 상태일 때의 스타일링 변경이 필요합니다.**

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- `TextBtn.tsx` 버튼에 클릭이벤트를 추가하여 **전체<->취소** 버튼 변경 로직이 적절한 지 검토 부탁드려요!

## 관련 이슈

close #62 

## 스크린샷 (선택)

https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/128016888/e4d6629c-2069-4f1b-83b3-16309a28dc09

