### PR TITLE
[FEAT] 날짜, 시간 수정 데이트피커 모달 제작

### DIFF
--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -1,0 +1,68 @@
+import styled from '@emotion/styled';
+
+import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
+import TextboxInput from '../textbox/TextboxInput';
+
+interface CustomHeaderProps {
+	prevDate: Date | null;
+	decreaseMonth: () => void;
+	increaseMonth: () => void;
+	prevMonthButtonDisabled: boolean;
+	nextMonthButtonDisabled: boolean;
+	onChange: (date: Date) => void;
+	dateTextRef: React.RefObject<HTMLInputElement>;
+}
+
+function CorrectionCustomHeader({
+	prevDate,
+	decreaseMonth,
+	increaseMonth,
+	prevMonthButtonDisabled,
+	nextMonthButtonDisabled,
+	onChange,
+	dateTextRef,
+}: CustomHeaderProps) {
+	return (
+		<div className="react-datepicker__header-custom">
+			<InfoBox>
+				<TextboxInput variant="date" dateValue={prevDate} onChange={onChange} dateTextRef={dateTextRef} />
+				<div className="react-datepicker__navigation-wrapper">
+					<BtnWrapper className="react-datepicker__navigation-container">
+						<ArrangeBtn
+							color="WHITE"
+							mode="DEFAULT"
+							size="small"
+							type="left"
+							className="react-datepicker__navigation react-datepicker__navigation--previous"
+							onClick={decreaseMonth}
+							disabled={prevMonthButtonDisabled}
+							aria-label="Previous Month"
+						/>
+						<ArrangeBtn
+							color="WHITE"
+							mode="DEFAULT"
+							size="small"
+							type="right"
+							className="react-datepicker__navigation react-datepicker__navigation--next"
+							onClick={increaseMonth}
+							disabled={nextMonthButtonDisabled}
+							aria-label="Next Month"
+						/>
+					</BtnWrapper>
+				</div>
+			</InfoBox>
+		</div>
+	);
+}
+const BtnWrapper = styled.div`
+	display: flex;
+	justify-content: flex-end;
+`;
+const InfoBox = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 20.4rem;
+	padding-bottom: 0.6rem;
+`;
+export default CorrectionCustomHeader;

--- a/src/components/common/datePicker/CustomHeader.tsx
+++ b/src/components/common/datePicker/CustomHeader.tsx
@@ -110,7 +110,7 @@ const InfoWrapper = styled.div`
 const InfoBox = styled.div`
 	display: flex;
 	justify-content: space-between;
-	width: 22.8rem;
+	width: 20.4rem;
 	padding-bottom: 0.6rem;
 `;
 export default CustomHeader;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -35,7 +35,7 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 			)}
 		>
 			<BottomBtnWrapper>
-				{isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
+				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
 				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
 			</BottomBtnWrapper>
 		</DatePicker>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -12,7 +12,7 @@ import CalendarStyle from './DatePickerStyle';
 
 import formatDatetoString from '@/utils/formatDatetoString';
 
-function DateCorrectionModal() {
+function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 	const prevDate: Date = new Date();
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
 	const dateTextRef = useRef<HTMLInputElement>(null);
@@ -35,7 +35,7 @@ function DateCorrectionModal() {
 			)}
 		>
 			<BottomBtnWrapper>
-				<TextboxInput variant="time" dateTextRef={timeTextRef} />
+				{isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
 				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
 			</BottomBtnWrapper>
 		</DatePicker>
@@ -43,7 +43,8 @@ function DateCorrectionModal() {
 }
 const BottomBtnWrapper = styled.div`
 	display: flex;
-	justify-content: space-between;
+	gap: 0.5rem;
+	justify-content: flex-end;
 	width: 100%;
 `;
 export default DateCorrectionModal;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { ko } from 'date-fns/locale';
+import { useRef, useState } from 'react';
+import DatePicker from 'react-datepicker';
+
+import 'react-datepicker/dist/react-datepicker.css';
+import TextBtn from '../button/textBtn/TextBtn';
+import TextboxInput from '../textbox/TextboxInput';
+
+import CorrectionCustomHeader from './CorrectionCustomHeader';
+import CalendarStyle from './DatePickerStyle';
+
+import formatDatetoString from '@/utils/formatDatetoString';
+
+function DateCorrectionModal() {
+	const prevDate: Date = new Date();
+	const [currentDate, setCurrentDate] = useState<Date | null>(null);
+	const dateTextRef = useRef<HTMLInputElement>(null);
+	const timeTextRef = useRef<HTMLInputElement>(null);
+	const onChange = (date: Date | null) => {
+		setCurrentDate(date);
+		if (dateTextRef.current) {
+			dateTextRef.current.value = formatDatetoString(date);
+		}
+	};
+	return (
+		<DatePicker
+			locale={ko}
+			selected={currentDate}
+			onChange={onChange}
+			inline
+			calendarContainer={CalendarStyle}
+			renderCustomHeader={(props) => (
+				<CorrectionCustomHeader {...props} prevDate={prevDate} dateTextRef={dateTextRef} onChange={onChange} />
+			)}
+		>
+			<BottomBtnWrapper>
+				<TextboxInput variant="time" dateTextRef={timeTextRef} />
+				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
+			</BottomBtnWrapper>
+		</DatePicker>
+	);
+}
+const BottomBtnWrapper = styled.div`
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+`;
+export default DateCorrectionModal;

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 const CalendarStyle = styled.div`
 	display: flex;
 	flex-direction: column;
+	flex-shrink: 0;
 	align-items: center;
 	width: 22.8rem;
 	height: fit-content;

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -5,13 +5,15 @@ const CalendarStyle = styled.div`
 	flex-direction: column;
 	align-items: center;
 	width: 22.8rem;
-	padding: 1.6rem 1.2rem;
+	height: fit-content;
+	padding: 1.6rem 0;
 	overflow: hidden;
 
 	box-shadow: 0 3px 7px 0 rgb(0 0 0 / 38%);
 	border: 0;
 	border-radius: 12px;
 	/* stylelint-disable selector-class-pattern */
+
 	.react-datepicker__month-container {
 		display: flex;
 		flex-direction: column;
@@ -55,7 +57,8 @@ const CalendarStyle = styled.div`
 	/** 주 날짜 */
 	.react-datepicker__week {
 		display: flex;
-		width: 19.6rem;
+		justify-content: center;
+		width: 22rem;
 	}
 
 	/* 선택된 날짜 */
@@ -63,8 +66,8 @@ const CalendarStyle = styled.div`
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 100%;
-		height: 2.9rem;
+		width: 2.8rem;
+		height: 2.8rem;
 		margin: 0;
 
 		border-radius: 0;
@@ -106,8 +109,9 @@ const CalendarStyle = styled.div`
 	}
 
 	.react-datepicker__children-container {
-		align-self: flex-end;
-		width: fit-content;
+		display: flex;
+		justify-content: end;
+		width: 20.4rem;
 		margin: 0;
 		padding: 0;
 	}

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -14,7 +14,7 @@ interface TextboxInputProps {
 }
 function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		if (onChange) {
+		if (onChange && dateValue) {
 			const formattedInput = dotFormatDate(e.target.value);
 			e.target.value = formattedInput;
 			if (formattedInput && formattedInput.length > 9) {
@@ -54,6 +54,7 @@ const InputContainer = styled.div<{ variant: 'date' | 'time' | 'smallDate' }>`
 	display: flex;
 	gap: 0.5rem;
 	align-items: center;
+	box-sizing: border-box;
 	width: 15.4rem;
 	height: 2.6rem;
 	padding: 0.3rem 1rem;

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -36,7 +36,8 @@ function DashBoard() {
 					<TaskSummary key={info.name} text={info.text} data={info.data} unit={info.unit} />
 				))}
 			</TaskSummaryWrapper>
-			<DateCorrectionModal />
+			<DateCorrectionModal isDateOnly />
+			<DateCorrectionModal isDateOnly={false} />
 			<DatePickerCustom />
 		</DashBoardWrapper>
 	);

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
+import DatePickerCustom from '@/components/common/datePicker/DatePickerCustom';
 import DashboardTask from '@/components/DashboardPage/DashboardTask';
 import TaskSummary from '@/components/DashboardPage/TaskSummary';
 import PERIOD from '@/constants/tasksPeriod';
@@ -34,6 +36,8 @@ function DashBoard() {
 					<TaskSummary key={info.name} text={info.text} data={info.data} unit={info.unit} />
 				))}
 			</TaskSummaryWrapper>
+			<DateCorrectionModal />
+			<DatePickerCustom />
 		</DashBoardWrapper>
 	);
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

날짜, 시간 수정 데이트피커 모달 제작했습니다


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
 
기존 데이트피커에서 props 로 분기처리하기에는 너무 복잡해질 것 같아 수정 모달은 새로운 컴포넌트를 만들었습니다  
`isDateOnly` boolean 타입의 값을 통해서 시간 설정하는 인풋 표시 여부를 결정합니다  
  
시간 설정하는 부분 인풋창 시간 포맷팅 안된 상태이고
기존 선택된 날짜인 prevDate 스타일 지정 안된 상태입니다! 이후 추가 예정입니다

## 관련 이슈

close #78 

## 스크린샷 (선택)
![Jul-11-2024 03-33-45](https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/f91b2ce8-9bcd-428c-a996-1d01bb1a999e)
