### PR TITLE
[FEAT] fullCalendar task와 schedule 구분

### DIFF
--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -57,6 +57,7 @@ function FullCalendarBox({ size }: FullCalendarBoxProps) {
 				selectable
 				nowIndicator
 				dayMaxEvents
+				// netshell에서 할당한 이벤트 : tasks, 구글 캘린더에서 가져온 이벤트 : schedule
 				events={[
 					{ title: 'Meeting', start: '2024-07-06T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
 					{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -10,7 +10,6 @@ import RefreshBtn from '@/components/common/button/RefreshBtn';
 import DayHeaderContent from '@/components/common/fullCalendar/DayHeaderContent';
 import FullCalendarLayout from '@/components/common/fullCalendar/FullCalendarStyle';
 import { customDayCellContent, customSlotLabelContent } from '@/components/common/fullCalendar/fullCalendarUtils';
-import { theme } from '@/styles/theme';
 
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
@@ -59,12 +58,27 @@ function FullCalendarBox({ size }: FullCalendarBoxProps) {
 				nowIndicator
 				dayMaxEvents
 				events={[
-					{ title: 'Meeting', start: '2024-07-06T10:00:00', end: '2024-07-06T12:00:00' },
-					{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00' },
-					{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00' },
-					{ title: 'All Day Event', start: '2024-07-08T10:00:00', end: '2024-07-08T12:00:00', allDay: true },
+					{ title: 'Meeting', start: '2024-07-06T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
+					{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },
+					{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00', classNames: 'tasks' },
+					{
+						title: 'All Day Event',
+						start: '2024-07-08T10:00:00',
+						end: '2024-07-08T12:00:00',
+						allDay: true,
+						classNames: 'task',
+					},
+					{ title: 'Meeting', start: '2024-07-11T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
+					{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
+					{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
+					{
+						title: 'All Day Event',
+						start: '2024-07-12T10:00:00',
+						end: '2024-07-12T12:00:00',
+						allDay: true,
+						classNames: 'schedule',
+					},
 				]}
-				eventColor={theme.palette.Blue.Blue2}
 				buttonText={{
 					today: '오늘',
 					month: '월간',
@@ -90,6 +104,7 @@ function FullCalendarBox({ size }: FullCalendarBoxProps) {
 					minute: '2-digit',
 					hour12: false,
 				}}
+				droppable={true}
 			/>
 		</FullCalendarLayout>
 	);

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -21,6 +21,7 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 
 		color: ${(color) => color.theme.palette.Grey.Grey8};
 
+		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
 		border: none;
 		border-radius: 4px;
 		${({ theme }) => theme.fontTheme.CAPTION_03};
@@ -255,12 +256,20 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		border: none;
 	}
 
-	.fc .fc-daygrid-event-harness {
-		margin: 0;
+	.fc .fc-daygrid-day-frame .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue8};
 	}
 
-	.fc .fc-daygrid-day-frame .fc-daygrid-event-harness {
-		background-color: ${({ theme }) => theme.palette.Grey.White};
+	.fc .fc-daygrid-day-frame .schedule .fc-event-main {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+	}
+
+	.fc .fc-daygrid-day-frame .tasks .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey7};
+	}
+
+	.fc .fc-daygrid-event-harness {
+		margin: 0;
 	}
 
 	.fc .fc-daygrid-event {
@@ -283,15 +292,30 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		height: 2.1rem;
 		margin: 0.1rem;
 
-		background-color: ${({ theme }) => theme.palette.Primary};
+		border-radius: 4px;
 	}
 
 	.fc .fc-daygrid-dot-event {
 		padding: 0.4rem 0.6rem;
 
-		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
-		border-left: 2px solid ${({ theme }) => theme.palette.Primary};
 		border-radius: 4px;
+	}
+
+	.fc .fc-daygrid-dot-event.schedule {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey2};
+		box-shadow: 2px 0 0 0 ${({ theme }) => theme.palette.Grey.Grey6} inset;
+	}
+
+	.fc .fc-daygrid-dot-event.tasks {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
+	}
+
+	.fc .fc-daygrid-dot-event.schedule:hover {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
+	}
+
+	.fc .fc-daygrid-dot-event.tasks:hover {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue3};
 	}
 
 	.fc .fc-h-event {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -21,11 +21,26 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 
 		color: ${(color) => color.theme.palette.Grey.Grey8};
 
-		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
-		box-shadow: 2px 0 0 0 ${({ theme }) => theme.palette.Primary} inset;
 		border: none;
 		border-radius: 4px;
 		${({ theme }) => theme.fontTheme.CAPTION_03};
+	}
+
+	.tasks .fc-event-main {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
+	}
+
+	.schedule .fc-event-main {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey2};
+		box-shadow: 2px 0 0 0 ${({ theme }) => theme.palette.Grey.Grey6} inset;
+	}
+
+	.tasks .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue3};
+	}
+
+	.schedule .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
 	}
 
 	.fc-v-event .fc-event-main-frame {
@@ -143,6 +158,10 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 	/* 오늘 배경색 없애기 */
 	.fc .fc-day-today {
 		background: none;
+	}
+
+	.fc-timegrid-event {
+		border-radius: 4px;
 	}
 
 	/* event에 있는 기본 스타일 지우기  */

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -27,21 +27,62 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		${({ theme }) => theme.fontTheme.CAPTION_03};
 	}
 
-	.tasks .fc-event-main {
+	.fc-event-main .tasks {
 		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
 	}
 
 	.schedule .fc-event-main {
 		background-color: ${({ theme }) => theme.palette.Grey.Grey2};
-		box-shadow: 2px 0 0 0 ${({ theme }) => theme.palette.Grey.Grey6} inset;
 	}
 
-	.tasks .fc-event-main:hover {
+	/* 종일 이벤트 테두리 */
+	.fc .fc-daygrid-day-frame .fc-event-main {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		height: 2.1rem;
+		padding: 0.3rem 1.2rem;
+
+		color: ${({ theme }) => theme.palette.Grey.White};
+
+		background-color: ${({ theme }) => theme.palette.Primary};
+		border: none;
+	}
+
+	/* fc-timegrid-col-events : 주간 이벤트 , fc-daygrid-day-frame: 월간 이벤트 */
+	.fc .fc-timegrid-col-events .fc-event-main:hover {
 		background-color: ${({ theme }) => theme.palette.Blue.Blue3};
 	}
 
-	.schedule .fc-event-main:hover {
+	.fc .fc-daygrid-day-frame .schedule .fc-event-main {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+	}
+
+	.fc .fc-timegrid-col-events .schedule .fc-event-main {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey2};
+		box-shadow: 2px 0 0 0 ${({ theme }) => theme.palette.Grey.Grey6} inset;
+	}
+
+	.fc .fc-daygrid-day-frame .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue8};
+	}
+
+	.fc .fc-timegrid-col-events .schedule .fc-event-main:hover {
 		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
+	}
+
+	.fc .fc-daygrid-day-frame .schedule .fc-event-main:hover {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey7};
+	}
+
+	/* user-select: none 상태에서의 스타일 */
+	.schedule[style*='user-select: none'] {
+		background-color: ${({ theme }) => theme.palette.Grey.Grey4} !important;
+	}
+
+	.tasks[style*='user-select: none'] {
+		background-color: ${({ theme }) => theme.palette.Blue.Blue4} !important;
 	}
 
 	.fc-v-event .fc-event-main-frame {
@@ -241,33 +282,6 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		${({ theme }) => theme.fontTheme.HEADLINE_02};
 	}
 
-	/* 종일 이벤트 테두리 */
-	.fc .fc-daygrid-day-frame .fc-event-main {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		box-sizing: border-box;
-		height: 2.1rem;
-		padding: 0.3rem 1.2rem;
-
-		color: ${({ theme }) => theme.palette.Grey.White};
-
-		background-color: ${({ theme }) => theme.palette.Primary};
-		border: none;
-	}
-
-	.fc .fc-daygrid-day-frame .fc-event-main:hover {
-		background-color: ${({ theme }) => theme.palette.Blue.Blue8};
-	}
-
-	.fc .fc-daygrid-day-frame .schedule .fc-event-main {
-		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
-	}
-
-	.fc .fc-daygrid-day-frame .tasks .fc-event-main:hover {
-		background-color: ${({ theme }) => theme.palette.Grey.Grey7};
-	}
-
 	.fc .fc-daygrid-event-harness {
 		margin: 0;
 	}
@@ -310,6 +324,7 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
 	}
 
+	/* 월간 이벤트 호버 효과 */
 	.fc .fc-daygrid-dot-event.schedule:hover {
 		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
 	}

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -149,7 +149,7 @@ const style = css`
 	}
 
 	:root {
-		--fc-highlight-color: #0f00;
+		--fc-highlight-color: #f0f5ff;
 		--fc-event-border-color: #ffff;
 	}
 `;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -150,6 +150,7 @@ const style = css`
 
 	:root {
 		--fc-highlight-color: #dfe9ff;
+		--fc-event-border-color: #ffff;
 	}
 `;
 

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -149,7 +149,7 @@ const style = css`
 	}
 
 	:root {
-		--fc-highlight-color: #dfe9ff;
+		--fc-highlight-color: #0f00;
 		--fc-event-border-color: #ffff;
 	}
 `;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 서버로부터 받아오는 이벤트를 class로 구분하여 taks와 schedule을 구분할 수 있도록 하였습니다.
- 각 이벤트의 호버 색상도 추가하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

-  `[style*='user-select: none']`이런식으로 드래그할 때의 스타일을 적용할 수 있음을 알았습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

![Jul-13-2024 18-10-03](https://github.com/user-attachments/assets/ccaa2d9a-fdfa-454d-bf6f-97407fbeb6c5)


## 관련 이슈

close #110

## 스크린샷 (선택)
