### PR TITLE
[FEAT] 시간 포맷팅 추가

### DIFF
--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -25,13 +25,6 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 		}
 	};
 
-	const onTimeChange = (timeVal: string) => {
-		// 현재 사용되지 않지만 이후 시간값 api 연결시 필요
-		// setTime(timeVal);
-		if (timeTextRef.current) {
-			timeTextRef.current.value = timeVal;
-		}
-	};
 	return (
 		<DatePicker
 			locale={ko}
@@ -44,7 +37,7 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 			)}
 		>
 			<BottomBtnWrapper>
-				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} onTimeChange={onTimeChange} />}
+				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
 				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
 			</BottomBtnWrapper>
 		</DatePicker>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -15,12 +15,21 @@ import formatDatetoString from '@/utils/formatDatetoString';
 function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 	const prevDate: Date = new Date();
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
+	// const [time, setTime] = useState<string>('');
 	const dateTextRef = useRef<HTMLInputElement>(null);
 	const timeTextRef = useRef<HTMLInputElement>(null);
 	const onChange = (date: Date | null) => {
 		setCurrentDate(date);
 		if (dateTextRef.current) {
 			dateTextRef.current.value = formatDatetoString(date);
+		}
+	};
+
+	const onTimeChange = (timeVal: string) => {
+		// 현재 사용되지 않지만 이후 시간값 api 연결시 필요
+		// setTime(timeVal);
+		if (timeTextRef.current) {
+			timeTextRef.current.value = timeVal;
 		}
 	};
 	return (
@@ -35,7 +44,7 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 			)}
 		>
 			<BottomBtnWrapper>
-				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
+				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} onTimeChange={onTimeChange} />}
 				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
 			</BottomBtnWrapper>
 		</DatePicker>

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -4,23 +4,31 @@ import styled from '@emotion/styled';
 import Icons from '@/assets/svg/index';
 import { theme } from '@/styles/theme';
 import dotFormatDate from '@/utils/dotFormatDate';
+import dotFormatTime from '@/utils/dotFormatTime';
 import formatDatetoString from '@/utils/formatDatetoString';
 
 interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
 	dateValue?: Date | null;
 	onChange?: (date: Date) => void;
+	onTimeChange?: (time: string) => void;
 	dateTextRef?: React.RefObject<HTMLInputElement>;
 }
-function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInputProps) {
+function TextboxInput({ variant, dateValue, onChange, onTimeChange, dateTextRef }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		if (onChange && dateValue) {
+		if ((variant === 'date' || variant === 'smallDate') && onChange) {
 			const formattedInput = dotFormatDate(e.target.value);
 			e.target.value = formattedInput;
 			if (formattedInput && formattedInput.length > 9) {
 				const valueDate = new Date(formattedInput);
 				onChange(valueDate);
 			}
+		}
+
+		if (variant === 'time' && onTimeChange) {
+			const formattedInput = dotFormatTime(e.target.value);
+			e.target.value = formattedInput;
+			onTimeChange(formattedInput);
 		}
 	};
 	return (

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Icons from '@/assets/svg/index';
 import { theme } from '@/styles/theme';
+import checkTimeFormat from '@/utils/checkTimeFormat';
 import dotFormatDate from '@/utils/dotFormatDate';
 import dotFormatTime from '@/utils/dotFormatTime';
 import formatDatetoString from '@/utils/formatDatetoString';
@@ -11,10 +12,9 @@ interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
 	dateValue?: Date | null;
 	onChange?: (date: Date) => void;
-	onTimeChange?: (time: string) => void;
 	dateTextRef?: React.RefObject<HTMLInputElement>;
 }
-function TextboxInput({ variant, dateValue, onChange, onTimeChange, dateTextRef }: TextboxInputProps) {
+function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		if ((variant === 'date' || variant === 'smallDate') && onChange) {
 			const formattedInput = dotFormatDate(e.target.value);
@@ -25,10 +25,17 @@ function TextboxInput({ variant, dateValue, onChange, onTimeChange, dateTextRef 
 			}
 		}
 
-		if (variant === 'time' && onTimeChange) {
+		if (variant === 'time') {
 			const formattedInput = dotFormatTime(e.target.value);
 			e.target.value = formattedInput;
-			onTimeChange(formattedInput);
+
+			// 유효한 시간인지 검사
+			if (formattedInput && formattedInput.length > 4) {
+				if (!checkTimeFormat(formattedInput)) {
+					alert('유효한 시간이 아님');
+					e.target.value = '';
+				}
+			}
 		}
 	};
 	return (

--- a/src/utils/checkTimeFormat.ts
+++ b/src/utils/checkTimeFormat.ts
@@ -1,0 +1,10 @@
+/** 00:00 ~ 23:59 내의 유효한 시간인지 확인하고 유효하면 true 아니라면 false 반환 */
+const checkTimeFormat = (time: string) => {
+	const [hours, minutes] = time.split(':').map(Number);
+	if (hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59) {
+		return true;
+	}
+	return false;
+};
+
+export default checkTimeFormat;

--- a/src/utils/dotFormatTime.ts
+++ b/src/utils/dotFormatTime.ts
@@ -1,0 +1,10 @@
+/** 입력 중인 시간 string에 HH:MM 형태로 ':' 을 추가한 string 을 반환합니다 */
+const dotFormatTime = (text: string) => {
+	let value = text.replace(/\D/g, '');
+	value = value.slice(0, 4);
+	if (value.length > 2) {
+		value = value.replace(/(\d{2})(\d{1,2})/, '$1:$2');
+	}
+	return value;
+};
+export default dotFormatTime;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

-  숫자 이외 입력 막기
-  자동 포맷팅 구현
-  데이트피커 모달에 연결하기

## 알게된 점 :rocket:

> 기록하며 개발하기!

다시 보니까 모달에서 시간을 눌러서 설정하는 방식은 없어서 `onTimeChange`를 제거하고 텍스트 인풋 -> 시간 설정 방식만 유효하게 했습니다  


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

`time, setTime` 상태 만들었는데 지금 사용하지는 않아서 주석처리 해뒀습니다 ! 나중에 모달 연결할 때나 기능 연결할 때 풀어써 쓰면 될 것 같습니다.  

00:00 ~ 23:59 내의 유효한 시간인지 확인하고 유효하면 끝까지 입력되도록, 유효하지 않으면 알러트 뜨고 입력 초기화되도록 설정해두었습니다. 

## 관련 이슈

close #92 

## 스크린샷 (선택)
![Jul-11-2024 10-59-20](https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/c0de8944-cd80-4a00-bc53-254c989113a4)

