### PR TITLE
[FEAT] FullCalendar events에 모달 연결

### DIFF
--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ViewMountArg, DatesSetArg } from '@fullcalendar/core';
+import { ViewMountArg, DatesSetArg, EventClickArg } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
@@ -10,6 +10,8 @@ import RefreshBtn from '@/components/common/button/RefreshBtn';
 import DayHeaderContent from '@/components/common/fullCalendar/DayHeaderContent';
 import FullCalendarLayout from '@/components/common/fullCalendar/FullCalendarStyle';
 import { customDayCellContent, customSlotLabelContent } from '@/components/common/fullCalendar/fullCalendarUtils';
+import Modal from '../modal/Modal';
+import MODAL from '@/constants/modalLocation';
 
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
@@ -19,6 +21,8 @@ interface FullCalendarBoxProps {
 function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const [currentView, setCurrentView] = useState('timeGridWeek');
+
+	const [isModalOpen, setModalOpen] = useState(false);
 
 	const handleViewChange = (view: ViewMountArg) => {
 		setCurrentView(view.view.type);
@@ -35,6 +39,23 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 			calendarApi.gotoDate(selectDate);
 		}
 	}, [selectDate]);
+
+	const [top, setTop] = useState(0);
+	const [left, setLeft] = useState(0);
+
+	const handleEventClick = (info: EventClickArg) => {
+		const rect = info.el.getBoundingClientRect();
+		const calculatedTop = rect.top;
+		const adjustedTop = Math.min(calculatedTop, MODAL.SCREEN_HEIGHT - MODAL.TASK_MODAL_HEIGHT);
+		setTop(adjustedTop);
+		setLeft(rect.left - MODAL.TASK_MODAL_WIDTH + 40);
+		setModalOpen(true);
+	};
+
+	/** 모달 닫기 */
+	const closeModal = () => {
+		setModalOpen(false);
+	};
 
 	return (
 		<FullCalendarLayout size={size}>
@@ -116,7 +137,11 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 					hour12: false,
 				}}
 				droppable={true}
+				eventClick={handleEventClick}
 			/>
+			{isModalOpen && (
+				<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />
+			)}
 		</FullCalendarLayout>
 	);
 }

--- a/src/constants/modalLocation.ts
+++ b/src/constants/modalLocation.ts
@@ -3,6 +3,7 @@ const MODAL = {
 
 	// // Task 버튼 누르면 나오는 Modal 모달
 	TASK_MODAL_HEIGHT: 362,
+	TASK_MODAL_WIDTH: 372,
 
 	// 날짜 & 시간 세팅하는 DateCorrectionModal 모달
 	DATE_CORRECTION: {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- FullCalendar의 events에 클릭이벤트 추가(모달 연결)을 하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- fullcalendar 라이브러리에서는 각 이벤트를 클릭하는 `eventClick` 속성을 지원한다.
이때의 props 타입은 `EventClickArg` 라고 한다.
```typescript
const handleEventClick = (info: EventClickArg) => {};
```
해당 부분에서 `info.event.title` 과 같은 방식으로 클릭된 이벤트의 정보를 불러올 수 있다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 모달에 이벤트가 덮히는 문제로, 모달 위치를 조정하였습니다. 이상하다면 수정하겠습니다!

## 관련 이슈

close #123 

## 스크린샷 (선택)
![Jul-13-2024 23-44-44](https://github.com/user-attachments/assets/05645c64-0b5c-42b8-9192-3fdb4aaa59d4)
