### PR TITLE
[FEAT] 캘린더 뷰 퍼블리싱

### DIFF
--- a/src/components/calendarPage/CategoryBox.tsx
+++ b/src/components/calendarPage/CategoryBox.tsx
@@ -32,7 +32,7 @@ const CategoryBoxLayout = styled.div`
 	width: 31.7rem;
 	height: 49rem;
 
-	border: 1px solid #e4e4e4;
+	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;
 `;
 

--- a/src/components/calendarPage/CategoryBox.tsx
+++ b/src/components/calendarPage/CategoryBox.tsx
@@ -30,7 +30,9 @@ const CategoryBoxLayout = styled.div`
 	flex-direction: column;
 	gap: 1.2rem;
 	width: 31.7rem;
-	height: 49rem;
+	height: 100%;
+	min-height: 46.1rem;
+	max-height: 49.3rem;
 
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const FullCalendarLayout = styled.div<{ size: string }>`
-	width: ${({ size }) => (size === 'big' ? '89.7rem' : '58rem')};
+	width: ${({ size }) => (size === 'big' ? '91rem' : '58rem')};
 	height: 93rem;
 
 	.fc .fc-toolbar.fc-header-toolbar {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 const FullCalendarLayout = styled.div<{ size: string }>`
 	width: ${({ size }) => (size === 'big' ? '91rem' : '58rem')};
-	height: 93rem;
 
 	.fc .fc-toolbar.fc-header-toolbar {
 		margin-bottom: 1.8rem;

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -23,6 +23,8 @@ function Calendar() {
 const CalendarLayout = styled.div`
 	display: flex;
 	gap: 1rem;
+	box-sizing: border-box;
+	height: 76.8rem;
 	padding: 10px 16px 10px 7px;
 `;
 

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,14 +1,52 @@
+import styled from '@emotion/styled';
+
 import CategoryBox from '@/components/calendarPage/CategoryBox';
 import MiniCalendar from '@/components/calendarPage/miniCalendar/MiniCalendar';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 
 function Calendar() {
 	return (
-		<div>
-			<MiniCalendar />
-			<CategoryBox email="hongildong@gmail.com" categoryList={['내 할 일', '공부', '운동']} />
-			<FullCalendarBox size="big" />
-		</div>
+		<CalendarLayout>
+			<LeftSection>
+				<MiniCalendar />
+				<CategoryBox email="hongildong@gmail.com" categoryList={['내 할 일', '공부', '운동']} />
+			</LeftSection>
+			<RightSection>
+				<FullCalendarBoxWapper>
+					<FullCalendarBox size="big" />
+				</FullCalendarBoxWapper>
+			</RightSection>
+		</CalendarLayout>
 	);
 }
+
+const CalendarLayout = styled.div`
+	display: flex;
+	gap: 1rem;
+	padding: 10px 16px 10px 7px;
+`;
+
+const LeftSection = styled.section`
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	align-items: center;
+	box-sizing: border-box;
+	width: 33.4rem;
+	height: 100%;
+`;
+
+const RightSection = styled.section`
+	height: 74.8rem;
+`;
+
+const FullCalendarBoxWapper = styled.div`
+	box-sizing: border-box;
+	width: 94.4rem;
+	height: 74.8rem;
+	padding: 18px 0 7px 17px;
+
+	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
+	border-radius: 12px;
+`;
 export default Calendar;

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -25,7 +25,7 @@ const CalendarLayout = styled.div`
 	gap: 1rem;
 	box-sizing: border-box;
 	height: 76.8rem;
-	padding: 10px 16px 10px 7px;
+	padding: 1rem 1.6rem 1rem 0.7rem;
 `;
 
 const LeftSection = styled.section`
@@ -46,7 +46,7 @@ const FullCalendarBoxWapper = styled.div`
 	box-sizing: border-box;
 	width: 94.4rem;
 	height: 74.8rem;
-	padding: 18px 0 7px 17px;
+	padding: 18px 0 0 17px;
 
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -12,7 +12,11 @@ function MainLayout() {
 	);
 }
 const MainLayOutContainer = styled.div`
+	width: 1294px;
+	height: 768px;
 	padding-left: 7.2rem;
+
+	border: 1px solid red;
 `;
 
 export default MainLayout;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -12,11 +12,7 @@ function MainLayout() {
 	);
 }
 const MainLayOutContainer = styled.div`
-	width: 1294px;
-	height: 768px;
 	padding-left: 7.2rem;
-
-	border: 1px solid red;
 `;
 
 export default MainLayout;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 1366px x 768px 에 맞춰서 캘린더 뷰 퍼블리싱을 진행했습니다.
- 빨간색 선이 해상도 크기이고 그 크기에 맞춰서 배치 조정을 했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


- 카테고리의 경우 위에 있는 미니 캘린더가 길어지면 줄어드는 크기를 계산해서 min, max height를 지정했는데 이것보다 좋은 방법이 있다면 말씀해주세용.. height : 100%로하면 꽉안차서 이렇게 진행을 했습니다.
## 관련 이슈

close #103 

## 스크린샷 (선택)
<img width="1378" alt="Screenshot 2024-07-12 at 12 44 41 AM" src="https://github.com/TEAM-DAWM/NUTSHELL-FE/assets/52481403/64233bba-0b91-4b19-9a34-55ec02b726b5">
