### PR TITLE
[FEAT] Today 페이지 퍼블리싱 + StagingArea 모달 연결

### DIFF
--- a/src/components/common/BtnDate/BtnStagingDate.tsx
+++ b/src/components/common/BtnDate/BtnStagingDate.tsx
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled';
 
-function BtnStagingDate() {
+interface BtnStagingDateProps {
+	onClick?: () => void;
+}
+
+function BtnStagingDate({ onClick }: BtnStagingDateProps) {
 	return (
-		<BtnStagingDateLayout>
+		<BtnStagingDateLayout onClick={onClick}>
 			<BtnStagingDateText>⇥ 마감 기한 설정</BtnStagingDateText>
 		</BtnStagingDateLayout>
 	);

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -157,7 +157,7 @@ const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: B
 };
 
 const ModalLayout = styled.div`
-	position: relative;
+	display: flex;
 `;
 
 const BtnTaskLayout = styled('div', { target: 'BtnTaskLayout' })<{

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -70,9 +70,9 @@ function BtnTask(props: BtnTaskProps) {
 		if (iconClicked) {
 			setIconClicked(false);
 		} else {
-			stopPropagation(e);
 			setIconClicked(true);
 		}
+		stopPropagation(e);
 	};
 
 	const renderStatusButton = () => {

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -126,7 +126,7 @@ function BtnTask(props: BtnTaskProps) {
 					{renderStatusButton()}
 				</IconHoverContainer>
 			</BtnTaskLayout>
-			<Modal isOpen={isClicked} sizeType={{ type: 'short' }} top={top} left={left} />
+			<Modal isOpen={isClicked} sizeType={{ type: 'short' }} top={top} left={left} onClose={handleClick} />
 		</ModalLayout>
 	);
 }

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -34,6 +34,9 @@ function BtnTask(props: BtnTaskProps) {
 	const [top, setTop] = useState(0);
 	const [left, setLeft] = useState(0);
 
+	const MODAL_HEIGHT = 362;
+	const SCREEN_HEIGHT = 768;
+
 	const handleMouseEnter = () => {
 		setIsHovered(true);
 	};
@@ -44,7 +47,9 @@ function BtnTask(props: BtnTaskProps) {
 
 	const handleClick = (e: React.MouseEvent) => {
 		const rect = e.currentTarget.getBoundingClientRect();
-		setTop(rect.top);
+		const calculatedTop = rect.top;
+		const adjustedTop = Math.min(calculatedTop, SCREEN_HEIGHT - MODAL_HEIGHT);
+		setTop(adjustedTop);
 		setLeft(rect.right + 6);
 		setIsClicked((prev) => !prev);
 	};

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -2,6 +2,8 @@ import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
+import Modal from '../modal/Modal';
+
 import Icons from '@/assets/svg/index';
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
@@ -29,6 +31,9 @@ function BtnTask(props: BtnTaskProps) {
 	const [iconHovered, setIconHovered] = useState(false);
 	const [iconClicked, setIconClicked] = useState(false);
 
+	const [top, setTop] = useState(0);
+	const [left, setLeft] = useState(0);
+
 	const handleMouseEnter = () => {
 		setIsHovered(true);
 	};
@@ -37,7 +42,10 @@ function BtnTask(props: BtnTaskProps) {
 		setIsHovered(false);
 	};
 
-	const handleClick = () => {
+	const handleClick = (e: React.MouseEvent) => {
+		const rect = e.currentTarget.getBoundingClientRect();
+		setTop(rect.top);
+		setLeft(rect.right + 6);
 		setIsClicked((prev) => !prev);
 	};
 
@@ -90,33 +98,36 @@ function BtnTask(props: BtnTaskProps) {
 	};
 
 	return (
-		<BtnTaskLayout
-			isClicked={isClicked}
-			isHovered={isHovered}
-			iconHovered={iconHovered}
-			btnType={btnType}
-			onClick={handleClick}
-		>
-			<BtnTaskContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-				<BtnTaskTextWrapper isDescription={hasDescription}>
-					{hasDescription && <IconFile />}
-					{name}
-				</BtnTaskTextWrapper>
-				<BtnDate
-					date={deadLine?.date}
-					time={deadLine?.time}
-					size={{ type: 'short' }}
-					isDelayed={btnType === 'delayed'}
-				/>
-			</BtnTaskContainer>
-			<IconHoverContainer
-				onClick={handleIconClick}
-				onMouseEnter={handleIconMouseEnter}
-				onMouseLeave={handleIconMouseLeave}
+		<ModalLayout>
+			<BtnTaskLayout
+				isClicked={isClicked}
+				isHovered={isHovered}
+				iconHovered={iconHovered}
+				btnType={btnType}
+				onClick={handleClick}
 			>
-				{renderStatusButton()}
-			</IconHoverContainer>
-		</BtnTaskLayout>
+				<BtnTaskContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+					<BtnTaskTextWrapper isDescription={hasDescription}>
+						{hasDescription && <IconFile />}
+						{name}
+					</BtnTaskTextWrapper>
+					<BtnDate
+						date={deadLine?.date}
+						time={deadLine?.time}
+						size={{ type: 'short' }}
+						isDelayed={btnType === 'delayed'}
+					/>
+				</BtnTaskContainer>
+				<IconHoverContainer
+					onClick={handleIconClick}
+					onMouseEnter={handleIconMouseEnter}
+					onMouseLeave={handleIconMouseLeave}
+				>
+					{renderStatusButton()}
+				</IconHoverContainer>
+			</BtnTaskLayout>
+			<Modal isOpen={isClicked} sizeType={{ type: 'short' }} top={top} left={left} />
+		</ModalLayout>
 	);
 }
 
@@ -139,6 +150,10 @@ const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: B
 		border-color: ${borderColor};
 	`;
 };
+
+const ModalLayout = styled.div`
+	position: relative;
+`;
 
 const BtnTaskLayout = styled('div', { target: 'BtnTaskLayout' })<{
 	isClicked: boolean;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -213,4 +213,15 @@ const BtnTaskContainer = styled.div`
 	width: 100%;
 	height: 56.7rem;
 	overflow: hidden auto;
+
+	::-webkit-scrollbar {
+		width: 0.6rem;
+	}
+
+	::-webkit-scrollbar-thumb {
+		width: 0.6rem;
+
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+		border-radius: 3px;
+	}
 `;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -84,6 +84,7 @@ const StagingAreaLayout = styled.div`
 	display: inline-flex;
 	gap: 0.8rem;
 	align-items: center;
+	height: 76.8rem;
 	padding: 0 0.7rem;
 
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -1,157 +1,16 @@
 import styled from '@emotion/styled';
 
-import BtnTask from '@/components/common/BtnTask/BtnTask';
-import ScrollGradient from '@/components/common/ScrollGradient';
-import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
+import StagingAreaTaskContainer from './StagingAreaTaskContainer';
+
 import TextInputStaging from '@/components/common/textbox/TextInputStaging';
-import { TaskType } from '@/types/tasks/taskType';
 
 function StagingArea() {
-	const dummyTaskList: TaskType[] = [
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-	];
-
 	return (
 		<StagingAreaLayout>
 			<StagingAreaContainer>
 				<StagingAreaUpContainer>
 					<StagingAreaTitle>쏟아내기</StagingAreaTitle>
-					<StagingAreaTaskContainer>
-						<StagingAreaSetting />
-						<BtnTaskContainer>
-							{dummyTaskList.map((task) => (
-								<BtnTask
-									key={task.id + task.name}
-									btnType="staging"
-									hasDescription={task.hasDescription}
-									id={task.id}
-									name={task.name}
-									status={task.status}
-									deadLine={task.deadLine}
-								/>
-							))}
-							<ScrollGradient />
-						</BtnTaskContainer>
-					</StagingAreaTaskContainer>
+					<StagingAreaTaskContainer />
 				</StagingAreaUpContainer>
 				<TextInputStaging />
 			</StagingAreaContainer>
@@ -166,7 +25,7 @@ const StagingAreaLayout = styled.div`
 	gap: 0.8rem;
 	align-items: center;
 	height: 76.8rem;
-	padding: 0 0.7rem;
+	padding: 0 0.1rem 0 0.7rem;
 
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 0 12px 12px 0;
@@ -195,33 +54,4 @@ const StagingAreaTitle = styled.div`
 	justify-content: center;
 	padding: 2.8rem 3.6rem 2.1rem 1.2rem;
 	${({ theme }) => theme.fontTheme.HEADLINE_02};
-`;
-
-const StagingAreaTaskContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: 1.3rem;
-	align-items: flex-start;
-	align-self: stretch;
-`;
-
-const BtnTaskContainer = styled.div`
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	width: 100%;
-	height: 56.7rem;
-	overflow: hidden auto;
-
-	::-webkit-scrollbar {
-		width: 0.6rem;
-	}
-
-	::-webkit-scrollbar-thumb {
-		width: 0.6rem;
-
-		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
-		border-radius: 3px;
-	}
 `;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -48,7 +48,88 @@ function StagingArea() {
 			hasDescription: true,
 			status: '미완료',
 		},
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
 	];
+
 	return (
 		<StagingAreaLayout>
 			<StagingAreaContainer>
@@ -125,7 +206,11 @@ const StagingAreaTaskContainer = styled.div`
 `;
 
 const BtnTaskContainer = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
 	width: 100%;
 	height: 56.7rem;
-	overflow: scroll;
+	overflow: hidden auto;
 `;

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -3,12 +3,18 @@ import { useState } from 'react';
 
 import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
 import TextBtn from '../button/textBtn/TextBtn';
+import ModalArrange from '../modal/ModalArrange/ModalArrange';
 
 function StagingAreaSetting() {
 	const [activeButton, setActiveButton] = useState<'전체' | '취소'>('전체');
+	const [isModalOpen, setIsModalOpen] = useState(false);
 
-	const handleButtonClick = (button: '전체' | '취소') => {
+	const handleTextBtnClick = (button: '전체' | '취소') => {
 		setActiveButton(button);
+	};
+
+	const handleArrangeBtnClick = () => {
+		setIsModalOpen((prev) => !prev);
 	};
 
 	return (
@@ -21,7 +27,7 @@ function StagingAreaSetting() {
 					mode={activeButton === '전체' ? 'DEFAULT' : 'LIGHT'}
 					isHover
 					isPressed
-					onClick={() => handleButtonClick('전체')}
+					onClick={() => handleTextBtnClick('전체')}
 				/>
 				<TextBtn
 					size="small"
@@ -30,10 +36,13 @@ function StagingAreaSetting() {
 					mode={activeButton === '취소' ? 'DEFAULT' : 'LIGHT'}
 					isHover
 					isPressed
-					onClick={() => handleButtonClick('취소')}
+					onClick={() => handleTextBtnClick('취소')}
 				/>
 			</TextBtnContainer>
-			<ArrangeBtn type="set" mode="DEFAULT" color="WHITE" size="small" />
+			<ArrangeContainer>
+				<ArrangeBtn type="set" mode="DEFAULT" color="WHITE" size="small" onClick={handleArrangeBtnClick} />
+				{isModalOpen && <ModalArrange />}
+			</ArrangeContainer>
 		</StagingAreaSettingLayout>
 	);
 }
@@ -52,4 +61,8 @@ const TextBtnContainer = styled.div`
 	gap: 0.4rem;
 	align-items: center;
 	padding-left: 0.4rem;
+`;
+
+const ArrangeContainer = styled.div`
+	position: relative;
 `;

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -33,7 +33,7 @@ function StagingAreaSetting() {
 					onClick={() => handleButtonClick('취소')}
 				/>
 			</TextBtnContainer>
-			<ArrangeBtn type="set" mode="DISABLED" color="WHITE" size="small" />
+			<ArrangeBtn type="set" mode="DEFAULT" color="WHITE" size="small" />
 		</StagingAreaSettingLayout>
 	);
 }

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -17,6 +17,10 @@ function StagingAreaSetting() {
 		setIsModalOpen((prev) => !prev);
 	};
 
+	const handleCloseModal = () => {
+		setIsModalOpen(false);
+	};
+
 	return (
 		<StagingAreaSettingLayout>
 			<TextBtnContainer>
@@ -43,11 +47,20 @@ function StagingAreaSetting() {
 				<ArrangeBtn type="set" mode="DEFAULT" color="WHITE" size="small" onClick={handleArrangeBtnClick} />
 				{isModalOpen && <ModalArrange />}
 			</ArrangeContainer>
+			{isModalOpen && <ModalBackdrop onClick={handleCloseModal} />}
 		</StagingAreaSettingLayout>
 	);
 }
 
 export default StagingAreaSetting;
+
+const ModalBackdrop = styled.div`
+	position: absolute;
+	top: 0;
+	z-index: 3;
+	width: 100vw;
+	height: 100vh;
+`;
 
 const StagingAreaSettingLayout = styled.div`
 	display: flex;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -1,0 +1,180 @@
+import styled from '@emotion/styled';
+
+import BtnTask from '@/components/common/BtnTask/BtnTask';
+import ScrollGradient from '@/components/common/ScrollGradient';
+import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
+import { TaskType } from '@/types/tasks/taskType';
+
+function StagingAreaTaskContainer() {
+	const dummyTaskList: TaskType[] = [
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
+		{
+			id: 0,
+			name: '바보~',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: false,
+			status: '진행중',
+		},
+		{
+			id: 1,
+			name: '넛수레',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '지연',
+		},
+		{
+			id: 2,
+			name: '콘하스',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '완료',
+		},
+		{
+			id: 3,
+			name: '김지원',
+			deadLine: {
+				date: '2024-06-30',
+				time: '12:30',
+			},
+			hasDescription: true,
+			status: '미완료',
+		},
+	];
+
+	return (
+		<StagingAreaTaskContainerLayout>
+			<StagingAreaSetting />
+			<BtnTaskContainer>
+				{dummyTaskList.map((task) => (
+					<BtnTask
+						key={task.id + task.name}
+						btnType="staging"
+						hasDescription={task.hasDescription}
+						id={task.id}
+						name={task.name}
+						status={task.status}
+						deadLine={task.deadLine}
+					/>
+				))}
+				<ScrollGradient />
+			</BtnTaskContainer>
+		</StagingAreaTaskContainerLayout>
+	);
+}
+
+export default StagingAreaTaskContainer;
+
+const StagingAreaTaskContainerLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 1.3rem;
+	align-items: flex-start;
+	align-self: stretch;
+`;
+const BtnTaskContainer = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	height: 56.7rem;
+	overflow: auto;
+	overflow-y: scroll;
+
+	::-webkit-scrollbar {
+		width: 0.6rem;
+	}
+
+	::-webkit-scrollbar-thumb {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+		border-radius: 3px;
+	}
+`;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -12,10 +12,10 @@ import CalendarStyle from './DatePickerStyle';
 
 import formatDatetoString from '@/utils/formatDatetoString';
 
-function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
+function DateCorrectionModal({ isDateOnly = false }: { isDateOnly?: boolean }) {
 	const prevDate: Date = new Date();
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
-	// const [time, setTime] = useState<string>('');
+
 	const dateTextRef = useRef<HTMLInputElement>(null);
 	const timeTextRef = useRef<HTMLInputElement>(null);
 	const onChange = (date: Date | null) => {
@@ -26,23 +26,33 @@ function DateCorrectionModal({ isDateOnly }: { isDateOnly: boolean }) {
 	};
 
 	return (
-		<DatePicker
-			locale={ko}
-			selected={currentDate}
-			onChange={onChange}
-			inline
-			calendarContainer={CalendarStyle}
-			renderCustomHeader={(props) => (
-				<CorrectionCustomHeader {...props} prevDate={prevDate} dateTextRef={dateTextRef} onChange={onChange} />
-			)}
-		>
-			<BottomBtnWrapper>
-				{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
-				<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
-			</BottomBtnWrapper>
-		</DatePicker>
+		<DateCorrectionModalLayout>
+			<DatePicker
+				locale={ko}
+				selected={currentDate}
+				onChange={onChange}
+				inline
+				calendarContainer={CalendarStyle}
+				renderCustomHeader={(props) => (
+					<CorrectionCustomHeader {...props} prevDate={prevDate} dateTextRef={dateTextRef} onChange={onChange} />
+				)}
+			>
+				<BottomBtnWrapper>
+					{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
+					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
+				</BottomBtnWrapper>
+			</DatePicker>
+		</DateCorrectionModalLayout>
 	);
 }
+
+const DateCorrectionModalLayout = styled.div`
+	position: absolute;
+	bottom: 7.6rem;
+	left: -1.1rem;
+	z-index: 2;
+`;
+
 const BottomBtnWrapper = styled.div`
 	display: flex;
 	gap: 0.5rem;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -50,7 +50,7 @@ const DateCorrectionModalLayout = styled.div`
 	position: absolute;
 	bottom: 7.6rem;
 	left: -1.1rem;
-	z-index: 2;
+	z-index: 4;
 `;
 
 const BottomBtnWrapper = styled.div`

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 
 const FullCalendarLayout = styled.div<{ size: string }>`
-	width: ${({ size }) => (size === 'big' ? '91rem' : '58rem')};
+	width: ${({ size }) => (size === 'big' ? '89.7rem' : '64.3rem')};
+	height: 70rem;
 
 	.fc .fc-toolbar.fc-header-toolbar {
 		margin-bottom: 1.8rem;

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const FullCalendarLayout = styled.div<{ size: string }>`
-	width: ${({ size }) => (size === 'big' ? '89.7rem' : '64.3rem')};
+	width: ${({ size }) => (size === 'big' ? '91rem' : '58rem')};
 	height: 70rem;
 
 	.fc .fc-toolbar.fc-header-toolbar {

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -10,12 +10,14 @@ import { SizeType } from '@/types/textInputType';
 interface ModalProps {
 	isOpen: boolean;
 	sizeType: SizeType;
+	top: number;
+	left: number;
 }
 
-function Modal({ isOpen, sizeType }: ModalProps) {
+function Modal({ isOpen, sizeType, top, left }: ModalProps) {
 	return (
 		isOpen && (
-			<ModalLayout type={sizeType.type}>
+			<ModalLayout type={sizeType.type} top={top} left={left}>
 				<ModalHeader>
 					<BtnDate />
 					<ModalHeaderBtn type={sizeType.type} />
@@ -33,7 +35,11 @@ function Modal({ isOpen, sizeType }: ModalProps) {
 	);
 }
 
-const ModalLayout = styled.div<{ type: string }>`
+const ModalLayout = styled.div<{ type: string; top: number; left: number }>`
+	position: fixed;
+	top: ${({ top }) => top}px;
+	left: ${({ left }) => left}px;
+	z-index: 2;
 	display: flex;
 	flex-direction: column;
 	gap: 1.6rem;

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -49,8 +49,6 @@ const ModalBackdrop = styled.div`
 	justify-content: center;
 	width: 100vw;
 	height: 100vh;
-
-	background: rgb(0 0 0 / 50%);
 `;
 
 const ModalLayout = styled.div<{ type: string; top: number; left: number }>`

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -64,6 +64,7 @@ const ModalLayout = styled.div<{ type: string; top: number; left: number }>`
 	box-sizing: border-box;
 	width: ${({ type }) => (type === 'long' ? '37.2rem' : '32.8rem')};
 	padding: 1rem 1.2rem;
+	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.palette.Grey.White};
 	box-shadow: 0 1.2rem 3rem 0 rgb(0 0 0 / 30%);

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import React from 'react';
 
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
@@ -12,34 +13,51 @@ interface ModalProps {
 	sizeType: SizeType;
 	top: number;
 	left: number;
+	onClose: React.MouseEventHandler;
 }
 
-function Modal({ isOpen, sizeType, top, left }: ModalProps) {
+function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
 	return (
 		isOpen && (
-			<ModalLayout type={sizeType.type} top={top} left={left}>
-				<ModalHeader>
-					<BtnDate />
-					<ModalHeaderBtn type={sizeType.type} />
-				</ModalHeader>
-				<ModalBody>
-					<TextInputBox type={sizeType.type} />
-					{sizeType.type === 'long' && <ModalTextInputTime />}
-				</ModalBody>
-				<ModalFooter>
-					<OkayCancelBtn type="cancel" />
-					<OkayCancelBtn type="okay" />
-				</ModalFooter>
-			</ModalLayout>
+			<ModalBackdrop onClick={onClose}>
+				<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
+					<ModalHeader>
+						<BtnDate />
+						<ModalHeaderBtn type={sizeType.type} />
+					</ModalHeader>
+					<ModalBody>
+						<TextInputBox type={sizeType.type} />
+						{sizeType.type === 'long' && <ModalTextInputTime />}
+					</ModalBody>
+					<ModalFooter>
+						<OkayCancelBtn type="cancel" />
+						<OkayCancelBtn type="okay" />
+					</ModalFooter>
+				</ModalLayout>
+			</ModalBackdrop>
 		)
 	);
 }
+
+const ModalBackdrop = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 3;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100vw;
+	height: 100vh;
+
+	background: rgb(0 0 0 / 50%);
+`;
 
 const ModalLayout = styled.div<{ type: string; top: number; left: number }>`
 	position: fixed;
 	top: ${({ top }) => top}px;
 	left: ${({ left }) => left}px;
-	z-index: 2;
+	z-index: 3;
 	display: flex;
 	flex-direction: column;
 	gap: 1.6rem;

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -54,6 +54,7 @@ const ModalArrangeLayout = styled.div`
 	position: absolute;
 	top: 3rem;
 	left: 0;
+	z-index: 1;
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 0;

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -5,11 +5,7 @@ import SortBtn from '../../button/SortBtn';
 
 import SORT_BY from '@/constants/sortType';
 
-interface ModalArrangeProps {
-	// onClose: React.MouseEventHandler;
-}
-
-function ModalArrange({ onClose }: ModalArrangeProps) {
+function ModalArrange() {
 	const [activeSorByDateAdded, setActiveSorByDateAdded] = useState<string | null>(null);
 	const [activeSorByDeadLine, setActiveSorByDeadLine] = useState<string | null>(null);
 

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -51,6 +51,9 @@ function ModalArrange() {
 export default ModalArrange;
 
 const ModalArrangeLayout = styled.div`
+	position: absolute;
+	top: 3rem;
+	left: 0;
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 0;

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -5,7 +5,11 @@ import SortBtn from '../../button/SortBtn';
 
 import SORT_BY from '@/constants/sortType';
 
-function ModalArrange() {
+interface ModalArrangeProps {
+	// onClose: React.MouseEventHandler;
+}
+
+function ModalArrange({ onClose }: ModalArrangeProps) {
 	const [activeSorByDateAdded, setActiveSorByDateAdded] = useState<string | null>(null);
 	const [activeSorByDeadLine, setActiveSorByDeadLine] = useState<string | null>(null);
 
@@ -18,7 +22,7 @@ function ModalArrange() {
 	};
 
 	return (
-		<ModalArrangeLayout>
+		<ModalArrangeLayout onClick={(e) => e.stopPropagation()}>
 			<SortBy>
 				<SortBtn
 					text={SORT_BY.NEWEST}

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -54,7 +54,7 @@ const ModalArrangeLayout = styled.div`
 	position: absolute;
 	top: 3rem;
 	left: 0;
-	z-index: 1;
+	z-index: 4;
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 0;

--- a/src/components/common/modal/ModalArrange/ModalArrange.tsx
+++ b/src/components/common/modal/ModalArrange/ModalArrange.tsx
@@ -39,9 +39,9 @@ function ModalArrange() {
 					onClick={() => handleSortByDeadLineClick(SORT_BY.CLOSEST)}
 				/>
 				<SortBtn
-					text={SORT_BY.CLOSEST}
-					isActive={activeSorByDeadLine === SORT_BY.CLOSEST}
-					onClick={() => handleSortByDeadLineClick(SORT_BY.CLOSEST)}
+					text={SORT_BY.FARTHEST}
+					isActive={activeSorByDeadLine === SORT_BY.FARTHEST}
+					onClick={() => handleSortByDeadLineClick(SORT_BY.FARTHEST)}
 				/>
 			</SortBy>
 		</ModalArrangeLayout>

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -12,6 +12,10 @@ function TextInputStaging() {
 		setIsModalOpen((prev) => !prev);
 	};
 
+	const handleCloseModal = () => {
+		setIsModalOpen(false);
+	};
+
 	return (
 		<StagingLayout>
 			<TextArea placeholder="해야하는 일들을 쏟아내보세요." />
@@ -20,11 +24,22 @@ function TextInputStaging() {
 					{isModalOpen && <DateCorrectionModal />}
 					<BtnStagingDate onClick={handleArrangeBtnClick} />
 				</SetDeadLineContainer>
+				{isModalOpen && <ModalBackdrop onClick={handleCloseModal} />}
+
 				<EnterBtn />
 			</BtnWrapper>
 		</StagingLayout>
 	);
 }
+
+const ModalBackdrop = styled.div`
+	position: absolute;
+	top: 0;
+	z-index: 3;
+	width: 100vw;
+	height: 100vh;
+`;
+
 const StagingLayout = styled.div`
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -1,14 +1,25 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import BtnStagingDate from '../BtnDate/BtnStagingDate';
 import EnterBtn from '../button/EnterBtn';
+import DateCorrectionModal from '../datePicker/DateCorrectionModal';
 
 function TextInputStaging() {
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
+	const handleArrangeBtnClick = () => {
+		setIsModalOpen((prev) => !prev);
+	};
+
 	return (
 		<StagingLayout>
 			<TextArea placeholder="해야하는 일들을 쏟아내보세요." />
 			<BtnWrapper>
-				<BtnStagingDate />
+				<SetDeadLineContainer>
+					{isModalOpen && <DateCorrectionModal />}
+					<BtnStagingDate onClick={handleArrangeBtnClick} />
+				</SetDeadLineContainer>
 				<EnterBtn />
 			</BtnWrapper>
 		</StagingLayout>
@@ -46,6 +57,10 @@ const BtnWrapper = styled.div`
 	justify-content: space-between;
 	width: 100%;
 	height: fit-content;
+`;
+
+const SetDeadLineContainer = styled.div`
+	position: relative;
 `;
 
 export default TextInputStaging;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -27,7 +27,7 @@ const TargetAreaLayout = styled.section`
 	align-items: flex-start;
 	height: 74.8rem;
 	margin: 1rem;
-	padding: 0 0.7rem;
+	padding: 0 0.1rem 0 0.7rem;
 
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -25,8 +25,7 @@ const TargetAreaLayout = styled.section`
 	flex-direction: column;
 	flex-shrink: 0;
 	align-items: flex-start;
-	width: 31rem;
-	height: fit-content;
+	height: 74.8rem;
 	margin: 1rem;
 	padding: 0 0.7rem;
 

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -27,6 +27,7 @@ const TargetAreaLayout = styled.section`
 	align-items: flex-start;
 	width: 31rem;
 	height: fit-content;
+	margin: 1rem;
 	padding: 0 0.7rem;
 
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -72,6 +72,17 @@ const TaskContainer = styled.div`
 	width: 100%;
 	height: 64rem;
 	overflow: scroll;
+
+	::-webkit-scrollbar {
+		width: 0.6rem;
+	}
+
+	::-webkit-scrollbar-thumb {
+		width: 0.6rem;
+
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+		border-radius: 3px;
+	}
 `;
 
 export default TargetTaskSection;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -48,6 +48,7 @@ function TargetTaskSection() {
 			status: '미완료',
 		},
 	];
+
 	return (
 		<TaskContainer>
 			{dummyTaskList.map((task) => (
@@ -71,15 +72,14 @@ const TaskContainer = styled.div`
 	gap: 1rem;
 	width: 100%;
 	height: 64rem;
-	overflow: scroll;
+	overflow: hidden;
+	overflow-y: scroll;
 
 	::-webkit-scrollbar {
 		width: 0.6rem;
 	}
 
 	::-webkit-scrollbar-thumb {
-		width: 0.6rem;
-
 		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
 		border-radius: 3px;
 	}

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import BtnTask from '../common/BtnTask/BtnTask';
+import ScrollGradient from '../common/ScrollGradient';
 
 import { TaskType } from '@/types/tasks/taskType';
 
@@ -60,6 +61,7 @@ function TargetTaskSection() {
 					id={task.id}
 				/>
 			))}
+			<ScrollGradient />
 		</TaskContainer>
 	);
 }
@@ -71,4 +73,5 @@ const TaskContainer = styled.div`
 	height: 64rem;
 	overflow: scroll;
 `;
+
 export default TargetTaskSection;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -12,6 +12,7 @@ function MainLayout() {
 	);
 }
 const MainLayOutContainer = styled.div`
+	box-sizing: border-box;
 	width: 136.6rem;
 	height: 76.8rem;
 	padding-left: 7.2rem;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -12,7 +12,11 @@ function MainLayout() {
 	);
 }
 const MainLayOutContainer = styled.div`
+	width: 136.6rem;
+	height: 76.8rem;
 	padding-left: 7.2rem;
+
+	border: 1px solid ${({ theme }) => theme.palette.Orange.Orange5};
 `;
 
 export default MainLayout;

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -15,7 +15,6 @@ import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import TextBtn from '@/components/common/button/textBtn/TextBtn';
 import TimelineDeleteBtn from '@/components/common/button/TimelineDeleteBtn';
 import TodayPlusBtn from '@/components/common/button/TodayPlusBtn';
-import Modal from '@/components/common/modal/Modal';
 import NavBar from '@/components/common/NavBar';
 import AccountArea from '@/components/SettingPage/AccountArea';
 import LogOutBtn from '@/components/SettingPage/LogOutBtn';
@@ -40,9 +39,6 @@ function Setting() {
 			<StatusStagingBtn />
 			<TimelineDeleteBtn />
 			<TodayPlusBtn />
-
-			<Modal isOpen sizeType={{ type: 'long' }} />
-			<Modal isOpen sizeType={{ type: 'short' }} />
 
 			<StatusDoneBtn />
 			<StatusInProgressBtn />

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -86,10 +86,10 @@ const CalendarWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	width: 65rem;
+	width: fit-content;
 	height: 72.8rem;
 	margin: 1rem 0;
-	padding: 18px 0 0 23px;
+	padding: 1.8rem 0.7rem 0 2.3rem;
 
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 12px;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import BtnStagingDate from '@/components/common/BtnDate/BtnStagingDate';
 import BtnTask from '@/components/common/BtnTask/BtnTask';
@@ -5,6 +7,7 @@ import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
 import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
 import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
+import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import ModalArrange from '@/components/common/modal/ModalArrange/ModalArrange';
 import NavBar from '@/components/common/NavBar';
 import ScrollGradient from '@/components/common/ScrollGradient';
@@ -23,6 +26,14 @@ function Today() {
 			<NavBar />
 
 			<ModalArrange />
+
+			<TodayLayout>
+				<StagingArea />
+				<TargetArea />
+				<CalendarWrapper>
+					<FullCalendarBox size="small" />
+				</CalendarWrapper>
+			</TodayLayout>
 
 			<ScrollGradient />
 
@@ -72,3 +83,20 @@ function Today() {
 }
 
 export default Today;
+
+const TodayLayout = styled.div`
+	display: flex;
+`;
+
+const CalendarWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	width: 65rem;
+	height: 72.8rem;
+	margin: 1rem 0;
+	padding: 18px 0 0 23px;
+
+	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
+	border-radius: 12px;
+`;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -25,8 +25,6 @@ function Today() {
 		<>
 			<NavBar />
 
-			<ModalArrange />
-
 			<TodayLayout>
 				<StagingArea />
 				<TargetArea />
@@ -34,6 +32,8 @@ function Today() {
 					<FullCalendarBox size="small" />
 				</CalendarWrapper>
 			</TodayLayout>
+
+			<ModalArrange />
 
 			<ScrollGradient />
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -9,7 +9,6 @@ import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStaging
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import NavBar from '@/components/common/NavBar';
-import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TextboxDailydate from '@/components/common/textbox/TextboxDailydate';
 import TextboxInput from '@/components/common/textbox/TextboxInput';
@@ -31,8 +30,6 @@ function Today() {
 					<FullCalendarBox size="small" />
 				</CalendarWrapper>
 			</TodayLayout>
-
-			<ScrollGradient />
 
 			<StagingArea />
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -8,7 +8,6 @@ import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInPr
 import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
 import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
-import ModalArrange from '@/components/common/modal/ModalArrange/ModalArrange';
 import NavBar from '@/components/common/NavBar';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
@@ -32,8 +31,6 @@ function Today() {
 					<FullCalendarBox size="small" />
 				</CalendarWrapper>
 			</TodayLayout>
-
-			<ModalArrange />
 
 			<ScrollGradient />
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -1,21 +1,8 @@
 import styled from '@emotion/styled';
 
-import BtnDate from '@/components/common/BtnDate/BtnDate';
-import BtnStagingDate from '@/components/common/BtnDate/BtnStagingDate';
-import BtnTask from '@/components/common/BtnTask/BtnTask';
-import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
-import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
-import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
-import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import NavBar from '@/components/common/NavBar';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
-import TextboxDailydate from '@/components/common/textbox/TextboxDailydate';
-import TextboxInput from '@/components/common/textbox/TextboxInput';
-import TextInputDesc from '@/components/common/textbox/TextInputDesc';
-import TextInputStaging from '@/components/common/textbox/TextInputStaging';
-import TextInputTime from '@/components/common/textbox/TextInputTime';
-import TextInputTitle from '@/components/common/textbox/TextInputTitle';
 import TargetArea from '@/components/targetArea/TargetArea';
 
 function Today() {
@@ -30,48 +17,6 @@ function Today() {
 					<FullCalendarBox size="small" />
 				</CalendarWrapper>
 			</TodayLayout>
-
-			<StagingArea />
-
-			<BtnTask btnType="staging" hasDescription id={99} name="예시" status="미완료" />
-
-			<p>Done</p>
-			<BtnTask btnType="target" hasDescription id={99} name="예시" status="완료" />
-			<p>InProgress</p>
-			<BtnTask btnType="target" hasDescription id={99} name="예시" status="진행중" />
-			<p>Todo(default)</p>
-			<BtnTask btnType="target" hasDescription id={99} name="예시" status="미완료" />
-
-			<p>Staging</p>
-			<BtnTask btnType="target" hasDescription id={99} name="예시" status="지연" />
-
-			<p>Done</p>
-			<StatusDoneBtn />
-			<p>InProgress</p>
-			<StatusInProgressBtn />
-			<p>Staging</p>
-			<StatusStagingBtn />
-			<p>Todo</p>
-			<StatusTodoBtn />
-
-			<TextboxInput variant="date" />
-			<TextboxInput variant="time" />
-			<TextboxInput variant="smallDate" />
-			<TextInputTitle type="long" />
-			<TextInputTitle type="short" />
-			<TextInputDesc type="long" />
-			<TextInputDesc type="short" />
-			<TextboxDailydate type="long" />
-			<TextboxDailydate type="short" />
-			<TextInputTime time="start" />
-			<TextInputTime time="end" />
-			<TextInputTime time="total" />
-			<TextInputStaging />
-			<BtnDate date="2024.07.11" size={{ type: 'long' }} />
-			<BtnDate date="2024.07.11" size={{ type: 'short' }} />
-			<BtnDate date="2024.07.11" size={{ type: 'short' }} isDelayed />
-			<BtnStagingDate />
-			<TargetArea />
 		</>
 	);
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- Today 페이지 퍼블리싱입니다. PR이 너무 길어질 듯 하여 StagingArea 모달 연결까지만 진행 후 나눠서 PR 올리겠습니다!
- 생성 완료된 공통 컴포넌트를 통해 Today 뷰 퍼블리싱을 마쳤습니다.
- StagingArea의 모달을 3개 연결하였습니다. 
  - 정렬 모달
  - Task 추가 모달
  - Task 할당 모달
- 배경에 background 넣고 모달 제외부분 클릭 시 모달 닫히도록 구현했습니다! ㅜㅜ저한텐 너무 어려웠습니다 😖😫🥺

- **스크롤 문제 해결** 🥹
웹사이트 기본 제공 스크롤 스타일이 사람마다 다른 점을 고려하여 스크롤 스타일을 추가하였습니다.
스타일을 추가하니 그만큼의 자리를 차지하여 뷰가 옆으로 밀리는 현상이 발생하여 해당 부분 수정하였습니다.

  ```css
  const TaskContainer = styled.div`
	  display: flex;
	  flex-direction: column;
	  gap: 1rem;
	  width: 100%;
	  height: 64rem;
	  overflow: hidden; /* 가로스크롤 숨김 */
	  overflow-y: scroll; /* 스크롤 없을때도 자리 차지하도록 */
  
  
	  /* 스크롤 스타일 커스텀 */
	  ::-webkit-scrollbar {
		  width: 0.6rem;
	  }
  
	  ::-webkit-scrollbar-thumb {
		  background-color: ${({ theme }) => theme.palette.Grey.Grey6};
		  border-radius: 3px;
	  }
  `;
  ```


## 알게된 점 :rocket:

> 기록하며 개발하기!

- 성희 피알 보고 버튼에 `position: relative;` 설정, 모달에 `position: absolute;` 설정 시 버튼 위치에 맞추어 쉽게 포지셔닝 가능함을 알았습니다.
- ref를 통해 위치값을 넘겨주는 방법을 알았습니다!


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- Task 할당 모달은 모달이 스크롤 뒤에 숨어버리는,.. 문제로 fixed로 박은 후 ref 통해서 위치값 넘겨줬습니다. 더 나은 방법이 있다면 공유해주시면 감사하겠습니다ㅜㅜ!!! + 스크롤 뒤로 숨는 이유를 아신다면 코멘트 부탁드려요ㅜㅜ **> 해결**
- 주황색 테두리는 서비스 화면 크기 영역 잡아둔 부분입니다! 해당 뷰 퍼블리싱이 완전히 끝나면 삭제하겠습니다
- Task 할당 모달 생성 시 생성되는 반투명 배경은 디자인에서 아직 고민중인 부분이라고 하셔서 확정나면 다시 반영하겠습니다! **> 제거하는 것으로 결정, 반영 완료**

## 관련 이슈

close #80 

## 스크린샷 (선택)

![Jul-12-2024 03-46-33](https://github.com/user-attachments/assets/d883c9f5-e585-419e-87db-15c0a17fca8c)
