### PR TITLE
[FEAT] TargetArea 디자인 최신화

### DIFF
--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -8,11 +8,10 @@ import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
 import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
 import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
+import { TaskType } from '@/types/tasks/taskType';
 
-interface BtnTaskProps {
+interface BtnTaskProps extends TaskType {
 	btnType: 'staging' | 'target' | 'delayed';
-	status?: string;
-	isDescription?: boolean;
 }
 
 interface BorderColorProps {
@@ -24,7 +23,7 @@ interface BorderColorProps {
 }
 
 function BtnTask(props: BtnTaskProps) {
-	const { btnType, status = 'Todo', isDescription = false } = props;
+	const { btnType, name, deadLine, hasDescription, status } = props;
 	const [isClicked, setIsClicked] = useState(false);
 	const [isHovered, setIsHovered] = useState(false);
 	const [iconHovered, setIconHovered] = useState(false);
@@ -78,9 +77,9 @@ function BtnTask(props: BtnTaskProps) {
 
 		if (btnType === 'target') {
 			switch (status) {
-				case 'Done':
+				case '완료':
 					return <StatusDoneBtn />;
-				case 'InProgress':
+				case '진행중':
 					return <StatusInProgressBtn />;
 				default:
 					return <StatusTodoBtn />;
@@ -99,11 +98,11 @@ function BtnTask(props: BtnTaskProps) {
 			onClick={handleClick}
 		>
 			<BtnTaskContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-				<BtnTaskTextWrapper isDescription={isDescription}>
-					{isDescription && <IconFile />}
-					넛쉘 UT 진행하기
+				<BtnTaskTextWrapper isDescription={hasDescription}>
+					{hasDescription && <IconFile />}
+					{name}
 				</BtnTaskTextWrapper>
-				<BtnDate date="2024.07.11" time="22:22" size="small" isDelayed={btnType === 'delayed'} />
+				<BtnDate date={deadLine?.date} time={deadLine?.time} size="small" isDelayed={btnType === 'delayed'} />
 			</BtnTaskContainer>
 			<IconHoverContainer
 				onClick={handleIconClick}

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -4,8 +4,51 @@ import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
 import TextInputStaging from '@/components/common/textbox/TextInputStaging';
+import { TaskType } from '@/types/tasks/taskType';
 
 function StagingArea() {
+	const dummyTaskList: TaskType[] = [
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
+	];
 	return (
 		<StagingAreaLayout>
 			<StagingAreaContainer>
@@ -14,17 +57,17 @@ function StagingArea() {
 					<StagingAreaTaskContainer>
 						<StagingAreaSetting />
 						<BtnTaskContainer>
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
-							<BtnTask btnType="staging" />
+							{dummyTaskList.map((task) => (
+								<BtnTask
+									key={task.id + task.name}
+									btnType="staging"
+									hasDescription={task.hasDescription}
+									id={task.id}
+									name={task.name}
+									status={task.status}
+									deadLine={task.deadLine}
+								/>
+							))}
 							<ScrollGradient />
 						</BtnTaskContainer>
 					</StagingAreaTaskContainer>

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import ArrangeBtn from '../common/arrangeBtn/ArrangeBtn';
+
 import TextBtn from '@/components/common/button/textBtn/TextBtn';
 
 function TargetControlSection() {
@@ -7,10 +9,10 @@ function TargetControlSection() {
 		<TargetControlSectionLayout>
 			<BtnWrapper>
 				<TextBtn text="오늘" size="small" color="BLACK" mode="DEFAULT" isHover isPressed />
-				<TmpBtn />
-				<TmpBtn />
+				<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="left" />
+				<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="right" />
 			</BtnWrapper>
-			<TmpBtn />
+			<ArrangeBtn color="WHITE" mode="DEFAULT" size="small" type="calendar" />
 		</TargetControlSectionLayout>
 	);
 }
@@ -28,11 +30,5 @@ const BtnWrapper = styled.div`
 	gap: 0.4rem;
 	width: fit-content;
 `;
-const TmpBtn = styled.div`
-	width: 2.6rem;
-	height: 2.6rem;
 
-	background-color: ${({ theme }) => theme.palette.Grey.Black};
-	border-radius: 6.5px;
-`;
 export default TargetControlSection;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,24 +1,64 @@
 import styled from '@emotion/styled';
 
+import BtnTask from '../common/BtnTask/BtnTask';
+
+import { TaskType } from '@/types/tasks/taskType';
+
 function TargetTaskSection() {
-	const dummyTaskList = [
-		{ id: 0 },
-		{ id: 1 },
-		{ id: 2 },
-		{ id: 3 },
-		{ id: 4 },
-		{ id: 5 },
-		{ id: 6 },
-		{ id: 7 },
-		{ id: 8 },
-		{ id: 9 },
-		{ id: 10 },
-		{ id: 11 },
+	const dummyTaskList: TaskType[] = [
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
 	];
 	return (
 		<TaskContainer>
 			{dummyTaskList.map((task) => (
-				<TmpTask key={task.id} />
+				<BtnTask
+					btnType="target"
+					key={task.id}
+					hasDescription={task.hasDescription}
+					name={task.name}
+					deadLine={task.deadLine}
+					status={task.status}
+					id={task.id}
+				/>
 			))}
 		</TaskContainer>
 	);
@@ -30,13 +70,5 @@ const TaskContainer = styled.div`
 	width: 100%;
 	height: 64rem;
 	overflow: scroll;
-`;
-const TmpTask = styled.div`
-	flex-shrink: 0;
-	width: 100%;
-	height: 6.2rem;
-
-	background-color: ${({ theme }) => theme.palette.Grey.Grey3};
-	border-radius: 8px;
 `;
 export default TargetTaskSection;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -28,17 +28,17 @@ function Today() {
 
 			<StagingArea />
 
-			<BtnTask btnType="staging" isDescription />
+			<BtnTask btnType="staging" hasDescription id={99} name="예시" status="미완료" />
 
 			<p>Done</p>
-			<BtnTask btnType="target" status="Done" />
+			<BtnTask btnType="target" hasDescription id={99} name="예시" status="완료" />
 			<p>InProgress</p>
-			<BtnTask btnType="target" status="InProgress" />
+			<BtnTask btnType="target" hasDescription id={99} name="예시" status="진행중" />
 			<p>Todo(default)</p>
-			<BtnTask btnType="target" />
+			<BtnTask btnType="target" hasDescription id={99} name="예시" status="미완료" />
 
 			<p>Staging</p>
-			<BtnTask btnType="delayed" />
+			<BtnTask btnType="target" hasDescription id={99} name="예시" status="지연" />
 
 			<p>Done</p>
 			<StatusDoneBtn />

--- a/src/types/tasks/taskType.ts
+++ b/src/types/tasks/taskType.ts
@@ -1,0 +1,10 @@
+export interface TaskType {
+	id: number;
+	name: string;
+	deadLine?: {
+		date: string;
+		time: string;
+	};
+	hasDescription: boolean;
+	status: '진행중' | '미완료' | '완료' | '지연';
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- `TaskArea`의 임시 버튼들을 제작한 컴포넌트로 교체했습니다
- 서버의 반환타입을 참고해 `TaskType`를 추가했습니다
- `BtnTask` 컴포넌트에 고정되어 있던 내용들을 props 통해 받아와 표시할 수 있도록 했습니다
- 기타 `BtnTask` 가 사용되는 곳에서 넘겨주는 값 수정했습니다


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

`BtnTask` 에서 기존에 필요한 props 와 `TaskType` 를 동시에 사용하기 위해 `BtnTaskProps extends TaskType` 와 같이 사용해 btnType를 살렸습니다

## 관련 이슈

close #100 
  
백번!

## 스크린샷 (선택)
![image](https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/8fe1decd-8394-423c-bf96-85f5fec1f37c)
