### PR TITLE
[FEAT] 캘린더 날짜 맞추기

### DIFF
--- a/src/components/calendarPage/miniCalendar/MiniCalendar.tsx
+++ b/src/components/calendarPage/miniCalendar/MiniCalendar.tsx
@@ -1,18 +1,21 @@
 import { ko } from 'date-fns/locale';
-import { useState } from 'react';
 import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 import MiniCalendarHeader from './MiniCalendarHeader';
 import MiniCalendarStyle from './MiniCalendarStyle';
 
-function MiniCalendar() {
-	const [selectDate, setSelectDate] = useState<Date | null>(new Date());
+interface MiniCalendarProps {
+	selectDate: Date | null;
+	onClickDate: (date: Date | null) => void;
+}
+
+function MiniCalendar({ selectDate, onClickDate }: MiniCalendarProps) {
 	return (
 		<DatePicker
 			locale={ko}
 			selected={selectDate}
-			onChange={setSelectDate}
+			onChange={onClickDate}
 			inline
 			calendarContainer={MiniCalendarStyle}
 			renderCustomHeader={(props) => <MiniCalendarHeader {...props} />}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -4,7 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import RefreshBtn from '@/components/common/button/RefreshBtn';
 import DayHeaderContent from '@/components/common/fullCalendar/DayHeaderContent';
@@ -14,9 +14,10 @@ import { theme } from '@/styles/theme';
 
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
+	selectDate?: Date | null;
 }
 
-function FullCalendarBox({ size }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const [currentView, setCurrentView] = useState('timeGridWeek');
 
@@ -28,12 +29,21 @@ function FullCalendarBox({ size }: FullCalendarBoxProps) {
 		setCurrentView(dateInfo.view.type);
 	};
 
+	const calendarRef = useRef<FullCalendar>(null);
+	useEffect(() => {
+		if (selectDate && calendarRef.current) {
+			const calendarApi = calendarRef.current.getApi();
+			calendarApi.gotoDate(selectDate);
+		}
+	}, [selectDate]);
+
 	return (
 		<FullCalendarLayout size={size}>
 			<CustomButtonContainer>
 				<RefreshBtn isDisabled={false} />
 			</CustomButtonContainer>
 			<FullCalendar
+				ref={calendarRef}
 				initialView="timeGridWeek"
 				plugins={[timeGridPlugin, dayGridPlugin, interactionPlugin]}
 				headerToolbar={{

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -21,7 +21,7 @@ function Calendar() {
 			</LeftSection>
 			<RightSection>
 				<FullCalendarBoxWapper>
-					<FullCalendarBox size="big" />
+					<FullCalendarBox size="big" selectDate={selectDate}/>
 				</FullCalendarBoxWapper>
 			</RightSection>
 		</CalendarLayout>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -3,12 +3,20 @@ import styled from '@emotion/styled';
 import CategoryBox from '@/components/calendarPage/CategoryBox';
 import MiniCalendar from '@/components/calendarPage/miniCalendar/MiniCalendar';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
+import { useState } from 'react';
 
 function Calendar() {
+	const today = new Date();
+	const [selectDate, setSelectDate] = useState<Date | null>(today);
+
+	const onClickDate = (date: Date | null) => {
+		setSelectDate(date);
+	};
+
 	return (
 		<CalendarLayout>
 			<LeftSection>
-				<MiniCalendar />
+				<MiniCalendar selectDate={selectDate} onClickDate={onClickDate} />
 				<CategoryBox email="hongildong@gmail.com" categoryList={['내 할 일', '공부', '운동']} />
 			</LeftSection>
 			<RightSection>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 미니 캘린더의 날짜를 이동하면 풀캘린더의 날짜도 이동하는 기능을 구현하였습니다. 
-  ref로 FullCalendar 컴포넌트를 참조하게 해서 `getApi()` 메서드를 호출하고 `FullCalendar`의 API 인스턴스를 가져왔습니다.


## 알게된 점 :rocket:

> 기록하며 개발하기!

-`calendarApi`의 `gotoDate` 메서드는 캘린더를 `selectDate` 날짜로 이동시킵니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- useRef를 통해 생성된 객체는 current라는 프로퍼티를 가지게 됩니다. 그리고 이 current를 통해 실제 DOM 노드에 접근할 수 있습니다.
- ref를 사용하여 컴포넌트를 재생성하지 않고 날짜를 동적으로 변경할 수 있어 ref를 사용하여 날짜를 변경하는 방법을 선택했습니다.

## 관련 이슈

close #110 

## 스크린샷 (선택)
![Jul-13-2024 22-27-13](https://github.com/user-attachments/assets/988f9af1-da12-45a5-9173-fe62c25d5c65)


