### PR TITLE
[FEAT] Arrange Modal 생성

### DIFF
--- a/src/components/common/button/SortBtn.tsx
+++ b/src/components/common/button/SortBtn.tsx
@@ -2,35 +2,35 @@ import styled from '@emotion/styled';
 
 interface SortBtnProps {
 	text: string;
+	isActive?: boolean;
+	onClick?: () => void;
 }
 
-function SortBtn({ text }: SortBtnProps) {
-	return <SortBtnLayout>{text}</SortBtnLayout>;
+function SortBtn({ text, isActive = false, onClick }: SortBtnProps) {
+	return (
+		<SortBtnLayout onClick={onClick} isActive={isActive}>
+			{text}
+		</SortBtnLayout>
+	);
 }
 
 export default SortBtn;
 
-const SortBtnLayout = styled.button`
+const SortBtnLayout = styled.button<{ isActive: boolean }>`
 	display: flex;
 	align-items: center;
 	width: 10.5rem;
 	height: 2.9rem;
-	padding: 7px;
+	padding: 0.7rem;
 
-	color: ${({ theme }) => theme.palette.Grey.Grey6};
+	color: ${({ theme, isActive }) => (isActive ? theme.palette.Grey.Grey7 : theme.palette.Grey.Grey6)};
 
-	background-color: ${({ theme }) => theme.palette.Grey.White};
+	background-color: ${({ theme, isActive }) => (isActive ? theme.palette.Grey.Grey3 : theme.palette.Grey.White)};
 	border-radius: 6px;
 
-	${({ theme }) => theme.fontTheme.CAPTION_01}; /* 수정 필요 */
+	${({ theme }) => theme.fontTheme.CAPTION_04};
 
 	&:hover {
 		background-color: ${({ theme }) => theme.palette.Grey.Grey1};
-	}
-
-	&:active {
-		color: ${({ theme }) => theme.palette.Grey.Grey7};
-
-		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
 	}
 `;

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -1,18 +1,46 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import SortBtn from '../../button/SortBtn';
 
 function ModalArrange() {
+	const [activeSorByDateAdded, setActiveSorByDateAdded] = useState<string | null>(null);
+	const [activeSorByDeadLine, setActiveSorByDeadLine] = useState<string | null>(null);
+
+	const handleSortByDateAddedClick = (sortType: string) => {
+		setActiveSorByDateAdded((prev) => (prev === sortType ? null : sortType));
+	};
+
+	const handleSortByDeadLineClick = (sortType: string) => {
+		setActiveSorByDeadLine((prev) => (prev === sortType ? null : sortType));
+	};
+
 	return (
 		<ModalArrangeLayout>
 			<SortBy>
-				<SortBtn text="최신 등록순" />
-				<SortBtn text="오래된 등록순" />
+				<SortBtn
+					text="최신 등록순"
+					isActive={activeSorByDateAdded === '최신 등록순'}
+					onClick={() => handleSortByDateAddedClick('최신 등록순')}
+				/>
+				<SortBtn
+					text="오래된 등록순"
+					isActive={activeSorByDateAdded === '오래된 등록순'}
+					onClick={() => handleSortByDateAddedClick('오래된 등록순')}
+				/>
 			</SortBy>
 			<ModalArrangeLine />
 			<SortBy>
-				<SortBtn text="가까운 마감기한순" />
-				<SortBtn text="먼 마감기한순" />
+				<SortBtn
+					text="가까운 마감기한순"
+					isActive={activeSorByDeadLine === '가까운 마감기한순'}
+					onClick={() => handleSortByDeadLineClick('가까운 마감기한순')}
+				/>
+				<SortBtn
+					text="먼 마감기한순"
+					isActive={activeSorByDeadLine === '먼 마감기한순'}
+					onClick={() => handleSortByDeadLineClick('먼 마감기한순')}
+				/>
 			</SortBy>
 		</ModalArrangeLayout>
 	);

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 
 import SortBtn from '../../button/SortBtn';
 
+import SORT_BY from '@/constants/sortType';
+
 function ModalArrange() {
 	const [activeSorByDateAdded, setActiveSorByDateAdded] = useState<string | null>(null);
 	const [activeSorByDeadLine, setActiveSorByDeadLine] = useState<string | null>(null);
@@ -19,27 +21,27 @@ function ModalArrange() {
 		<ModalArrangeLayout>
 			<SortBy>
 				<SortBtn
-					text="최신 등록순"
-					isActive={activeSorByDateAdded === '최신 등록순'}
-					onClick={() => handleSortByDateAddedClick('최신 등록순')}
+					text={SORT_BY.NEWEST}
+					isActive={activeSorByDateAdded === SORT_BY.NEWEST}
+					onClick={() => handleSortByDateAddedClick(SORT_BY.NEWEST)}
 				/>
 				<SortBtn
-					text="오래된 등록순"
-					isActive={activeSorByDateAdded === '오래된 등록순'}
+					text={SORT_BY.OLDEST}
+					isActive={activeSorByDateAdded === SORT_BY.OLDEST}
 					onClick={() => handleSortByDateAddedClick('오래된 등록순')}
 				/>
 			</SortBy>
 			<ModalArrangeLine />
 			<SortBy>
 				<SortBtn
-					text="가까운 마감기한순"
-					isActive={activeSorByDeadLine === '가까운 마감기한순'}
-					onClick={() => handleSortByDeadLineClick('가까운 마감기한순')}
+					text={SORT_BY.CLOSEST}
+					isActive={activeSorByDeadLine === SORT_BY.CLOSEST}
+					onClick={() => handleSortByDeadLineClick(SORT_BY.CLOSEST)}
 				/>
 				<SortBtn
-					text="먼 마감기한순"
-					isActive={activeSorByDeadLine === '먼 마감기한순'}
-					onClick={() => handleSortByDeadLineClick('먼 마감기한순')}
+					text={SORT_BY.CLOSEST}
+					isActive={activeSorByDeadLine === SORT_BY.CLOSEST}
+					onClick={() => handleSortByDeadLineClick(SORT_BY.CLOSEST)}
 				/>
 			</SortBy>
 		</ModalArrangeLayout>

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+import SortBtn from '../../button/SortBtn';
+
+function ModalArrange() {
+	return (
+		<ModalArrangeLayout>
+			<SortBy>
+				<SortBtn text="최신 등록순" />
+				<SortBtn text="오래된 등록순" />
+			</SortBy>
+			<ModalArrangeLine />
+			<SortBy>
+				<SortBtn text="가까운 마감기한순" />
+				<SortBtn text="먼 마감기한순" />
+			</SortBy>
+		</ModalArrangeLayout>
+	);
+}
+
+export default ModalArrange;
+
+const ModalArrangeLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+	gap: 1.2rem;
+	align-items: center;
+	justify-content: center;
+	width: 10.6rem;
+	height: 14.6rem;
+	padding: 0.6rem;
+
+	background: ${({ theme }) => theme.palette.Grey.White};
+	box-shadow: 0 0.3rem 0.8rem 0 rgb(0 0 0 / 32%);
+	border-radius: 10px;
+`;
+
+const SortBy = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+const ModalArrangeLine = styled.div`
+	display: flex;
+	width: 11.8rem;
+	height: 0.1rem;
+
+	background-color: ${({ theme }) => theme.palette.Grey.Grey2};
+`;

--- a/src/constants/sortType.ts
+++ b/src/constants/sortType.ts
@@ -1,0 +1,8 @@
+const SORT_BY = {
+	NEWEST: '최신 등록순',
+	OLDEST: '오래된 등록순',
+	CLOSEST: '지연된 할 일',
+	FARTHEST: '먼 마감기한순',
+};
+
+export default SORT_BY;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -5,6 +5,7 @@ import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
 import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
 import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
+import ModalArrange from '@/components/common/modal/ModalArrange/ModalArrange';
 import NavBar from '@/components/common/NavBar';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
@@ -20,6 +21,8 @@ function Today() {
 	return (
 		<>
 			<NavBar />
+
+			<ModalArrange />
 
 			<ScrollGradient />
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- Today 페이지의 Staging Area에서의 정렬 기능을 수행할 Arrange Modal을 퍼블리싱 하였습니다.
  - `activeSorByDateAdded`(최신 등록순, 오래된 등록순) / `activeSorByDeadLine`(가까운 마감기한순, 먼 마감기한순) 로 크게 구분 가능합니다. 각 세트별로 정렬 선택 가능한 부분이라 상태를 2개로 나눴습니다!


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- Staging Area(:쏟아내기)에서 `SortBtn` 클릭 시 사용될 모달입니다!
- **`activeSorByDateAdded`(최신 등록순, 오래된 등록순)** / **`activeSorByDeadLine`(가까운 마감기한순, 먼 마감기한순)** 은 각 세트별로 정렬 선택 가능한 부분이라 상태를 2개로 나눴습니다! 

## 관련 이슈

close #86 

## 스크린샷 (선택)

![Jul-11-2024 02-46-02](https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/128016888/5fa1e176-4f0a-45ac-981f-c51fb4f33ac8)

