### PR TITLE
[FEAT] Today 뷰 모달 연결

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -2,10 +2,13 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
+import DateCorrectionModal from '../datePicker/DateCorrectionModal';
+
 import BtnDateText, { TextWrapper } from './BtnDateText';
 
 import Icons from '@/assets/svg/index';
 import { SizeType } from '@/types/textInputType';
+import MODAL from '@/constants/modalLocation';
 
 interface BtnDateProps {
 	date?: string;
@@ -40,31 +43,59 @@ function BtnDate(props: BtnDateProps) {
 	const isDefaultTime = time === '마감 시간';
 
 	return (
-		<BtnDateLayout
-			isPressed={isPressed}
-			isClicked={isClicked}
-			size={size.type}
-			isDelayed={isDelayed}
-			isDisabled={isDisabled}
-			isDefaultDate={isDefaultDate}
-			isDefaultTime={isDefaultTime}
-			onMouseDown={handleMouseDown}
-			onMouseUp={handleMouseUp}
-		>
-			<BtnDateText
-				icon={<CalanderIcon isDelayed={isDelayed} />}
-				text={date}
-				isDefault={isDefaultDate}
+		<ModalLayout>
+			<BtnDateLayout
+				isPressed={isPressed}
+				isClicked={isClicked}
 				size={size.type}
-			/>
-			<LineIcon size={size.type} isDelayed={isDelayed} />
-			<BtnDateText icon={<ClockIcon isDelayed={isDelayed} />} text={time} isDefault={isDefaultTime} size={size.type} />
-			{isClicked && <XIcon size={size.type} />}
-		</BtnDateLayout>
+				isDelayed={isDelayed}
+				isDisabled={isDisabled}
+				isDefaultDate={isDefaultDate}
+				isDefaultTime={isDefaultTime}
+				onMouseDown={handleMouseDown}
+				onMouseUp={handleMouseUp}
+			>
+				<BtnDateText
+					icon={<CalanderIcon isDelayed={isDelayed} />}
+					text={date}
+					isDefault={isDefaultDate}
+					size={size.type}
+				/>
+				<LineIcon size={size.type} isDelayed={isDelayed} />
+				<BtnDateText
+					icon={<ClockIcon isDelayed={isDelayed} />}
+					text={time}
+					isDefault={isDefaultTime}
+					size={size.type}
+				/>
+				{size.type === 'long' && <XIcon size={size.type} />}
+			</BtnDateLayout>
+			{isClicked && (
+				<>
+					<DateCorrectionModal
+						top={MODAL.DATE_CORRECTION.TASK_MODAL.top}
+						left={MODAL.DATE_CORRECTION.TASK_MODAL.left}
+					/>
+					<ModalBackdrop onClick={handleMouseUp} />
+				</>
+			)}
+		</ModalLayout>
 	);
 }
 
 export default BtnDate;
+
+const ModalLayout = styled.div`
+	position: relative;
+`;
+
+const ModalBackdrop = styled.div`
+	position: absolute;
+	top: 0;
+	z-index: 3;
+	width: 100vw;
+	height: 100vh;
+`;
 
 const XIcon = styled(Icons.IcnXCricle)<{ size: string }>`
 	width: ${({ size }) => (size === 'long' ? '2rem' : '1.6rem')};

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -69,7 +69,7 @@ function BtnDate(props: BtnDateProps) {
 					isDefault={isDefaultTime}
 					size={size.type}
 				/>
-				{size.type === 'long' && <XIcon size={size.type} />}
+				{isClicked && size.type === 'long' && <XIcon size={size.type} />}
 			</BtnDateLayout>
 			{isClicked && (
 				<>

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -9,6 +9,7 @@ import BtnDateText, { TextWrapper } from './BtnDateText';
 import Icons from '@/assets/svg/index';
 import { SizeType } from '@/types/textInputType';
 import MODAL from '@/constants/modalLocation';
+import ModalBackdrop from '../modal/ModalBackdrop';
 
 interface BtnDateProps {
 	date?: string;
@@ -87,14 +88,6 @@ export default BtnDate;
 
 const ModalLayout = styled.div`
 	position: relative;
-`;
-
-const ModalBackdrop = styled.div`
-	position: absolute;
-	top: 0;
-	z-index: 3;
-	width: 100vw;
-	height: 100vh;
 `;
 
 const XIcon = styled(Icons.IcnXCricle)<{ size: string }>`

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -9,6 +9,7 @@ import IconHoverContainer from './IconHoverContainer';
 import Icons from '@/assets/svg/index';
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import { TaskType } from '@/types/tasks/taskType';
+import MODAL from '@/constants/modalLocation';
 
 interface BtnTaskProps extends TaskType {
 	btnType: 'staging' | 'target' | 'delayed';
@@ -30,9 +31,6 @@ function BtnTask(props: BtnTaskProps) {
 	const [top, setTop] = useState(0);
 	const [left, setLeft] = useState(0);
 
-	const MODAL_HEIGHT = 362;
-	const SCREEN_HEIGHT = 768;
-
 	const handleMouseEnter = () => {
 		setIsHovered(true);
 	};
@@ -45,7 +43,7 @@ function BtnTask(props: BtnTaskProps) {
 	const handleDoubleClick = (e: React.MouseEvent) => {
 		const rect = e.currentTarget.getBoundingClientRect();
 		const calculatedTop = rect.top;
-		const adjustedTop = Math.min(calculatedTop, SCREEN_HEIGHT - MODAL_HEIGHT);
+		const adjustedTop = Math.min(calculatedTop, MODAL.SCREEN_HEIGHT - MODAL.TASK_MODAL_HEIGHT);
 		setTop(adjustedTop);
 		setLeft(rect.right + 6);
 		setModalOpen((prev) => !prev);

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -6,10 +6,10 @@ import TextBtn from '../button/textBtn/TextBtn';
 import ModalArrange from '../modal/ModalArrange/ModalArrange';
 
 function StagingAreaSetting() {
-	const [activeButton, setActiveButton] = useState<'전체' | '취소'>('전체');
+	const [activeButton, setActiveButton] = useState<'전체' | '지연'>('전체');
 	const [isModalOpen, setIsModalOpen] = useState(false);
 
-	const handleTextBtnClick = (button: '전체' | '취소') => {
+	const handleTextBtnClick = (button: '전체' | '지연') => {
 		setActiveButton(button);
 	};
 
@@ -35,12 +35,12 @@ function StagingAreaSetting() {
 				/>
 				<TextBtn
 					size="small"
-					text="취소"
-					color={activeButton === '취소' ? 'BLUE' : 'WHITE'}
-					mode={activeButton === '취소' ? 'DEFAULT' : 'LIGHT'}
+					text="지연"
+					color={activeButton === '지연' ? 'BLUE' : 'WHITE'}
+					mode={activeButton === '지연' ? 'DEFAULT' : 'LIGHT'}
 					isHover
 					isPressed
-					onClick={() => handleTextBtnClick('취소')}
+					onClick={() => handleTextBtnClick('지연')}
 				/>
 			</TextBtnContainer>
 			<ArrangeContainer>

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
 import TextBtn from '../button/textBtn/TextBtn';
 import ModalArrange from '../modal/ModalArrange/ModalArrange';
+import ModalBackdrop from '../modal/ModalBackdrop';
 
 function StagingAreaSetting() {
 	const [activeButton, setActiveButton] = useState<'전체' | '지연'>('전체');
@@ -53,14 +54,6 @@ function StagingAreaSetting() {
 }
 
 export default StagingAreaSetting;
-
-const ModalBackdrop = styled.div`
-	position: absolute;
-	top: 0;
-	z-index: 3;
-	width: 100vw;
-	height: 100vh;
-`;
 
 const StagingAreaSettingLayout = styled.div`
 	display: flex;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -13,7 +13,13 @@ import CalendarStyle from './DatePickerStyle';
 import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef } from '@/utils/refStatus';
 
-function DateCorrectionModal({ isDateOnly = false }: { isDateOnly?: boolean }) {
+interface DateCorrectionModalProps {
+	isDateOnly?: boolean;
+	top?: number;
+	left?: number;
+}
+
+function DateCorrectionModal({ isDateOnly = false, top = 0, left = 0 }: DateCorrectionModalProps) {
 	const prevDate: Date = new Date();
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
 
@@ -29,7 +35,7 @@ function DateCorrectionModal({ isDateOnly = false }: { isDateOnly?: boolean }) {
 	};
 
 	return (
-		<DateCorrectionModalLayout>
+		<DateCorrectionModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
 			<DatePicker
 				locale={ko}
 				selected={currentDate}
@@ -49,10 +55,10 @@ function DateCorrectionModal({ isDateOnly = false }: { isDateOnly?: boolean }) {
 	);
 }
 
-const DateCorrectionModalLayout = styled.div`
+const DateCorrectionModalLayout = styled.div<{ top: number; left: number }>`
 	position: absolute;
-	bottom: 7.6rem;
-	left: -1.1rem;
+	top: ${({ top }) => top}rem;
+	left: ${({ left }) => left}rem;
 	z-index: 4;
 `;
 

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -6,6 +6,7 @@ import ModalHeaderBtn from '@/components/common/modal/ModalHeaderBtn';
 import ModalTextInputTime from '@/components/common/modal/ModalTextInputTime';
 import TextInputBox from '@/components/common/modal/TextInputBox';
 import { SizeType } from '@/types/textInputType';
+import ModalBackdrop from './ModalBackdrop';
 
 interface ModalProps {
 	isOpen: boolean;
@@ -37,18 +38,6 @@ function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
 		)
 	);
 }
-
-const ModalBackdrop = styled.div`
-	position: fixed;
-	top: 0;
-	left: 0;
-	z-index: 3;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100vw;
-	height: 100vh;
-`;
 
 const ModalLayout = styled.div<{ type: string; top: number; left: number }>`
 	position: fixed;

--- a/src/components/common/modal/ModalBackdrop.tsx
+++ b/src/components/common/modal/ModalBackdrop.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+const ModalBackdrop = styled.div`
+	position: fixed;
+	top: 0;
+	right: 0;
+	left: 0;
+	z-index: 3;
+	width: 100vw;
+	height: 100vh;
+`;
+
+export default ModalBackdrop;

--- a/src/components/common/modal/ModalDeleteDetail.tsx
+++ b/src/components/common/modal/ModalDeleteDetail.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
+import ModalBackdrop from './ModalBackdrop';
 
 interface ModalDeleteDetailProps {
 	top: number;
@@ -18,18 +19,6 @@ function ModalDeleteDetail({ top, left, onClose }: ModalDeleteDetailProps) {
 		</ModalBackdrop>
 	);
 }
-
-const ModalBackdrop = styled.div`
-	position: fixed;
-	top: 0;
-	left: 0;
-	z-index: 3;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100vw;
-	height: 100vh;
-`;
 
 const ModalDeleteDetailLayout = styled.div<{ top: number; left: number }>`
 	position: fixed;

--- a/src/components/common/textbox/TextInputDesc.tsx
+++ b/src/components/common/textbox/TextInputDesc.tsx
@@ -19,5 +19,6 @@ const TextInputDescLayout = styled.textarea<{ type: string }>`
 	&:focus {
 		outline: none;
 	}
+	resize: none;
 `;
 export default TextInputDesc;

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import BtnStagingDate from '../BtnDate/BtnStagingDate';
 import EnterBtn from '../button/EnterBtn';
 import DateCorrectionModal from '../datePicker/DateCorrectionModal';
+import MODAL from '@/constants/modalLocation';
 
 function TextInputStaging() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -21,7 +22,15 @@ function TextInputStaging() {
 			<TextArea placeholder="해야하는 일들을 쏟아내보세요." />
 			<BtnWrapper>
 				<SetDeadLineContainer>
-					{isModalOpen && <DateCorrectionModal />}
+					{isModalOpen && (
+						<>
+							<DateCorrectionModal
+								top={MODAL.DATE_CORRECTION.SET_DEADLINE.top}
+								left={MODAL.DATE_CORRECTION.SET_DEADLINE.left}
+							/>
+							<ModalBackdrop onClick={handleCloseModal} />
+						</>
+					)}
 					<BtnStagingDate onClick={handleArrangeBtnClick} />
 				</SetDeadLineContainer>
 				{isModalOpen && <ModalBackdrop onClick={handleCloseModal} />}

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -5,6 +5,7 @@ import BtnStagingDate from '../BtnDate/BtnStagingDate';
 import EnterBtn from '../button/EnterBtn';
 import DateCorrectionModal from '../datePicker/DateCorrectionModal';
 import MODAL from '@/constants/modalLocation';
+import ModalBackdrop from '../modal/ModalBackdrop';
 
 function TextInputStaging() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -40,14 +41,6 @@ function TextInputStaging() {
 		</StagingLayout>
 	);
 }
-
-const ModalBackdrop = styled.div`
-	position: absolute;
-	top: 0;
-	z-index: 3;
-	width: 100vw;
-	height: 100vh;
-`;
 
 const StagingLayout = styled.div`
 	display: flex;

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -1,21 +1,56 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import ArrangeBtn from '../common/arrangeBtn/ArrangeBtn';
+import DateCorrectionModal from '../common/datePicker/DateCorrectionModal';
 
 import TextBtn from '@/components/common/button/textBtn/TextBtn';
+import MODAL from '@/constants/modalLocation';
 
 function TargetControlSection() {
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
+	const handleArrangeBtnClick = () => {
+		setIsModalOpen((prev) => !prev);
+	};
+
+	const handleCloseModal = () => {
+		setIsModalOpen(false);
+	};
+
 	return (
-		<TargetControlSectionLayout>
-			<BtnWrapper>
-				<TextBtn text="오늘" size="small" color="BLACK" mode="DEFAULT" isHover isPressed />
-				<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="left" />
-				<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="right" />
-			</BtnWrapper>
-			<ArrangeBtn color="WHITE" mode="DEFAULT" size="small" type="calendar" />
-		</TargetControlSectionLayout>
+		<>
+			<TargetControlSectionLayout>
+				<BtnWrapper>
+					<TextBtn text="오늘" size="small" color="BLACK" mode="DEFAULT" isHover isPressed />
+					<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="left" />
+					<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="right" />
+				</BtnWrapper>
+				<ModalLayout>
+					<ArrangeBtn color="WHITE" mode="DEFAULT" size="small" type="calendar" onClick={handleArrangeBtnClick} />
+					{isModalOpen && (
+						<DateCorrectionModal top={MODAL.DATE_CORRECTION.TARGET.top} left={MODAL.DATE_CORRECTION.TARGET.left} />
+					)}
+				</ModalLayout>
+			</TargetControlSectionLayout>
+			{isModalOpen && <ModalBackdrop onClick={handleCloseModal} />}
+		</>
 	);
 }
+
+const ModalLayout = styled.div`
+	position: relative;
+`;
+
+const ModalBackdrop = styled.div`
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	z-index: 3;
+	width: 100vw;
+	height: 100vh;
+`;
 
 const TargetControlSectionLayout = styled.div`
 	display: flex;

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -6,6 +6,7 @@ import DateCorrectionModal from '../common/datePicker/DateCorrectionModal';
 
 import TextBtn from '@/components/common/button/textBtn/TextBtn';
 import MODAL from '@/constants/modalLocation';
+import ModalBackdrop from '../common/modal/ModalBackdrop';
 
 function TargetControlSection() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -40,16 +41,6 @@ function TargetControlSection() {
 
 const ModalLayout = styled.div`
 	position: relative;
-`;
-
-const ModalBackdrop = styled.div`
-	position: absolute;
-	top: 0;
-	right: 0;
-	left: 0;
-	z-index: 3;
-	width: 100vw;
-	height: 100vh;
 `;
 
 const TargetControlSectionLayout = styled.div`

--- a/src/constants/modalLocation.ts
+++ b/src/constants/modalLocation.ts
@@ -1,0 +1,24 @@
+const MODAL = {
+	SCREEN_HEIGHT: 768,
+
+	// // Task 버튼 누르면 나오는 Modal 모달
+	TASK_MODAL_HEIGHT: 362,
+
+	// 날짜 & 시간 세팅하는 DateCorrectionModal 모달
+	DATE_CORRECTION: {
+		SET_DEADLINE: {
+			top: -35.4,
+			left: -1,
+		},
+		TASK_MODAL: {
+			top: 3.8,
+			left: 0,
+		},
+		TARGET: {
+			top: 3.2,
+			left: -20.2,
+		},
+	},
+};
+
+export default MODAL;

--- a/src/types/arrangeBtnType.ts
+++ b/src/types/arrangeBtnType.ts
@@ -3,7 +3,7 @@ export interface ArrangeBtnType {
 	mode: 'DISABLED' | 'DEFAULT';
 	color: 'BLUE' | 'WHITE' | 'BLACK';
 	size: 'big' | 'small';
-	onClick?: () => void;
+	onClick?: React.MouseEventHandler;
 	className?: string;
 	'aria-label'?: string;
 	disabled?: boolean;

--- a/src/types/arrangeBtnType.ts
+++ b/src/types/arrangeBtnType.ts
@@ -3,7 +3,7 @@ export interface ArrangeBtnType {
 	mode: 'DISABLED' | 'DEFAULT';
 	color: 'BLUE' | 'WHITE' | 'BLACK';
 	size: 'big' | 'small';
-	onClick?: React.MouseEventHandler;
+	onClick?: () => void;
 	className?: string;
 	'aria-label'?: string;
 	disabled?: boolean;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

Today 페이지의 모달 중 `DateCorrectionModal`을 다음 3군데에서 연결하였습니다.
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/3cdd5c13-9206-48e6-bc59-7c8a55a6fb74">
(주황색 테두리는 서비스 전체화면 크기를 잡아둔 부분입니다!)

- 연동이 필요한 값은 아직 연결해두지 않았습니다! 우선적으로 모달이 열리는 부분까지만 구현해두었습니다.
- BackDrop은 모든 모달 전체 화면에 설정해두었습니다!

<br>

**추가 수정사항**

- `arrangeBtnType`에서 onClick 타입 확장성 위해 void로 변경하였습니다.
- `BtnDate`(: 마감기한 & 마감시간 나타나는 모달)에서 size 관련 수정사항 적용 중, x 버튼이 필터링 안되어있어 해당 부분 추가 수정하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- `position: absolute;` 설정 시 화면이 꽉 안찬다면 top, left, bottom, right 속성을 전부 0으로 줘보자!

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 모달이 적절한 위치에 띄워지는 지 + 혹시 플로우에 문제가 있을 지 확인부탁드립니다!! 

## 관련 이슈

close #112 

## 스크린샷 (선택)
![Jul-13-2024 18-02-17](https://github.com/user-attachments/assets/f3fa4cbb-9634-49c8-af4b-71e3e6d79990)

