### PR TITLE
[FEAT] TaskBtn 더블클릭, 클릭 인터랙션 분리

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -27,12 +27,14 @@ function BtnDate(props: BtnDateProps) {
 	const [isClicked, setIsClicked] = useState(false);
 
 	const handleMouseDown = () => {
-		setIsPressed(true);
+		if (size.type !== 'short') setIsPressed(true);
 	};
 
 	const handleMouseUp = () => {
-		setIsPressed(false);
-		setIsClicked((prev) => !prev);
+		if (size.type !== 'short') {
+			setIsPressed(false);
+			setIsClicked((prev) => !prev);
+		}
 	};
 	const isDefaultDate = date === '마감 기한';
 	const isDefaultTime = time === '마감 시간';

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -57,7 +57,7 @@ function BtnDate(props: BtnDateProps) {
 			/>
 			<LineIcon size={size.type} isDelayed={isDelayed} />
 			<BtnDateText icon={<ClockIcon isDelayed={isDelayed} />} text={time} isDefault={isDefaultTime} size={size.type} />
-			{isClicked && size.type === 'long' && <XIcon size={size.type} />}
+			{isClicked && <XIcon size={size.type} />}
 		</BtnDateLayout>
 	);
 }

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -57,18 +57,14 @@ function BtnDate(props: BtnDateProps) {
 			/>
 			<LineIcon size={size.type} isDelayed={isDelayed} />
 			<BtnDateText icon={<ClockIcon isDelayed={isDelayed} />} text={time} isDefault={isDefaultTime} size={size.type} />
-			<XIcon isClicked={isClicked} size={size.type} />
+			{isClicked && size.type === 'long' && <XIcon size={size.type} />}
 		</BtnDateLayout>
 	);
 }
 
 export default BtnDate;
 
-const XIcon = styled((props: React.SVGProps<SVGSVGElement> & { isClicked: boolean; size: string }) => {
-	const { isClicked, ...rest } = props;
-	return <Icons.IcnXCricle {...rest} />;
-})<{ isClicked: boolean }>`
-	display: ${({ isClicked }) => (isClicked ? 'flex' : 'none')};
+const XIcon = styled(Icons.IcnXCricle)<{ size: string }>`
 	width: ${({ size }) => (size === 'long' ? '2rem' : '1.6rem')};
 	height: ${({ size }) => (size === 'long' ? '2rem' : '1.6rem')};
 `;

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -133,7 +133,12 @@ const BtnDateLayout = styled.div<{
 	height: ${({ size }) => (size === 'long' ? '2.2rem' : '2rem')};
 	padding: ${({ size }) => (size === 'long' ? '0.5rem 1rem' : '0rem 1rem')};
 
-	cursor: pointer;
+	${({ size }) =>
+		size !== 'short' &&
+		css`
+			cursor: pointer;
+		`};
+
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-color: ${({ isClicked, theme }) => (isClicked ? theme.palette.Primary : theme.palette.Grey.Grey3)};
 	border-radius: 8px;
@@ -173,26 +178,30 @@ const BtnDateLayout = styled.div<{
 			pointer-events: none;
 		`}
 
-	&:hover {
-		color: ${({ isPressed, theme }) => (isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey6)};
+		${({ size, isPressed, theme, isDefaultDate, isDefaultTime }) =>
+		size !== 'short' &&
+		css`
+			&:hover {
+				color: ${isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey6};
 
-		background: ${({ isPressed, theme }) => (isPressed ? theme.palette.Grey.Grey5 : theme.palette.Grey.Grey4)};
-		box-shadow: ${({ isPressed, theme }) =>
-			isPressed ? `1px 0 0 0 ${theme.palette.Grey.Grey5} inset` : `1px 0 0 0 ${theme.palette.Grey.Grey4} inset`};
+				background: ${isPressed ? theme.palette.Grey.Grey5 : theme.palette.Grey.Grey4};
+				box-shadow: ${isPressed
+					? `1px 0 0 0 ${theme.palette.Grey.Grey5} inset`
+					: `1px 0 0 0 ${theme.palette.Grey.Grey4} inset`};
 
-		${TextWrapper} {
-			color: ${({ isDefaultDate, isDefaultTime, theme }) =>
-				isDefaultDate || isDefaultTime ? theme.palette.Grey.Grey6 : theme.palette.Grey.Black};
-		}
-	}
+				${TextWrapper} {
+					color: ${isDefaultDate || isDefaultTime ? theme.palette.Grey.Grey6 : theme.palette.Grey.Black};
+				}
+			}
 
-	&:hover ${CalanderIcon}, &:hover ${ClockIcon}, &:hover ${LineIcon} {
-		path {
-			stroke: ${({ isPressed, theme }) => (isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey5)};
-		}
+			&:hover ${CalanderIcon}, &:hover ${ClockIcon}, &:hover ${LineIcon} {
+				path {
+					stroke: ${isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey5};
+				}
 
-		line {
-			stroke: ${({ isPressed, theme }) => (isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey5)};
-		}
-	}
+				line {
+					stroke: ${isPressed ? theme.palette.Grey.Grey4 : theme.palette.Grey.Grey5};
+				}
+			}
+		`};
 `;

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -152,13 +152,13 @@ const BtnDateLayout = styled.div<{
 			pointer-events: none;
 		`}
 
-	${({ isClicked, size, theme }) =>
+	${({ isClicked, theme }) =>
 		isClicked &&
 		css`
-			padding-right: ${size === 'long' ? '0.6rem' : '0.2rem'};
+			padding-right: 0.6rem;
 
 			border-color: ${theme.palette.Primary};
-			border-width: ${size === 'long' ? '2px' : '1px'};
+			border-width: 1px;
 		`}
 
 	${({ isPressed, theme }) =>

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -4,12 +4,10 @@ import React, { useState } from 'react';
 
 import Modal from '../modal/Modal';
 
+import IconHoverContainer from './IconHoverContainer';
+
 import Icons from '@/assets/svg/index';
 import BtnDate from '@/components/common/BtnDate/BtnDate';
-import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
-import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
-import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
-import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
 import { TaskType } from '@/types/tasks/taskType';
 
 interface BtnTaskProps extends TaskType {
@@ -19,7 +17,6 @@ interface BtnTaskProps extends TaskType {
 interface BorderColorProps {
 	isHovered: boolean;
 	isClicked: boolean;
-	iconHovered: boolean;
 	theme: Theme;
 	btnType: string;
 }
@@ -29,8 +26,6 @@ function BtnTask(props: BtnTaskProps) {
 	const [isModalOpen, setModalOpen] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
 	const [isHovered, setIsHovered] = useState(false);
-	const [iconHovered, setIconHovered] = useState(false);
-	const [iconClicked, setIconClicked] = useState(false);
 
 	const [top, setTop] = useState(0);
 	const [left, setLeft] = useState(0);
@@ -65,60 +60,12 @@ function BtnTask(props: BtnTaskProps) {
 	const closeModal = () => {
 		setModalOpen(false);
 	};
-	const stopPropagation = (e: React.MouseEvent) => {
-		e.stopPropagation();
-	};
-
-	const handleIconMouseEnter = () => {
-		setIconHovered(true);
-	};
-
-	const handleIconMouseLeave = () => {
-		setIconHovered(false);
-	};
-
-	const handleIconClick = (e: React.MouseEvent) => {
-		if (iconClicked) {
-			setIconClicked(false);
-		} else {
-			setIconClicked(true);
-		}
-		stopPropagation(e);
-	};
-
-	const renderStatusButton = () => {
-		if (btnType === 'delayed') {
-			return <StagingIconHoverIndicator />;
-		}
-
-		if (!iconHovered && !iconClicked) {
-			return <IconHoverIndicator />;
-		}
-
-		if (btnType === 'staging') {
-			return <StatusStagingBtn />;
-		}
-
-		if (btnType === 'target') {
-			switch (status) {
-				case '완료':
-					return <StatusDoneBtn />;
-				case '진행중':
-					return <StatusInProgressBtn />;
-				default:
-					return <StatusTodoBtn />;
-			}
-		}
-
-		return null;
-	};
 
 	return (
 		<ModalLayout>
 			<BtnTaskLayout
 				isClicked={isClicked}
 				isHovered={isHovered}
-				iconHovered={iconHovered}
 				btnType={btnType}
 				onDoubleClick={handleDoubleClick}
 				onClick={handleClick}
@@ -135,13 +82,7 @@ function BtnTask(props: BtnTaskProps) {
 						isDelayed={btnType === 'delayed'}
 					/>
 				</BtnTaskContainer>
-				<IconHoverContainer
-					onClick={handleIconClick}
-					onMouseEnter={handleIconMouseEnter}
-					onMouseLeave={handleIconMouseLeave}
-				>
-					{renderStatusButton()}
-				</IconHoverContainer>
+				<IconHoverContainer btnType={btnType} status={status} />
 			</BtnTaskLayout>
 			<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />
 		</ModalLayout>
@@ -150,7 +91,7 @@ function BtnTask(props: BtnTaskProps) {
 
 export default BtnTask;
 
-const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: BorderColorProps) => {
+const getBorderColor = ({ isHovered, isClicked, theme, btnType }: BorderColorProps) => {
 	const defaultColor = theme.palette.Grey.Grey1;
 	const hoverColor = theme.palette.Blue.Blue3;
 	const clickColor = theme.palette.Primary;
@@ -160,7 +101,7 @@ const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: B
 		borderColor = orangeColor;
 	} else if (isClicked) {
 		borderColor = clickColor;
-	} else if (iconHovered || isHovered) {
+	} else if (isHovered) {
 		borderColor = hoverColor;
 	}
 	return css`
@@ -175,7 +116,6 @@ const ModalLayout = styled.div`
 const BtnTaskLayout = styled('div', { target: 'BtnTaskLayout' })<{
 	isClicked: boolean;
 	isHovered: boolean;
-	iconHovered: boolean;
 	btnType: string;
 }>`
 	display: flex;
@@ -207,35 +147,6 @@ const BtnTaskTextWrapper = styled.div<{ isDescription: boolean }>`
 	padding-left: ${({ isDescription }) => (isDescription ? '0rem' : '0.4rem')};
 
 	${({ theme }) => theme.fontTheme.LABEL_03};
-`;
-
-const IconHoverContainer = styled('div', { target: 'IconHoverContainer' })`
-	display: flex;
-	gap: 0.4rem;
-	align-items: center;
-	padding: 0 1.2rem 0 0.8rem;
-`;
-
-const IconHoverCss = css`
-	display: flex;
-	gap: 0.6rem;
-	align-items: center;
-	justify-content: center;
-	width: 1.4rem;
-	height: 1.4rem;
-	padding: 0.3rem;
-`;
-
-const IconHoverIndicator = styled(Icons.Icn_hover_indicator, { target: 'IconHoverIndicator' })`
-	${IconHoverCss}
-`;
-
-const StagingIconHoverIndicator = styled(Icons.Icn_hover_indicator)`
-	${IconHoverCss}
-
-	circle {
-		stroke: ${({ theme }) => theme.palette.Orange.Orange8};
-	}
 `;
 
 const IconFile = styled(Icons.IcnFile)`

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -26,6 +26,7 @@ interface BorderColorProps {
 
 function BtnTask(props: BtnTaskProps) {
 	const { btnType, name, deadLine, hasDescription, status } = props;
+	const [isModalOpen, setModalOpen] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
 	const [isHovered, setIsHovered] = useState(false);
 	const [iconHovered, setIconHovered] = useState(false);
@@ -45,15 +46,25 @@ function BtnTask(props: BtnTaskProps) {
 		setIsHovered(false);
 	};
 
-	const handleClick = (e: React.MouseEvent) => {
+	/** 모달 띄우기 */
+	const handleDoubleClick = (e: React.MouseEvent) => {
 		const rect = e.currentTarget.getBoundingClientRect();
 		const calculatedTop = rect.top;
 		const adjustedTop = Math.min(calculatedTop, SCREEN_HEIGHT - MODAL_HEIGHT);
 		setTop(adjustedTop);
 		setLeft(rect.right + 6);
+		setModalOpen((prev) => !prev);
+	};
+
+	/** 보더 색상 */
+	const handleClick = () => {
 		setIsClicked((prev) => !prev);
 	};
 
+	/** 모달 닫기 */
+	const closeModal = () => {
+		setModalOpen(false);
+	};
 	const stopPropagation = (e: React.MouseEvent) => {
 		e.stopPropagation();
 	};
@@ -109,6 +120,7 @@ function BtnTask(props: BtnTaskProps) {
 				isHovered={isHovered}
 				iconHovered={iconHovered}
 				btnType={btnType}
+				onDoubleClick={handleDoubleClick}
 				onClick={handleClick}
 			>
 				<BtnTaskContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
@@ -131,7 +143,7 @@ function BtnTask(props: BtnTaskProps) {
 					{renderStatusButton()}
 				</IconHoverContainer>
 			</BtnTaskLayout>
-			<Modal isOpen={isClicked} sizeType={{ type: 'short' }} top={top} left={left} onClose={handleClick} />
+			<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />
 		</ModalLayout>
 	);
 }
@@ -140,16 +152,16 @@ export default BtnTask;
 
 const getBorderColor = ({ isHovered, isClicked, iconHovered, theme, btnType }: BorderColorProps) => {
 	const defaultColor = theme.palette.Grey.Grey1;
-	const hoverColor = theme.palette.Blue.Blue1;
+	const hoverColor = theme.palette.Blue.Blue3;
 	const clickColor = theme.palette.Primary;
 	const orangeColor = theme.palette.Orange.Orange8;
 	let borderColor = defaultColor;
 	if (btnType === 'delayed') {
 		borderColor = orangeColor;
-	} else if (iconHovered || isHovered) {
-		borderColor = hoverColor;
 	} else if (isClicked) {
 		borderColor = clickColor;
+	} else if (iconHovered || isHovered) {
+		borderColor = hoverColor;
 	}
 	return css`
 		border-color: ${borderColor};

--- a/src/components/common/BtnTask/IconHoverContainer.tsx
+++ b/src/components/common/BtnTask/IconHoverContainer.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React, { useState } from 'react';
+
+import Icons from '@/assets/svg/index';
+import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
+import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
+import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
+import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
+
+type Props = { btnType: 'staging' | 'target' | 'delayed'; status: '진행중' | '미완료' | '완료' | '지연' };
+
+function IconHoverContainer({ btnType, status }: Props) {
+	const [iconHovered, setIconHovered] = useState(false);
+	const [iconClicked, setIconClicked] = useState(false);
+	const handleIconMouseEnter = () => {
+		setIconHovered(true);
+	};
+	const handleIconMouseLeave = () => {
+		setIconHovered(false);
+	};
+	const stopPropagation = (e: React.MouseEvent) => {
+		e.stopPropagation();
+	};
+
+	const handleIconClick = (e: React.MouseEvent) => {
+		if (iconClicked) {
+			setIconClicked(false);
+		} else {
+			setIconClicked(true);
+		}
+		stopPropagation(e);
+	};
+
+	const renderStatusButton = () => {
+		if (btnType === 'delayed') {
+			return <StagingIconHoverIndicator />;
+		}
+
+		if (!iconHovered && !iconClicked) {
+			return <IconHoverIndicator />;
+		}
+
+		if (btnType === 'staging') {
+			return <StatusStagingBtn />;
+		}
+
+		if (btnType === 'target') {
+			switch (status) {
+				case '완료':
+					return <StatusDoneBtn />;
+				case '진행중':
+					return <StatusInProgressBtn />;
+				default:
+					return <StatusTodoBtn />;
+			}
+		}
+
+		return null;
+	};
+	return (
+		<IconHoverLayout onClick={handleIconClick} onMouseEnter={handleIconMouseEnter} onMouseLeave={handleIconMouseLeave}>
+			{renderStatusButton()}
+		</IconHoverLayout>
+	);
+}
+const IconHoverLayout = styled('div', { target: 'IconHoverContainer' })`
+	display: flex;
+	gap: 0.4rem;
+	align-items: center;
+	padding: 0 1.2rem 0 0.8rem;
+`;
+const IconHoverCss = css`
+	display: flex;
+	gap: 0.6rem;
+	align-items: center;
+	justify-content: center;
+	width: 1.4rem;
+	height: 1.4rem;
+	padding: 0.3rem;
+`;
+const IconHoverIndicator = styled(Icons.Icn_hover_indicator, { target: 'IconHoverIndicator' })`
+	${IconHoverCss}
+`;
+
+const StagingIconHoverIndicator = styled(Icons.Icn_hover_indicator)`
+	${IconHoverCss}
+
+	circle {
+		stroke: ${({ theme }) => theme.palette.Orange.Orange8};
+	}
+`;
+export default IconHoverContainer;

--- a/src/components/common/button/OkayCancelBtn.tsx
+++ b/src/components/common/button/OkayCancelBtn.tsx
@@ -3,10 +3,15 @@ import styled from '@emotion/styled';
 
 interface OkayCancelBtnProps {
 	type: 'okay' | 'cancel';
+	onClick: () => void;
 }
 
-function OkayCancelBtn({ type }: OkayCancelBtnProps) {
-	return <div>{type === 'okay' ? <OkayBtn>확인</OkayBtn> : <CancelBtn>취소</CancelBtn>}</div>;
+function OkayCancelBtn({ type, onClick }: OkayCancelBtnProps) {
+	return (
+		<div>
+			{type === 'okay' ? <OkayBtn onClick={onClick}>확인</OkayBtn> : <CancelBtn onClick={onClick}>취소</CancelBtn>}
+		</div>
+	);
 }
 
 export default OkayCancelBtn;

--- a/src/components/common/button/OkayCancelBtn.tsx
+++ b/src/components/common/button/OkayCancelBtn.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 interface OkayCancelBtnProps {
 	type: 'okay' | 'cancel';
-	onClick: () => void;
+	onClick?: () => void;
 }
 
 function OkayCancelBtn({ type, onClick }: OkayCancelBtnProps) {

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import React from 'react';
 
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
@@ -13,7 +12,7 @@ interface ModalProps {
 	sizeType: SizeType;
 	top: number;
 	left: number;
-	onClose: React.MouseEventHandler;
+	onClose: () => void;
 }
 
 function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
@@ -30,8 +29,8 @@ function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
 						{sizeType.type === 'long' && <ModalTextInputTime />}
 					</ModalBody>
 					<ModalFooter>
-						<OkayCancelBtn type="cancel" />
-						<OkayCancelBtn type="okay" />
+						<OkayCancelBtn type="cancel" onClick={onClose} />
+						<OkayCancelBtn type="okay" onClick={onClose} />
 					</ModalFooter>
 				</ModalLayout>
 			</ModalBackdrop>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- doubleclick 시 모달 띄우기
기존에는 클릭으로 보더 스타일, 모달 전부 컨트롤했었는데 더블클릭으로 모달 뜨도록 제작하고 클릭으로는 스타일만 컨트롤하도록 변경했습니다.  

- `BtnTask` 에서 `IconHoverContainer` 분리
`BtnTask` 컴포넌트 코드가 너무 길어져서 호버하면 아이콘이 뜨는 부분인 `IconHoverContainer`를 분리했습니다  

- `XIcon` styled component props 단순화  


- 태스크 목록에서 `BtnDate`가 사용될 경우 short size 로 사용되는데, 이 경우 clicked, pressed, hover를 막았습니다  

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

혹시 `BtnDate`가 short size로 사용되는 경우가 태스크 목록 이외에도 있다면 알려주세요!

## 관련 이슈

close #117 

## 스크린샷 (선택)
![Jul-13-2024 17-31-37](https://github.com/user-attachments/assets/d626a4eb-6ff3-457d-a4f9-f008b4cc83d1)
