### PR TITLE
[FEAT] TextBoxInput 날짜, 시간 체크 실패시 피드백

### DIFF
--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
 import TextboxInput from '../textbox/TextboxInput';
 
+import formatDatetoString from '@/utils/formatDatetoString';
+
 interface CustomHeaderProps {
 	prevDate: Date | null;
 	decreaseMonth: () => void;
@@ -25,7 +27,12 @@ function CorrectionCustomHeader({
 	return (
 		<div className="react-datepicker__header-custom">
 			<InfoBox>
-				<TextboxInput variant="date" dateValue={prevDate} onChange={onChange} dateTextRef={dateTextRef} />
+				<TextboxInput
+					variant="date"
+					placeholder={formatDatetoString(prevDate)}
+					onChange={onChange}
+					dateTextRef={dateTextRef}
+				/>
 				<div className="react-datepicker__navigation-wrapper">
 					<BtnWrapper className="react-datepicker__navigation-container">
 						<ArrangeBtn

--- a/src/components/common/datePicker/CustomHeader.tsx
+++ b/src/components/common/datePicker/CustomHeader.tsx
@@ -36,9 +36,12 @@ function CustomHeader({
 		diff = Math.abs(endDate.getTime() - startDate.getTime());
 		diff = Math.ceil(diff / (1000 * 60 * 60 * 24)) + 1;
 	}
-
+	const stripTime = (date: Date) => new Date(date.setHours(0, 0, 0, 0));
 	const onStartChange = (date: Date) => {
-		if (endDate && endDate <= date) {
+		const strippedEndDate = endDate ? stripTime(endDate) : null;
+		const strippedDate = stripTime(date);
+
+		if (strippedEndDate && strippedEndDate < strippedDate) {
 			warnRef(startDateTextRef);
 			if (startDateTextRef.current) {
 				Object.assign(startDateTextRef.current, { value: '' });
@@ -48,7 +51,10 @@ function CustomHeader({
 		}
 	};
 	const onEndChange = (date: Date) => {
-		if (startDate && date <= startDate) {
+		const strippedStartDate = startDate ? stripTime(startDate) : null;
+		const strippedDate = stripTime(date);
+
+		if (strippedStartDate && strippedDate < strippedStartDate) {
 			warnRef(endDateTextRef);
 			if (endDateTextRef.current) {
 				Object.assign(endDateTextRef.current, { value: '' });

--- a/src/components/common/datePicker/CustomHeader.tsx
+++ b/src/components/common/datePicker/CustomHeader.tsx
@@ -5,6 +5,7 @@ import TextboxInput from '../textbox/TextboxInput';
 
 import DayDiffText from './DayDiffText';
 
+import formatDatetoString from '@/utils/formatDatetoString';
 import { warnRef } from '@/utils/refStatus';
 
 interface CustonHeaderProps {
@@ -63,18 +64,22 @@ function CustomHeader({
 			onChange(date, 'end');
 		}
 	};
-
 	return (
 		<div className="react-datepicker__header-custom">
 			<InfoBox>
 				<InfoWrapper>
 					<TextboxInput
 						variant="smallDate"
-						dateValue={startDate}
+						placeholder={formatDatetoString(startDate)}
 						onChange={onStartChange}
 						dateTextRef={startDateTextRef}
 					/>
-					<TextboxInput variant="smallDate" dateValue={endDate} onChange={onEndChange} dateTextRef={endDateTextRef} />
+					<TextboxInput
+						variant="smallDate"
+						placeholder={formatDatetoString(new Date())}
+						onChange={onEndChange}
+						dateTextRef={endDateTextRef}
+					/>
 				</InfoWrapper>
 				<DayDiffText diff={diff} />
 			</InfoBox>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -21,7 +21,8 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 	const onChange = (date: Date | null) => {
 		setCurrentDate(date);
 		if (dateTextRef.current) {
-			dateTextRef.current.value = formatDatetoString(date);
+			const inputElement = dateTextRef.current.querySelector('input');
+			if (inputElement) inputElement.value = formatDatetoString(date);
 		}
 	};
 

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -11,6 +11,7 @@ import CorrectionCustomHeader from './CorrectionCustomHeader';
 import CalendarStyle from './DatePickerStyle';
 
 import formatDatetoString from '@/utils/formatDatetoString';
+import { blurRef } from '@/utils/refStatus';
 
 function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 	const prevDate: Date = new Date();
@@ -23,6 +24,7 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 		if (dateTextRef.current) {
 			const inputElement = dateTextRef.current.querySelector('input');
 			if (inputElement) inputElement.value = formatDatetoString(date);
+			blurRef(dateTextRef);
 		}
 	};
 

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -17,22 +17,44 @@ function DatePickerCustom() {
 	const startDateTextRef = useRef<HTMLInputElement>(null);
 	const endDateTextRef = useRef<HTMLInputElement>(null);
 
+	/** ref 안에 Input DOM 있는지 검사하고 있다면 반환, 없으면 false 반환 */
+	const inputElementOfRef = (ref: React.RefObject<HTMLInputElement>) => {
+		if (ref.current) {
+			const inputElement = ref.current.querySelector('input');
+			if (inputElement) {
+				return inputElement;
+			}
+		}
+		return false;
+	};
+
+	/** 캘린더에서 날짜 선택할 경우 변경 */
 	const onChange = (dates: [Date | null, Date | null]) => {
 		const [start, end] = dates;
 		setStartDate(start);
 		blurRef(startDateTextRef);
-		if (startDateTextRef.current) {
-			const inputElement = startDateTextRef.current.querySelector('input');
-			if (inputElement) inputElement.value = formatDatetoString(start);
+		// 캘린더에서 선택한 시작시간 인풋에 반영
+		const startInputEle = inputElementOfRef(startDateTextRef);
+		if (startInputEle) {
+			startInputEle.value = formatDatetoString(start);
 		}
 
+		const endInputEle = inputElementOfRef(endDateTextRef);
+		// 시작 날짜는 있고 마감 날짜는 없을 경우
+		if (start && end === null) {
+			if (endInputEle) {
+				endInputEle.value = '';
+				endInputEle.placeholder = '마감 날짜';
+			}
+		}
+
+		// 캘린더에서 선택한 마감시간 인풋에 반영
+		if (endInputEle) endInputEle.value = formatDatetoString(end);
 		setEndDate(end);
 		blurRef(endDateTextRef);
-		if (endDateTextRef.current) {
-			const inputElement = endDateTextRef.current.querySelector('input');
-			if (inputElement) inputElement.value = formatDatetoString(end);
-		}
 	};
+
+	/** 인풋에서 날짜 타이핑했을 경우 변경 */
 	const onDateChange = (date: Date, mode: 'start' | 'end') => {
 		if (mode === 'start') {
 			blurRef(startDateTextRef);

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -13,7 +13,7 @@ import { blurRef } from '@/utils/refStatus';
 
 function DatePickerCustom() {
 	const [startDate, setStartDate] = useState<Date | null>(new Date());
-	const [endDate, setEndDate] = useState<Date | null>(null);
+	const [endDate, setEndDate] = useState<Date | null>(new Date());
 	const startDateTextRef = useRef<HTMLInputElement>(null);
 	const endDateTextRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -1,5 +1,5 @@
 import { ko } from 'date-fns/locale';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
@@ -12,10 +12,24 @@ import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef } from '@/utils/refStatus';
 
 function DatePickerCustom() {
-	const [startDate, setStartDate] = useState<Date | null>(new Date());
-	const [endDate, setEndDate] = useState<Date | null>(new Date());
+	const today = new Date();
+	const [startDate, setStartDate] = useState<Date | null>(today);
+	const [endDate, setEndDate] = useState<Date | null>(null);
 	const startDateTextRef = useRef<HTMLInputElement>(null);
 	const endDateTextRef = useRef<HTMLInputElement>(null);
+
+	// 초기값 이주 전으로 설정
+	useEffect(() => {
+		if (startDate) {
+			const newEndDate = new Date(startDate);
+			newEndDate.setDate(startDate.getDate() - 13);
+			setEndDate(newEndDate);
+			if (endDateTextRef.current) {
+				const inputElement = endDateTextRef.current.querySelector('input');
+				if (inputElement) inputElement.placeholder = formatDatetoString(newEndDate);
+			}
+		}
+	}, []);
 
 	/** ref 안에 Input DOM 있는지 검사하고 있다면 반환, 없으면 false 반환 */
 	const inputElementOfRef = (ref: React.RefObject<HTMLInputElement>) => {

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -22,13 +22,15 @@ function DatePickerCustom() {
 		setStartDate(start);
 		blurRef(startDateTextRef);
 		if (startDateTextRef.current) {
-			startDateTextRef.current.value = formatDatetoString(start);
+			const inputElement = startDateTextRef.current.querySelector('input');
+			if (inputElement) inputElement.value = formatDatetoString(start);
 		}
 
 		setEndDate(end);
 		blurRef(endDateTextRef);
 		if (endDateTextRef.current) {
-			endDateTextRef.current.value = formatDatetoString(end);
+			const inputElement = endDateTextRef.current.querySelector('input');
+			if (inputElement) inputElement.value = formatDatetoString(end);
 		}
 	};
 	const onDateChange = (date: Date, mode: 'start' | 'end') => {

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -27,7 +27,7 @@ function TextboxInput({ variant, onChange, dateTextRef, placeholder }: TextboxIn
 				// 유효하지 않음
 				warnRef(dateTextRef);
 				// 유효하지 않은 경우 인풋 삭제 필요?
-				// e.target.value = '';
+				e.target.value = '';
 			} else if ((variant === 'date' || variant === 'smallDate') && onChange) {
 				// 유효하고 date 인 경우
 				const valueDate = new Date(formattedInput);

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -28,7 +28,7 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 				// 유효하지 않음
 				warnRef(dateTextRef);
 				e.target.value = '';
-			} else if (variant === 'date' && onChange) {
+			} else if ((variant === 'date' || variant === 'smallDate') && onChange) {
 				// 유효하고 date 인 경우
 				const valueDate = new Date(formattedInput);
 				if (dateTextRef) blurRef(dateTextRef);

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -18,36 +18,24 @@ interface TextboxInputProps {
 }
 function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		if ((variant === 'date' || variant === 'smallDate') && onChange) {
-			const formattedInput = dotFormatDate(e.target.value);
-			e.target.value = formattedInput;
+		const { value } = e.target;
+		const formattedInput = variant === 'time' ? dotFormatTime(value) : dotFormatDate(value);
+		e.target.value = formattedInput;
 
-			if (formattedInput && formattedInput.length > 9) {
-				if (!checkDateFormat(formattedInput) && dateTextRef) {
-					warnRef(dateTextRef);
-					e.target.value = '';
-				} else {
-					const valueDate = new Date(formattedInput);
-					if (dateTextRef) {
-						blurRef(dateTextRef);
-					}
-					onChange(valueDate);
-				}
-			}
-		}
-
-		if (variant === 'time') {
-			const formattedInput = dotFormatTime(e.target.value);
-			e.target.value = formattedInput;
-
-			// 유효한 시간인지 검사
-			if (formattedInput && formattedInput.length > 4) {
-				if (!checkTimeFormat(formattedInput) && dateTextRef) {
-					warnRef(dateTextRef);
-					e.target.value = '';
-				} else if (dateTextRef) {
-					blurRef(dateTextRef);
-				}
+		if (formattedInput && formattedInput.length > (variant === 'time' ? 4 : 9)) {
+			const isValid = variant === 'time' ? checkTimeFormat(formattedInput) : checkDateFormat(formattedInput);
+			if (!isValid && dateTextRef) {
+				// 유효하지 않음
+				warnRef(dateTextRef);
+				e.target.value = '';
+			} else if (variant === 'date' && onChange) {
+				// 유효하고 date 인 경우
+				const valueDate = new Date(formattedInput);
+				if (dateTextRef) blurRef(dateTextRef);
+				onChange(valueDate);
+			} else if (dateTextRef) {
+				// 유효하고 time 인 경우
+				blurRef(dateTextRef);
 			}
 		}
 	};

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -8,6 +8,7 @@ import checkTimeFormat from '@/utils/checkTimeFormat';
 import dotFormatDate from '@/utils/dotFormatDate';
 import dotFormatTime from '@/utils/dotFormatTime';
 import formatDatetoString from '@/utils/formatDatetoString';
+import { blurRef, warnRef } from '@/utils/refStatus';
 
 interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
@@ -22,11 +23,14 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 			e.target.value = formattedInput;
 
 			if (formattedInput && formattedInput.length > 9) {
-				if (!checkDateFormat(formattedInput)) {
-					alert('유효한 날짜가 아님');
+				if (!checkDateFormat(formattedInput) && dateTextRef) {
+					warnRef(dateTextRef);
 					e.target.value = '';
 				} else {
 					const valueDate = new Date(formattedInput);
+					if (dateTextRef) {
+						blurRef(dateTextRef);
+					}
 					onChange(valueDate);
 				}
 			}
@@ -38,15 +42,17 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 
 			// 유효한 시간인지 검사
 			if (formattedInput && formattedInput.length > 4) {
-				if (!checkTimeFormat(formattedInput)) {
-					alert('유효한 시간이 아님');
+				if (!checkTimeFormat(formattedInput) && dateTextRef) {
+					warnRef(dateTextRef);
 					e.target.value = '';
+				} else if (dateTextRef) {
+					blurRef(dateTextRef);
 				}
 			}
 		}
 	};
 	return (
-		<InputContainer variant={variant}>
+		<InputContainer variant={variant} ref={dateTextRef}>
 			{variant === 'time' && <ClockIcon />}
 			<StyledInput
 				type="text"
@@ -54,7 +60,6 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 				maxLength={10}
 				variant={variant}
 				onChange={handleDateChange}
-				ref={dateTextRef}
 			/>
 		</InputContainer>
 	);

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -7,16 +7,15 @@ import checkDateFormat from '@/utils/checkDateFormat';
 import checkTimeFormat from '@/utils/checkTimeFormat';
 import dotFormatDate from '@/utils/dotFormatDate';
 import dotFormatTime from '@/utils/dotFormatTime';
-import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef, focusRef, warnRef } from '@/utils/refStatus';
 
 interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
-	dateValue?: Date | null;
 	onChange?: (date: Date) => void;
 	dateTextRef?: React.RefObject<HTMLInputElement>;
+	placeholder?: string;
 }
-function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInputProps) {
+function TextboxInput({ variant, onChange, dateTextRef, placeholder }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { value } = e.target;
 		const formattedInput = variant === 'time' ? dotFormatTime(value) : dotFormatDate(value);
@@ -45,7 +44,7 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 			{variant === 'time' && <ClockIcon />}
 			<StyledInput
 				type="text"
-				placeholder={variant === 'time' ? '시간 없음' : formatDatetoString(dateValue)}
+				placeholder={variant === 'time' ? '시간 없음' : placeholder}
 				maxLength={10}
 				variant={variant}
 				onChange={handleDateChange}

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -8,7 +8,7 @@ import checkTimeFormat from '@/utils/checkTimeFormat';
 import dotFormatDate from '@/utils/dotFormatDate';
 import dotFormatTime from '@/utils/dotFormatTime';
 import formatDatetoString from '@/utils/formatDatetoString';
-import { blurRef, warnRef } from '@/utils/refStatus';
+import { blurRef, focusRef, warnRef } from '@/utils/refStatus';
 
 interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
@@ -21,13 +21,14 @@ function TextboxInput({ variant, dateValue, onChange, dateTextRef }: TextboxInpu
 		const { value } = e.target;
 		const formattedInput = variant === 'time' ? dotFormatTime(value) : dotFormatDate(value);
 		e.target.value = formattedInput;
-
+		if (dateTextRef) focusRef(dateTextRef);
 		if (formattedInput && formattedInput.length > (variant === 'time' ? 4 : 9)) {
 			const isValid = variant === 'time' ? checkTimeFormat(formattedInput) : checkDateFormat(formattedInput);
 			if (!isValid && dateTextRef) {
 				// 유효하지 않음
 				warnRef(dateTextRef);
-				e.target.value = '';
+				// 유효하지 않은 경우 인풋 삭제 필요?
+				// e.target.value = '';
 			} else if ((variant === 'date' || variant === 'smallDate') && onChange) {
 				// 유효하고 date 인 경우
 				const valueDate = new Date(formattedInput);
@@ -76,11 +77,6 @@ const InputContainer = styled.div<{ variant: 'date' | 'time' | 'smallDate' }>`
 
 	background-color: ${({ theme }) => theme.palette.Grey.Grey1};
 	border-radius: 8px;
-
-	&:focus-within {
-		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
-		outline: solid 1px ${theme.palette.Primary};
-	}
 
 	${({ variant }) => variant === 'smallDate' && smallDateStyle}
 `;

--- a/src/utils/formatDatetoString.ts
+++ b/src/utils/formatDatetoString.ts
@@ -8,7 +8,7 @@ const formatDatetoString = (date: Date | undefined | null) => {
 		const day = '0'.concat(date.getDate().toString()).slice(-2);
 		return `${year}.${month}.${day}`;
 	}
-	return '시간';
+	return '';
 };
 
 export default formatDatetoString;

--- a/src/utils/refStatus.ts
+++ b/src/utils/refStatus.ts
@@ -13,3 +13,10 @@ export const blurRef = (ref: React.RefObject<HTMLInputElement>) => {
 	ref.current?.style.setProperty('outline', `none`);
 	ref.current?.style.setProperty('background-color', `${theme.palette.Grey.Grey1}`);
 };
+
+/** ref 파란줄 */
+export const focusRef = (ref: React.RefObject<HTMLInputElement>) => {
+	ref.current?.focus();
+	ref.current?.style.setProperty('outline', `solid 1px ${theme.palette.Primary}`);
+	ref.current?.style.setProperty('background-color', `${theme.palette.Blue.Blue2}`);
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 시간, 날짜 형식 체크 후 실패시 alert 처리 했었는데, 이를 인풋창 배경색과 테두리 색상 피드백으로 변경했습니다

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 이해하기 쉬운 코드와 중복이 적어 간결하게 적힌 코드 사이에서 고민이 되었습니다
- 간결하게 적은 코드의 경우 적은 양의 코드로 분기처리를 해서 로직을 수행하는 대신 직관적으로 이해하기 힘들었고, 모든 케이스를 명시적으로 작성한 경우 가독성과 직관성은 가져가지만 중복 코드를 많이 작성해야 했습니다
- 현재는 중복 로직을 줄이고 조건에 따라 분기했습니다


또 focus 는 ref 에만 되는 거 아닌가? 하는 우려가 있었는데 생각해보니 그냥 보더라인 색상 바꾸게 되어 있어서 ref 위치만 바꿔주었습니다. 별개로 div에 focus 주려면 tabindex 속성을 조정하면 된다고 하네요 ..

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 코드가 이해가 잘 되는지, 인풋 엣지케이스에도 잘 동작하는지 확인해주시면 감사하겠습니당

## 관련 이슈

close #105 

## 스크린샷 (선택)
![Jul-12-2024 00-42-08](https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/98469609/8c2dfd8f-3888-4a88-9374-9eef091a98b6)
