### PR TITLE
[FEAT] 날짜 인풋 유효성 검사

### DIFF
--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Icons from '@/assets/svg/index';
 import { theme } from '@/styles/theme';
+import checkDateFormat from '@/utils/checkDateFormat';
 import checkTimeFormat from '@/utils/checkTimeFormat';
 import dotFormatDate from '@/utils/dotFormatDate';
 import dotFormatTime from '@/utils/dotFormatTime';
@@ -19,9 +20,15 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 		if ((variant === 'date' || variant === 'smallDate') && onChange) {
 			const formattedInput = dotFormatDate(e.target.value);
 			e.target.value = formattedInput;
+
 			if (formattedInput && formattedInput.length > 9) {
-				const valueDate = new Date(formattedInput);
-				onChange(valueDate);
+				if (!checkDateFormat(formattedInput)) {
+					alert('유효한 날짜가 아님');
+					e.target.value = '';
+				} else {
+					const valueDate = new Date(formattedInput);
+					onChange(valueDate);
+				}
 			}
 		}
 

--- a/src/utils/checkDateFormat.ts
+++ b/src/utils/checkDateFormat.ts
@@ -1,0 +1,13 @@
+/** 입력된 날짜가 2000년 - 9999년인지, 01.01 - 12.31 인지 검사 */
+const checkDateFormat = (date: string) => {
+	const [year, month, day] = date.split('.').map(Number);
+
+	if (year >= 2000 && year <= 9999 && month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+		const maxDays = new Date(year, month, 0).getDate();
+		if (day <= maxDays) {
+			return true;
+		}
+	}
+	return false;
+};
+export default checkDateFormat;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 날짜 인풋 유효성 검사 유틸 함수를 만들었습니다
- 그리고 `TextboxInput`에 추가했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

day <= 31 조건을 명시적으로 추가하지 않아도 `new Date(year, month, 0).getDate()`가 해당 월의 최대 일수를 반환해서 이 조건이 없어도 32일이나 31일이 없는 달의 31일이 잘 걸러짐!  
그래도 명시적으로 조건을 표시해두긴 하였습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

이상한 값 넣었을 때 잘 막아지는지 확인해주시면 감사하겠습니당

## 관련 이슈

close #97 

## 스크린샷 (선택)
<img width="302" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/9c066e32-3bb5-429b-a419-9cc50bda5c2a">
<img width="469" alt="image" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/ab30768b-afd9-4449-9a60-7f6658ef1bf1">
