### PR TITLE
[FEAT] 스크롤할 때만 스크롤바 보이도록 설정

### DIFF
--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -1,13 +1,13 @@
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
 
-const BtnTaskContainer = styled.div`
+const BtnTaskContainer = styled.div<{ type: string }>`
 	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
 	width: 100%;
-	height: 56.7rem;
+	height: ${({ type }) => (type === 'staging' ? '56.7rem' : '64rem')};
 	overflow: auto;
 	overflow-y: scroll;
 

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -1,0 +1,29 @@
+import { theme } from '@/styles/theme';
+import styled from '@emotion/styled';
+
+const BtnTaskContainer = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	height: 56.7rem;
+	overflow: auto;
+	overflow-y: scroll;
+
+	::-webkit-scrollbar {
+		width: 0.6rem;
+	}
+
+	::-webkit-scrollbar-thumb {
+		background-color: ${theme.palette.Grey.Grey6};
+		visibility: hidden;
+		border-radius: 3px;
+	}
+
+	&:hover::-webkit-scrollbar-thumb {
+		visibility: visible;
+	}
+`;
+
+export default BtnTaskContainer;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -133,7 +133,7 @@ function StagingAreaTaskContainer() {
 	return (
 		<StagingAreaTaskContainerLayout>
 			<StagingAreaSetting />
-			<BtnTaskContainer>
+			<BtnTaskContainer type="staging">
 				{dummyTaskList.map((task) => (
 					<BtnTask
 						key={task.id + task.name}

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -4,6 +4,7 @@ import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
 import { TaskType } from '@/types/tasks/taskType';
+import BtnTaskContainer from '../BtnTaskContainer';
 
 function StagingAreaTaskContainer() {
 	const dummyTaskList: TaskType[] = [
@@ -158,23 +159,4 @@ const StagingAreaTaskContainerLayout = styled.div`
 	gap: 1.3rem;
 	align-items: flex-start;
 	align-self: stretch;
-`;
-const BtnTaskContainer = styled.div`
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	width: 100%;
-	height: 56.7rem;
-	overflow: auto;
-	overflow-y: scroll;
-
-	::-webkit-scrollbar {
-		width: 0.6rem;
-	}
-
-	::-webkit-scrollbar-thumb {
-		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
-		border-radius: 3px;
-	}
 `;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,9 +1,8 @@
-import styled from '@emotion/styled';
-
 import BtnTask from '../common/BtnTask/BtnTask';
 import ScrollGradient from '../common/ScrollGradient';
 
 import { TaskType } from '@/types/tasks/taskType';
+import BtnTaskContainer from '../common/BtnTaskContainer';
 
 function TargetTaskSection() {
 	const dummyTaskList: TaskType[] = [
@@ -50,7 +49,7 @@ function TargetTaskSection() {
 	];
 
 	return (
-		<TaskContainer>
+		<BtnTaskContainer>
 			{dummyTaskList.map((task) => (
 				<BtnTask
 					btnType="target"
@@ -63,26 +62,8 @@ function TargetTaskSection() {
 				/>
 			))}
 			<ScrollGradient />
-		</TaskContainer>
+		</BtnTaskContainer>
 	);
 }
-const TaskContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	width: 100%;
-	height: 64rem;
-	overflow: hidden;
-	overflow-y: scroll;
-
-	::-webkit-scrollbar {
-		width: 0.6rem;
-	}
-
-	::-webkit-scrollbar-thumb {
-		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
-		border-radius: 3px;
-	}
-`;
 
 export default TargetTaskSection;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -49,7 +49,7 @@ function TargetTaskSection() {
 	];
 
 	return (
-		<BtnTaskContainer>
+		<BtnTaskContainer type="target">
 			{dummyTaskList.map((task) => (
 				<BtnTask
 					btnType="target"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

기본 스크롤바에 visibility hidden 속성을 주고 
```css
	&:hover::-webkit-scrollbar-thumb {
		visibility: visible;
	}
```

해서 호버시에만 스크롤바가 보이도록 했습니다.  

그리고 TaskArea 와 StagingArea 에서 BtnTask 를 감싸는 컴포넌트가 동일한 기능 수행, 동일한 스타일링을 가지고 있는 것 같아 분리한 후 재사용할 수 있도록 제작했습니다.


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

컴포넌트 통일로 인해 다른 컴포넌트와의 상호작용에 문제가 생기는 부분이 있다면 제보 바랍니다 ...

## 관련 이슈

close #126 
