### PR TITLE
[FIX] Task 할당 모달 스타일 수정

### DIFF
--- a/src/components/common/button/settingBtn/SettingDeleteBtn.tsx
+++ b/src/components/common/button/settingBtn/SettingDeleteBtn.tsx
@@ -7,7 +7,7 @@ import Icons from '@/assets/svg/index';
 
 interface SettingDeleteBtnProps {
 	size: 'small' | 'big';
-	onClick?: () => void;
+	onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 	isHover: boolean;
 	isPressed: boolean;
 	isActive: boolean;

--- a/src/components/common/modal/ModalDeleteBtn.tsx
+++ b/src/components/common/modal/ModalDeleteBtn.tsx
@@ -6,15 +6,23 @@ import ModalDeleteDetail from '@/components/common/modal/ModalDeleteDetail';
 
 function ModalDeleteBtn() {
 	const [isClicked, setIsClicked] = useState(false);
-	const handleBtnClick = () => {
+
+	const [top, setTop] = useState(0);
+	const [left, setLeft] = useState(0);
+
+	const handleBtnClick = (e: React.MouseEvent) => {
+		const rect = e.currentTarget.getBoundingClientRect();
+		setTop(rect.bottom + 6);
+		setLeft(rect.left);
 		setIsClicked((prev) => !prev);
 	};
+
 	return (
 		<ModalDeleteBtnLayout>
 			<SettingDeleteBtn size="big" isHover isPressed={false} isActive onClick={handleBtnClick} />
 			{isClicked && (
 				<ModalDeleteDetailWapper>
-					<ModalDeleteDetail />
+					<ModalDeleteDetail top={top} left={left} onClose={handleBtnClick} />
 				</ModalDeleteDetailWapper>
 			)}
 		</ModalDeleteBtnLayout>

--- a/src/components/common/modal/ModalDeleteDetail.tsx
+++ b/src/components/common/modal/ModalDeleteDetail.tsx
@@ -2,19 +2,39 @@ import styled from '@emotion/styled';
 
 import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 
-function ModalDeleteDetail() {
+interface ModalDeleteDetailProps {
+	top: number;
+	left: number;
+	onClose: React.MouseEventHandler;
+}
+
+function ModalDeleteDetail({ top, left, onClose }: ModalDeleteDetailProps) {
 	return (
-		<ModalDeleteDetailLayout>
-			<DeleteCancelBtn status="cancel" />
-			<DeleteCancelBtn status="delete" />
-		</ModalDeleteDetailLayout>
+		<ModalBackdrop onClick={onClose}>
+			<ModalDeleteDetailLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
+				<DeleteCancelBtn status="cancel" />
+				<DeleteCancelBtn status="delete" />
+			</ModalDeleteDetailLayout>
+		</ModalBackdrop>
 	);
 }
 
-const ModalDeleteDetailLayout = styled.div`
-	position: absolute;
-	top: 0.6rem;
-	left: -0.2rem;
+const ModalBackdrop = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 3;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100vw;
+	height: 100vh;
+`;
+
+const ModalDeleteDetailLayout = styled.div<{ top: number; left: number }>`
+	position: fixed;
+	top: ${({ top }) => top}px;
+	left: ${({ left }) => left}px;
 	display: flex;
 	flex-direction: column;
 	gap: 0.3rem;

--- a/src/components/common/textbox/TextInputDesc.tsx
+++ b/src/components/common/textbox/TextInputDesc.tsx
@@ -15,5 +15,9 @@ const TextInputDescLayout = styled.textarea<{ type: string }>`
 	${({ theme }) => theme.fontTheme.BODY_02};
 	border: solid 1px ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 5px;
+
+	&:focus {
+		outline: none;
+	}
 `;
 export default TextInputDesc;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

Today 페이지의 Task 할당 모달 중 수정사항을 해결하였습니다.
- **`ModalDeleteDetail` 모달이 잘리는 문제**
  - `position: absolute;` -> `position: fixed;` 로 변경 후 ref 통해 삭제버튼의 위치 받아와서 위치 조정
  - BackDrop 적용하여 모달 제외 배경 클릭 시 모달 닫히도록 구현
- **`Modal`의 설명 추가 input 창에서, focus 시 border 색변화 제거** (디자인 요구사항) 


## 알게된 점 :rocket:

> 기록하며 개발하기!

- 이제 모달 위치조정 잘합니닷 ㅋㅋ


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 모달 위치가 요구사항에 맞게 조정되어있는지 확인부탁드립니다!

## 관련 이슈

close #113 

## 스크린샷 (선택)

![Jul-12-2024 17-09-21](https://github.com/user-attachments/assets/e66470ee-679f-4e35-bb27-88e18141a9b2)
