### PR TITLE
[FEAT] 대시보드 뷰 task 요약 컴포넌트 퍼블리싱 (하단 컴포넌트)

### DIFF
--- a/src/components/DashboardPage/TaskSummary.tsx
+++ b/src/components/DashboardPage/TaskSummary.tsx
@@ -1,0 +1,100 @@
+import styled from '@emotion/styled';
+
+import sampleImg from '@/assets/images/sample.png';
+import PERIOD from '@/constants/tasksPeriod';
+
+interface TaskSummaryProps {
+	text: 'complete' | 'postponed' | 'inprogress';
+}
+
+function TaskSummary({ text }: TaskSummaryProps) {
+	const TASK_SUMMARY_TYPE = {
+		COMPLETE: '완료한 할 일 갯수',
+		POSTPONED: '평균 진행중인 할 일 갯수',
+		INPROGRESS: '진행중인 할 일',
+	};
+	let summaryTask = '';
+	if (text === 'complete') {
+		summaryTask = TASK_SUMMARY_TYPE.COMPLETE;
+	} else if (text === 'postponed') {
+		summaryTask = TASK_SUMMARY_TYPE.POSTPONED;
+	} else if (text === 'inprogress') {
+		summaryTask = TASK_SUMMARY_TYPE.INPROGRESS;
+	}
+
+	let summaryNumber = 0;
+	if (text === 'complete') {
+		summaryNumber = PERIOD.data.completeTasks;
+	} else if (text === 'postponed') {
+		summaryNumber = PERIOD.data.avgDeferredRate;
+	} else if (text === 'inprogress') {
+		summaryNumber = PERIOD.data.avgInprogressTasks;
+	}
+	return (
+		<TaskSummaryLayout>
+			<ProfileImg src={sampleImg} alt="프로필" />
+			<TextWrapper>
+				<SummaryText text={text}>{summaryTask}</SummaryText>
+				<NumberTaskBox>
+					<Number>{summaryNumber}</Number>
+					<NumberText>개</NumberText>
+				</NumberTaskBox>
+			</TextWrapper>
+		</TaskSummaryLayout>
+	);
+}
+
+export default TaskSummary;
+
+const TaskSummaryLayout = styled.div`
+	display: flex;
+	flex: 1 0 0;
+	flex-direction: column;
+	gap: 2rem;
+	align-items: flex-start;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 41.7rem;
+	height: 18.8rem;
+	padding-left: 2.8rem;
+
+	background-color: ${({ theme }) => theme.palette.Grey.Grey1};
+	border-radius: 16px;
+`;
+
+const ProfileImg = styled.img`
+	width: 4.4rem;
+	height: 4.4rem;
+	margin: 3rem 34.5rem 0 0;
+`;
+
+const TextWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	align-self: stretch;
+	width: 38.9rem;
+	height: 6.4rem;
+	margin-bottom: 3rem;
+`;
+
+const SummaryText = styled.p<{ text: string }>`
+	${({ theme }) => theme.fontTheme.HEADLINE_03}
+	color: ${({ theme }) => theme.palette.Grey.Grey7}
+`;
+
+const NumberTaskBox = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+`;
+
+const Number = styled.p`
+	${({ theme }) => theme.fontTheme.TITLE_02};
+	color: ${({ theme }) => theme.palette.Grey.Grey8};
+`;
+
+const NumberText = styled.p`
+	${({ theme }) => theme.fontTheme.HEADLINE_02};
+	color: ${({ theme }) => theme.palette.Grey.Grey7};
+`;

--- a/src/components/DashboardPage/TaskSummary.tsx
+++ b/src/components/DashboardPage/TaskSummary.tsx
@@ -1,43 +1,22 @@
 import styled from '@emotion/styled';
 
 import sampleImg from '@/assets/images/sample.png';
-import PERIOD from '@/constants/tasksPeriod';
 
 interface TaskSummaryProps {
-	text: 'complete' | 'postponed' | 'inprogress';
+	text: string;
+	data: number;
+	unit: string;
 }
 
-function TaskSummary({ text }: TaskSummaryProps) {
-	const TASK_SUMMARY_TYPE = {
-		COMPLETE: '완료한 할 일 갯수',
-		POSTPONED: '평균 진행중인 할 일 갯수',
-		INPROGRESS: '진행중인 할 일',
-	};
-	let summaryTask = '';
-	if (text === 'complete') {
-		summaryTask = TASK_SUMMARY_TYPE.COMPLETE;
-	} else if (text === 'postponed') {
-		summaryTask = TASK_SUMMARY_TYPE.POSTPONED;
-	} else if (text === 'inprogress') {
-		summaryTask = TASK_SUMMARY_TYPE.INPROGRESS;
-	}
-
-	let summaryNumber = 0;
-	if (text === 'complete') {
-		summaryNumber = PERIOD.data.completeTasks;
-	} else if (text === 'postponed') {
-		summaryNumber = PERIOD.data.avgDeferredRate;
-	} else if (text === 'inprogress') {
-		summaryNumber = PERIOD.data.avgInprogressTasks;
-	}
+function TaskSummary({ text, data, unit }: TaskSummaryProps) {
 	return (
 		<TaskSummaryLayout>
 			<ProfileImg src={sampleImg} alt="프로필" />
 			<TextWrapper>
-				<SummaryText text={text}>{summaryTask}</SummaryText>
+				<SummaryText>{text}</SummaryText>
 				<NumberTaskBox>
-					<Number>{summaryNumber}</Number>
-					<NumberText>개</NumberText>
+					<Number>{data}</Number>
+					<NumberText>{unit}</NumberText>
 				</NumberTaskBox>
 			</TextWrapper>
 		</TaskSummaryLayout>
@@ -78,7 +57,7 @@ const TextWrapper = styled.div`
 	margin-bottom: 3rem;
 `;
 
-const SummaryText = styled.p<{ text: string }>`
+const SummaryText = styled.p`
 	${({ theme }) => theme.fontTheme.HEADLINE_03}
 	color: ${({ theme }) => theme.palette.Grey.Grey7}
 `;

--- a/src/constants/tasksPeriod.ts
+++ b/src/constants/tasksPeriod.ts
@@ -1,0 +1,12 @@
+const PERIOD = {
+	code: 'success',
+	data: {
+		completeTasks: 51,
+		avgInprogressTasks: 7,
+		avgInprogressDay: 13,
+		avgDeferredRate: 22,
+	},
+	message: null,
+};
+
+export default PERIOD;

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -13,15 +13,15 @@ function DashBoard() {
 		},
 		{
 			name: 'postponed',
-			text: '평균 진행중인 할 일 갯수',
-			data: PERIOD.data.avgInprogressTasks,
-			unit: '개',
+			text: '평균 지연율',
+			data: PERIOD.data.avgDeferredRate,
+			unit: '%',
 		},
 		{
 			name: 'inprogress',
-			text: '진행중인 할 일',
-			data: PERIOD.data.avgDeferredRate,
-			unit: '%',
+			text: '평균 진행중인 할 일 갯수',
+			data: PERIOD.data.avgInprogressTasks,
+			unit: '개',
 		},
 	];
 

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 
 import ArrangeBtn from '@/components/common/arrangeBtn/ArrangeBtn';
+import TaskSummary from '@/components/DashboardPage/TaskSummary';
 
 function DashBoard() {
 	return (
 		<>
 			{/* right */}
+			<TaskSummary text="complete" />
 			<Wrapper>
 				<ArrangeBtn type="right" color="BLUE" mode="DEFAULT" size="small" />
 				<ArrangeBtn type="right" color="BLUE" mode="DISABLED" size="small" />

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -1,63 +1,56 @@
 import styled from '@emotion/styled';
 
-import ArrangeBtn from '@/components/common/arrangeBtn/ArrangeBtn';
 import TaskSummary from '@/components/DashboardPage/TaskSummary';
+import PERIOD from '@/constants/tasksPeriod';
 
 function DashBoard() {
+	const SUMMARY_INFO = [
+		{
+			name: 'complete',
+			text: '완료한 할 일 갯수',
+			data: PERIOD.data.completeTasks,
+			unit: '개',
+		},
+		{
+			name: 'postponed',
+			text: '평균 진행중인 할 일 갯수',
+			data: PERIOD.data.avgInprogressTasks,
+			unit: '개',
+		},
+		{
+			name: 'inprogress',
+			text: '진행중인 할 일',
+			data: PERIOD.data.avgDeferredRate,
+			unit: '%',
+		},
+	];
+
 	return (
-		<>
-			{/* right */}
-			<TaskSummary text="complete" />
-			<Wrapper>
-				<ArrangeBtn type="right" color="BLUE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="right" color="BLUE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="right" color="WHITE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="right" color="WHITE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="right" color="BLACK" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="right" color="BLACK" mode="DISABLED" size="small" />
-			</Wrapper>
-
-			{/* left */}
-			<Wrapper>
-				<ArrangeBtn type="left" color="BLUE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="left" color="BLUE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="left" color="WHITE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="left" color="WHITE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="left" color="BLACK" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="left" color="BLACK" mode="DISABLED" size="small" />
-			</Wrapper>
-
-			{/* set */}
-			<Wrapper>
-				<ArrangeBtn type="set" color="BLUE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="set" color="BLUE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="set" color="WHITE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="set" color="WHITE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="set" color="BLACK" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="set" color="BLACK" mode="DISABLED" size="small" />
-			</Wrapper>
-
-			{/* calendar */}
-			<Wrapper>
-				<ArrangeBtn type="calendar" color="BLUE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="calendar" color="BLUE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="calendar" color="WHITE" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="calendar" color="WHITE" mode="DISABLED" size="small" />
-
-				<ArrangeBtn type="calendar" color="BLACK" mode="DEFAULT" size="small" />
-				<ArrangeBtn type="calendar" color="BLACK" mode="DISABLED" size="small" />
-			</Wrapper>
-		</>
+		<DashBoardWrapper>
+			<TaskSummaryWrapper>
+				{SUMMARY_INFO.map((info) => (
+					<TaskSummary key={info.name} text={info.text} data={info.data} unit={info.unit} />
+				))}
+			</TaskSummaryWrapper>
+		</DashBoardWrapper>
 	);
 }
-const Wrapper = styled.div`
-	display: flex;
-`;
+
 export default DashBoard;
+
+const DashBoardWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	width: 127.8rem;
+	height: 100vh;
+`;
+
+const TaskSummaryWrapper = styled.div`
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+	align-self: stretch;
+	height: 21.4rem;
+	padding: 0 0 2.8rem 0.7rem;
+`;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 대시보드 뷰 하단 task 요약 박스 컴포넌트를 구현했습니다.
- 고양이 이미지 부분은 디자인에서 3D 이미지를 넘겨주실 예정이라 하여 영역만 잡았습니다. 참고해주세요!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- _api 연동해야 하는 부분을 상수 데이터로 가져오는 법은 알고 있었지만, 테스크 요약 컴포넌트의 경우 지연된 일인지, 완료된 일인지, 진행 중인 일인지에 따라 보여줘야 하는 api 데이터가 달라 고민이 되었습니다. 먼저 상수 데이터에 api 데이터를 가져온 뒤, let 으로 summaryNumber가 숫자임을 선언해준 뒤, 각각의 props 타입에 따라 api 데이터를 가져와주었습니다. 하하 별거 아니지만 뿌듯해요 ~~~ 잉 ㅋ 🏄_ > **갈아엎었습니다.**
- 하나의 컴포넌트 안에서 let으로 props 타입에 따라 api 데이터를 가져와줄 경우, 호이스팅이 3*3 9번이나 발생한다는 문제가 있다는 피드백을 받았습니다. 따라서 상위 페이지에서 api 데이터를 포함한 값을 배열로 선언해준 뒤, 상위 페이지에서 map 함수를 돌리고, 하위 컴포넌트에 props를 인자로 내려주었습니다. map 함수를 매번 어려워했는데 이번 기회에 잘 사용한 것 같아서 기분이 좋습니다. 그리고 또 알게된 사실, 상위에서 props를 내려주더라도 하위에서 역시 타입 선언을 해줘야하는 군요,, 당연하지만 저는 몰랐습니다. 더 공부하겠습니다아아!

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- _말씀드린 대로 api 연동하는 부분을 상수 데이터 + 숫자 타입 함수로 가져와주었는데, 혹시 이 부분에 대해서 더 좋은 방법이 있다면 편하게 말씀해주세요!!_ > **기각**
- 
- 현재 사용하고 있는 map 방식은 효율적이고 좋은 방식이 맞을까요?? 맞겠죠?? 더 좋은, 컴팩트한 방법이 있다면 알려주세용 ㅎㅎ

- _사용하실 때, prop으로 text에 'complete', 'postponed', 'inprogress'을 내려주시면 되고, 각각 완료한 할 일 갯수, 평균 진행중인 할 일 갯수, 진행중인 할 일 입니다!!_ > **아무것도 아실 필요가 없어졌습니다 ㅎㅎ map이 편한거였네요. 좋다 !!**

## 관련 이슈

close #74 

## 스크린샷

<img width="636" alt="스크린샷 2024-07-10 오후 5 05 05" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/151596186/c4aac453-b506-4c57-b379-08b6bebc1715">

