### PR TITLE
[FEAT] BtnTask 선택 후 캘린더 긁기

### DIFF
--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -5,12 +5,17 @@ import ScrollGradient from '@/components/common/ScrollGradient';
 import DASHBOARD_TASK_TYPE from '@/constants/dashboardTask';
 import TODAY from '@/constants/tasksToday';
 import { TaskType } from '@/types/tasks/taskType';
+import { useState } from 'react';
 
 interface DashboardTaskProps {
 	text: 'upcoming' | 'postponed' | 'inprogress';
 }
 
 function DashboardTask({ text }: DashboardTaskProps) {
+	const [selectedTarget, setSelectedTarget] = useState<TaskType | null>(null);
+	const handleSelectedTarget = (task: TaskType | null) => {
+		setSelectedTarget(task);
+	};
 	let taskStatus = '';
 	if (text === 'upcoming') {
 		taskStatus = DASHBOARD_TASK_TYPE.UPCOMING;
@@ -81,6 +86,8 @@ function DashboardTask({ text }: DashboardTaskProps) {
 						status={task.status}
 						deadLine={task.deadLine}
 						btnType="target"
+						selectedTarget={selectedTarget}
+						handleSelectedTarget={handleSelectedTarget}
 					/>
 				))}
 				<ScrollGradient />

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -13,8 +13,8 @@ import MODAL from '@/constants/modalLocation';
 
 interface BtnTaskProps extends TaskType {
 	btnType: 'staging' | 'target' | 'delayed';
-	handleSelectedTarget: (id: number | null) => void;
-	selectedTarget: number | null;
+	handleSelectedTarget: (task: TaskType | null) => void;
+	selectedTarget: TaskType | null;
 }
 
 interface BorderColorProps {
@@ -52,8 +52,18 @@ function BtnTask(props: BtnTaskProps) {
 
 	/** 보더 색상 */
 	const handleClick = () => {
-		if (selectedTarget === id) handleSelectedTarget(null);
-		else handleSelectedTarget(id);
+		if (selectedTarget?.id === id) {
+			handleSelectedTarget(null);
+		} else {
+			const currentData: TaskType = {
+				id,
+				name,
+				deadLine,
+				hasDescription,
+				status,
+			};
+			handleSelectedTarget(currentData);
+		}
 	};
 
 	/** 모달 닫기 */
@@ -64,7 +74,7 @@ function BtnTask(props: BtnTaskProps) {
 	return (
 		<ModalLayout>
 			<BtnTaskLayout
-				isClicked={selectedTarget === id}
+				isClicked={selectedTarget?.id === id}
 				isHovered={isHovered}
 				btnType={btnType}
 				onDoubleClick={handleDoubleClick}

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -13,6 +13,8 @@ import MODAL from '@/constants/modalLocation';
 
 interface BtnTaskProps extends TaskType {
 	btnType: 'staging' | 'target' | 'delayed';
+	handleSelectedTarget: (id: number | null) => void;
+	selectedTarget: number | null;
 }
 
 interface BorderColorProps {
@@ -23,9 +25,8 @@ interface BorderColorProps {
 }
 
 function BtnTask(props: BtnTaskProps) {
-	const { btnType, name, deadLine, hasDescription, status } = props;
+	const { id, btnType, name, deadLine, hasDescription, status, handleSelectedTarget, selectedTarget } = props;
 	const [isModalOpen, setModalOpen] = useState(false);
-	const [isClicked, setIsClicked] = useState(false);
 	const [isHovered, setIsHovered] = useState(false);
 
 	const [top, setTop] = useState(0);
@@ -51,7 +52,8 @@ function BtnTask(props: BtnTaskProps) {
 
 	/** 보더 색상 */
 	const handleClick = () => {
-		setIsClicked((prev) => !prev);
+		if (selectedTarget === id) handleSelectedTarget(null);
+		else handleSelectedTarget(id);
 	};
 
 	/** 모달 닫기 */
@@ -62,7 +64,7 @@ function BtnTask(props: BtnTaskProps) {
 	return (
 		<ModalLayout>
 			<BtnTaskLayout
-				isClicked={isClicked}
+				isClicked={selectedTarget === id}
 				isHovered={isHovered}
 				btnType={btnType}
 				onDoubleClick={handleDoubleClick}

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -3,14 +3,17 @@ import styled from '@emotion/styled';
 import StagingAreaTaskContainer from './StagingAreaTaskContainer';
 
 import TextInputStaging from '@/components/common/textbox/TextInputStaging';
-
-function StagingArea() {
+interface StagingAreaProps {
+	handleSelectedTarget: (id: number | null) => void;
+	selectedTarget: number | null;
+}
+function StagingArea({ handleSelectedTarget, selectedTarget }: StagingAreaProps) {
 	return (
 		<StagingAreaLayout>
 			<StagingAreaContainer>
 				<StagingAreaUpContainer>
 					<StagingAreaTitle>쏟아내기</StagingAreaTitle>
-					<StagingAreaTaskContainer />
+					<StagingAreaTaskContainer handleSelectedTarget={handleSelectedTarget} selectedTarget={selectedTarget} />
 				</StagingAreaUpContainer>
 				<TextInputStaging />
 			</StagingAreaContainer>

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import StagingAreaTaskContainer from './StagingAreaTaskContainer';
 
 import TextInputStaging from '@/components/common/textbox/TextInputStaging';
+import { TaskType } from '@/types/tasks/taskType';
 interface StagingAreaProps {
-	handleSelectedTarget: (id: number | null) => void;
-	selectedTarget: number | null;
+	handleSelectedTarget: (task: TaskType | null) => void;
+	selectedTarget: TaskType | null;
 }
 function StagingArea({ handleSelectedTarget, selectedTarget }: StagingAreaProps) {
 	return (

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -6,118 +6,12 @@ import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetti
 import { TaskType } from '@/types/tasks/taskType';
 import BtnTaskContainer from '../BtnTaskContainer';
 
-function StagingAreaTaskContainer() {
+interface StagingAreaTaskContainerProps {
+	handleSelectedTarget: (id: number | null) => void;
+	selectedTarget: number | null;
+}
+function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget }: StagingAreaTaskContainerProps) {
 	const dummyTaskList: TaskType[] = [
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-		{
-			id: 0,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 1,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 2,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
 		{
 			id: 3,
 			name: '김지원',
@@ -143,6 +37,8 @@ function StagingAreaTaskContainer() {
 						name={task.name}
 						status={task.status}
 						deadLine={task.deadLine}
+						selectedTarget={selectedTarget}
+						handleSelectedTarget={handleSelectedTarget}
 					/>
 				))}
 				<ScrollGradient />

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -7,8 +7,8 @@ import { TaskType } from '@/types/tasks/taskType';
 import BtnTaskContainer from '../BtnTaskContainer';
 
 interface StagingAreaTaskContainerProps {
-	handleSelectedTarget: (id: number | null) => void;
-	selectedTarget: number | null;
+	handleSelectedTarget: (task: TaskType | null) => void;
+	selectedTarget: TaskType | null;
 }
 function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget }: StagingAreaTaskContainerProps) {
 	const dummyTaskList: TaskType[] = [

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -16,6 +16,7 @@ import MODAL from '@/constants/modalLocation';
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
+	selectedTarget: number | null;
 }
 
 function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
@@ -100,7 +101,7 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 						allDay: true,
 						classNames: 'task',
 					},
-					{ title: 'Meeting', start: '2024-07-11T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
+					{ title: 'Meeting', start: '2024-07-15T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
 					{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
 					{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
 					{

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -13,13 +13,15 @@ import { customDayCellContent, customSlotLabelContent } from '@/components/commo
 import Modal from '../modal/Modal';
 import MODAL from '@/constants/modalLocation';
 
+import { DateSelectArg } from 'fullcalendar/index.js';
+import { TaskType } from '@/types/tasks/taskType';
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
-	selectedTarget: number | null;
+	selectedTarget: TaskType | null;
 }
 
-function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const [currentView, setCurrentView] = useState('timeGridWeek');
 
@@ -58,6 +60,54 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 		setModalOpen(false);
 	};
 
+	const calendarEvents = [
+		{ title: 'Meeting', start: '2024-07-16T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
+		{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },
+		{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00', classNames: 'tasks' },
+		{
+			title: 'All Day Event',
+			start: '2024-07-08T10:00:00',
+			end: '2024-07-08T12:00:00',
+			allDay: true,
+			classNames: 'task',
+		},
+		{ title: 'Meeting', start: '2024-07-15T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
+		{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
+		{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
+		{
+			title: 'All Day Event',
+			start: '2024-07-12T10:00:00',
+			end: '2024-07-12T12:00:00',
+			allDay: true,
+			classNames: 'schedule',
+		},
+	];
+
+	/** 드래그해서 이벤트 추가하기 */
+	const addEventWhenDragged = (selectInfo: DateSelectArg) => {
+		if (calendarRef.current && (selectedTarget?.id === 0 || selectedTarget)) {
+			const calendarApi = calendarRef.current.getApi();
+
+			// 기존에 같은 id 가진 이벤트가 캘린더에 있다면 삭제
+			const existingEvents = calendarApi.getEvents();
+			existingEvents.forEach((event) => {
+				if (event.id === selectedTarget.id.toString()) {
+					event.remove();
+				}
+			});
+
+			// 이벤트 추가
+			calendarApi.addEvent({
+				id: selectedTarget.id.toString(),
+				title: selectedTarget.name,
+				start: selectInfo.startStr,
+				end: selectInfo.endStr,
+				allDay: selectInfo.allDay,
+				// 구글캘린더 여부에 따라 수정하면 될듯?
+				classNames: 'new-event',
+			});
+		}
+	};
 	return (
 		<FullCalendarLayout size={size}>
 			<CustomButtonContainer>
@@ -90,28 +140,7 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 				nowIndicator
 				dayMaxEvents
 				// netshell에서 할당한 이벤트 : tasks, 구글 캘린더에서 가져온 이벤트 : schedule
-				events={[
-					{ title: 'Meeting', start: '2024-07-06T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
-					{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },
-					{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00', classNames: 'tasks' },
-					{
-						title: 'All Day Event',
-						start: '2024-07-08T10:00:00',
-						end: '2024-07-08T12:00:00',
-						allDay: true,
-						classNames: 'task',
-					},
-					{ title: 'Meeting', start: '2024-07-15T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
-					{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
-					{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
-					{
-						title: 'All Day Event',
-						start: '2024-07-12T10:00:00',
-						end: '2024-07-12T12:00:00',
-						allDay: true,
-						classNames: 'schedule',
-					},
-				]}
+				events={calendarEvents}
 				buttonText={{
 					today: '오늘',
 					month: '월간',
@@ -139,6 +168,7 @@ function FullCalendarBox({ size, selectDate }: FullCalendarBoxProps) {
 				}}
 				droppable={true}
 				eventClick={handleEventClick}
+				select={addEventWhenDragged}
 			/>
 			{isModalOpen && (
 				<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -18,7 +18,7 @@ import { TaskType } from '@/types/tasks/taskType';
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
-	selectedTarget: TaskType | null;
+	selectedTarget?: TaskType | null;
 }
 
 function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxProps) {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -4,17 +4,18 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
+import { DateSelectArg } from 'fullcalendar/index.js';
 import { useState, useRef, useEffect } from 'react';
+
+import Modal from '../modal/Modal';
 
 import RefreshBtn from '@/components/common/button/RefreshBtn';
 import DayHeaderContent from '@/components/common/fullCalendar/DayHeaderContent';
 import FullCalendarLayout from '@/components/common/fullCalendar/FullCalendarStyle';
 import { customDayCellContent, customSlotLabelContent } from '@/components/common/fullCalendar/fullCalendarUtils';
-import Modal from '../modal/Modal';
 import MODAL from '@/constants/modalLocation';
-
-import { DateSelectArg } from 'fullcalendar/index.js';
 import { TaskType } from '@/types/tasks/taskType';
+
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 import TargetAreaDate from './TargetAreaDate';
 import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
+import { TaskType } from '@/types/tasks/taskType';
 interface TargetAreaProps {
-	handleSelectedTarget: (id: number | null) => void;
-	selectedTarget: number | null;
+	handleSelectedTarget: (task: TaskType | null) => void;
+	selectedTarget: TaskType | null;
 }
 function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
 	return (

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -3,8 +3,11 @@ import styled from '@emotion/styled';
 import TargetAreaDate from './TargetAreaDate';
 import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
-
-function TargetArea() {
+interface TargetAreaProps {
+	handleSelectedTarget: (id: number | null) => void;
+	selectedTarget: number | null;
+}
+function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
 	return (
 		<TargetAreaLayout>
 			{/* 날짜 */}
@@ -16,7 +19,7 @@ function TargetArea() {
 			<TargetControlSection />
 
 			{/* 태스크 목록 */}
-			<TargetTaskSection />
+			<TargetTaskSection handleSelectedTarget={handleSelectedTarget} selectedTarget={selectedTarget} />
 		</TargetAreaLayout>
 	);
 }

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -4,7 +4,11 @@ import ScrollGradient from '../common/ScrollGradient';
 import { TaskType } from '@/types/tasks/taskType';
 import BtnTaskContainer from '../common/BtnTaskContainer';
 
-function TargetTaskSection() {
+interface TargetTaskSectionProps {
+	handleSelectedTarget: (id: number | null) => void;
+	selectedTarget: number | null;
+}
+function TargetTaskSection({ handleSelectedTarget, selectedTarget }: TargetTaskSectionProps) {
 	const dummyTaskList: TaskType[] = [
 		{
 			id: 0,
@@ -36,16 +40,6 @@ function TargetTaskSection() {
 			hasDescription: true,
 			status: '완료',
 		},
-		{
-			id: 3,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
 	];
 
 	return (
@@ -59,6 +53,8 @@ function TargetTaskSection() {
 					deadLine={task.deadLine}
 					status={task.status}
 					id={task.id}
+					handleSelectedTarget={handleSelectedTarget}
+					selectedTarget={selectedTarget}
 				/>
 			))}
 			<ScrollGradient />

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -5,8 +5,8 @@ import { TaskType } from '@/types/tasks/taskType';
 import BtnTaskContainer from '../common/BtnTaskContainer';
 
 interface TargetTaskSectionProps {
-	handleSelectedTarget: (id: number | null) => void;
-	selectedTarget: number | null;
+	handleSelectedTarget: (task: TaskType | null) => void;
+	selectedTarget: TaskType | null;
 }
 function TargetTaskSection({ handleSelectedTarget, selectedTarget }: TargetTaskSectionProps) {
 	const dummyTaskList: TaskType[] = [

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import CategoryBox from '@/components/calendarPage/CategoryBox';
 import MiniCalendar from '@/components/calendarPage/miniCalendar/MiniCalendar';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
-import { useState } from 'react';
 
 function Calendar() {
 	const today = new Date();
@@ -21,7 +21,7 @@ function Calendar() {
 			</LeftSection>
 			<RightSection>
 				<FullCalendarBoxWapper>
-					<FullCalendarBox size="big" selectDate={selectDate}/>
+					<FullCalendarBox size="big" selectDate={selectDate} />
 				</FullCalendarBoxWapper>
 			</RightSection>
 		</CalendarLayout>

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
 import DatePickerCustom from '@/components/common/datePicker/DatePickerCustom';
 import DashboardTask from '@/components/DashboardPage/DashboardTask';
 import TaskSummary from '@/components/DashboardPage/TaskSummary';

--- a/src/pages/DashBoard.tsx
+++ b/src/pages/DashBoard.tsx
@@ -36,8 +36,6 @@ function DashBoard() {
 					<TaskSummary key={info.name} text={info.text} data={info.data} unit={info.unit} />
 				))}
 			</TaskSummaryWrapper>
-			<DateCorrectionModal isDateOnly />
-			<DateCorrectionModal isDateOnly={false} />
 			<DatePickerCustom />
 		</DashBoardWrapper>
 	);

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -1,20 +1,22 @@
 import styled from '@emotion/styled';
 
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
-import NavBar from '@/components/common/NavBar';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TargetArea from '@/components/targetArea/TargetArea';
+import { useState } from 'react';
 
 function Today() {
+	const [selectedTarget, setSelectedTarget] = useState<number | null>(null);
+	const handleSelectedTarget = (id: number | null) => {
+		setSelectedTarget(id);
+	};
 	return (
 		<>
-			<NavBar />
-
 			<TodayLayout>
-				<StagingArea />
-				<TargetArea />
+				<StagingArea handleSelectedTarget={handleSelectedTarget} selectedTarget={selectedTarget} />
+				<TargetArea handleSelectedTarget={handleSelectedTarget} selectedTarget={selectedTarget} />
 				<CalendarWrapper>
-					<FullCalendarBox size="small" />
+					<FullCalendarBox size="small" selectedTarget={selectedTarget} />
 				</CalendarWrapper>
 			</TodayLayout>
 		</>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -4,11 +4,12 @@ import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TargetArea from '@/components/targetArea/TargetArea';
 import { useState } from 'react';
+import { TaskType } from '@/types/tasks/taskType';
 
 function Today() {
-	const [selectedTarget, setSelectedTarget] = useState<number | null>(null);
-	const handleSelectedTarget = (id: number | null) => {
-		setSelectedTarget(id);
+	const [selectedTarget, setSelectedTarget] = useState<TaskType | null>(null);
+	const handleSelectedTarget = (task: TaskType | null) => {
+		setSelectedTarget(task);
 	};
 	return (
 		<>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 태스크 선택을 하나만 할 수 있도록 state를 만들어 관리합니다. 기존 border 색상을 관리하던 isClicked 상태를 삭제하고 해당 state로 묶었습니다.
- Today 에서 selectedTarget state를 TaskType로 받습니다.
- task 담겨있는 컴포넌트들과 캘린더를 위 state로 연결해 드래그하면 해당되는 이벤트가 추가됩니다.
- 이미 같은 id의 이벤트가 있는 경우 이벤트를 지우고 새로 생성합니다
- 대시보드에서도 하나만 선택할 수 있도록 설정했습니다. 이후 변동시 수정하겠습니다

## 알게된 점 :rocket:

> 기록하며 개발하기!

- full calendar api를 이용해 이벤트를 생성하는 방법을 알게 되었습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

```tsx
if (calendarRef.current && (selectedTarget?.id === 0 || selectedTarget)) {
```
0이 false 한 값으로 처리되어 위와 같이 처리했는데, 0을 제외한 falsy 값을 걸러낼 수 있는 더 좋은 방법이 있는지 궁금합니다.

## 관련 이슈

close #130 

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3667476f-9d55-466a-9206-0bd403889491)
