### PR TITLE
[FEAT] datepicker 값 버튼에 연결

### DIFF
--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -16,7 +16,7 @@ interface DateAreaProps {
 function DateArea({ isHover, isPressed }: DateAreaProps) {
 	const today = new Date();
 	const [startDate, setStartDate] = useState<Date | null>(null);
-	const [endDate, setEndDate] = useState<Date | null>(null);
+	const [endDate, setEndDate] = useState<Date | null>(today);
 	const [isClicked, setIsClicked] = useState(false);
 
 	const handleClick = () => {
@@ -53,13 +53,7 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 		<DatePickerCustomLayout>
 			<DateAreaLayout>
 				<DatePickerContainer>
-					<DatePickerPlaceholder
-						isHover
-						isPressed
-						endDate={endDate || today}
-						startDate={startDate || today}
-						handleClick={handleClick}
-					/>
+					<DatePickerPlaceholder isHover isPressed endDate={endDate} startDate={startDate} handleClick={handleClick} />
 					<DatePickerWrapper>
 						<DatePickerCustom
 							isOpen={isClicked}

--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -17,8 +17,6 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 	const today = new Date();
 	const [startDate, setStartDate] = useState<Date | null>(null);
 	const [endDate, setEndDate] = useState<Date | null>(null);
-	// const [startDate, setStartDate] = useState(today);
-	// const [endDate, setEndDate] = useState<Date | null>(null);
 	const [isClicked, setIsClicked] = useState(false);
 
 	const handleClick = () => {
@@ -33,14 +31,6 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 		setEndDate(date);
 	};
 
-	// const handleStartDate = (date: Date | null) => {
-	// 	setStartDate(date || today);
-	// };
-
-	// const handleEndDate = (date: Date | null) => {
-	// 	setEndDate(date);
-	// };
-
 	const handleClickPastDate = (getPastDate: number) => {
 		const newStartDate = new Date(today);
 		newStartDate.setDate(today.getDate() - getPastDate);
@@ -51,20 +41,13 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 		handleEndDate(newEndDate);
 	};
 
-	// const handleClickPastDate = (getPastDate: number) => {
-	// 	const PastEndDate = new Date(startDate);
-	// 	PastEndDate.setDate(startDate.getDate() - getPastDate);
-	// 	handleEndDate(PastEndDate);
-	// };
-
 	const getPastDateWeek = 6;
 	const getPastDateMonth = 30;
 	useEffect(() => {
-		// 초기에는 endDate 기준으로 startDate 설정
 		const initialStartDate = new Date(today);
-		initialStartDate.setDate(today.getDate() - 14); // 2주 전
+		initialStartDate.setDate(today.getDate() - 13);
 		handleStartDate(initialStartDate);
-	}, []); // endDate가 변경될 때마다 초기값 설정
+	}, []);
 
 	return (
 		<DatePickerCustomLayout>

--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -6,6 +6,8 @@ import DatePickerCustom from '../common/datePicker/DatePickerCustom';
 import DatePickerPlaceholder from './DatePickerPlaceholder';
 import PastDateBtn from './pastDateBtnStyle';
 
+import GETPASTDATE from '@/constants/getPastDate';
+
 interface DateAreaProps {
 	isHover: boolean;
 	isPressed: boolean;
@@ -44,9 +46,6 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 		handleEndDate(newEndDate);
 	};
 
-	const getPastDateWeek = 6;
-	const getPastDateMonth = 30;
-
 	return (
 		<DatePickerCustomLayout>
 			<DateAreaLayout>
@@ -68,7 +67,7 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 						isHover={isHover}
 						isPressed={isPressed}
 						onClick={() => {
-							handleClickPastDate(getPastDateWeek);
+							handleClickPastDate(GETPASTDATE.getPastDateWeek);
 						}}
 					>
 						지난 1주일
@@ -77,7 +76,7 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 						isHover={isHover}
 						isPressed={isPressed}
 						onClick={() => {
-							handleClickPastDate(getPastDateMonth);
+							handleClickPastDate(GETPASTDATE.getPastDateMonth);
 						}}
 					>
 						지난 1달

--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -11,10 +11,14 @@ interface DateAreaProps {
 	isPressed: boolean;
 }
 
+// startDate : 시작 날짜 ; endDate : 마감 날짜
+
 function DateArea({ isHover, isPressed }: DateAreaProps) {
 	const today = new Date();
-	const [startDate, setStartDate] = useState(today);
+	const [startDate, setStartDate] = useState<Date | null>(null);
 	const [endDate, setEndDate] = useState<Date | null>(null);
+	// const [startDate, setStartDate] = useState(today);
+	// const [endDate, setEndDate] = useState<Date | null>(null);
 	const [isClicked, setIsClicked] = useState(false);
 
 	const handleClick = () => {
@@ -22,34 +26,57 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 	};
 
 	const handleStartDate = (date: Date | null) => {
-		setStartDate(date || today);
+		setStartDate(date);
 	};
 
 	const handleEndDate = (date: Date | null) => {
 		setEndDate(date);
 	};
 
+	// const handleStartDate = (date: Date | null) => {
+	// 	setStartDate(date || today);
+	// };
+
+	// const handleEndDate = (date: Date | null) => {
+	// 	setEndDate(date);
+	// };
+
 	const handleClickPastDate = (getPastDate: number) => {
-		const PastEndDate = new Date(startDate);
-		PastEndDate.setDate(startDate.getDate() - getPastDate);
-		handleEndDate(PastEndDate);
+		const newStartDate = new Date(today);
+		newStartDate.setDate(today.getDate() - getPastDate);
+		handleStartDate(newStartDate);
+
+		const newEndDate = new Date(today);
+		newEndDate.setDate(today.getDate());
+		handleEndDate(newEndDate);
 	};
+
+	// const handleClickPastDate = (getPastDate: number) => {
+	// 	const PastEndDate = new Date(startDate);
+	// 	PastEndDate.setDate(startDate.getDate() - getPastDate);
+	// 	handleEndDate(PastEndDate);
+	// };
 
 	const getPastDateWeek = 6;
 	const getPastDateMonth = 30;
-
 	useEffect(() => {
-		const newEndDate = new Date(startDate);
-		newEndDate.setDate(startDate.getDate() - 13);
-		handleEndDate(newEndDate);
-		handleStartDate(today);
-	}, []);
+		// 초기에는 endDate 기준으로 startDate 설정
+		const initialStartDate = new Date(today);
+		initialStartDate.setDate(today.getDate() - 14); // 2주 전
+		handleStartDate(initialStartDate);
+	}, []); // endDate가 변경될 때마다 초기값 설정
 
 	return (
 		<DatePickerCustomLayout>
 			<DateAreaLayout>
 				<DatePickerContainer>
-					<DatePickerPlaceholder isHover isPressed endDate={endDate} startDate={startDate} handleClick={handleClick} />
+					<DatePickerPlaceholder
+						isHover
+						isPressed
+						endDate={endDate || today}
+						startDate={startDate || today}
+						handleClick={handleClick}
+					/>
 					<DatePickerWrapper>
 						<DatePickerCustom
 							isOpen={isClicked}

--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -14,17 +14,25 @@ interface DateAreaProps {
 function DateArea({ isHover, isPressed }: DateAreaProps) {
 	const today = new Date();
 	const [startDate, setStartDate] = useState(today);
-	const [endDate, setEndDate] = useState<Date | null>();
+	const [endDate, setEndDate] = useState<Date | null>(null);
 	const [isClicked, setIsClicked] = useState(false);
 
 	const handleClick = () => {
 		setIsClicked((prev) => !prev);
 	};
 
+	const handleStartDate = (date: Date | null) => {
+		setStartDate(date || today);
+	};
+
+	const handleEndDate = (date: Date | null) => {
+		setEndDate(date);
+	};
+
 	const handleClickPastDate = (getPastDate: number) => {
 		const PastEndDate = new Date(startDate);
 		PastEndDate.setDate(startDate.getDate() - getPastDate);
-		setEndDate(PastEndDate);
+		handleEndDate(PastEndDate);
 	};
 
 	const getPastDateWeek = 6;
@@ -33,8 +41,8 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 	useEffect(() => {
 		const newEndDate = new Date(startDate);
 		newEndDate.setDate(startDate.getDate() - 13);
-		setEndDate(newEndDate);
-		setStartDate(today);
+		handleEndDate(newEndDate);
+		handleStartDate(today);
 	}, []);
 
 	return (
@@ -43,7 +51,14 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 				<DatePickerContainer>
 					<DatePickerPlaceholder isHover isPressed endDate={endDate} startDate={startDate} handleClick={handleClick} />
 					<DatePickerWrapper>
-						<DatePickerCustom isOpen={isClicked} onClose={handleClick} />
+						<DatePickerCustom
+							isOpen={isClicked}
+							onClose={handleClick}
+							endDate={endDate}
+							startDate={startDate}
+							handleStartDate={handleStartDate}
+							handleEndDate={handleEndDate}
+						/>
 					</DatePickerWrapper>
 				</DatePickerContainer>
 				<PastDateWrapper>

--- a/src/components/DashboardPage/DateArea.tsx
+++ b/src/components/DashboardPage/DateArea.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import DatePickerCustom from '../common/datePicker/DatePickerCustom';
 
@@ -15,7 +15,10 @@ interface DateAreaProps {
 
 function DateArea({ isHover, isPressed }: DateAreaProps) {
 	const today = new Date();
-	const [startDate, setStartDate] = useState<Date | null>(null);
+	const initialStartDate = new Date(today);
+	initialStartDate.setDate(today.getDate() - 13);
+
+	const [startDate, setStartDate] = useState<Date | null>(initialStartDate);
 	const [endDate, setEndDate] = useState<Date | null>(today);
 	const [isClicked, setIsClicked] = useState(false);
 
@@ -43,11 +46,6 @@ function DateArea({ isHover, isPressed }: DateAreaProps) {
 
 	const getPastDateWeek = 6;
 	const getPastDateMonth = 30;
-	useEffect(() => {
-		const initialStartDate = new Date(today);
-		initialStartDate.setDate(today.getDate() - 13);
-		handleStartDate(initialStartDate);
-	}, []);
 
 	return (
 		<DatePickerCustomLayout>
@@ -101,7 +99,7 @@ const DateAreaLayout = styled.div`
 	gap: 1.2rem;
 	align-items: flex-end;
 	justify-content: flex-start;
-	width: 51.9rem;
+	width: fit-content;
 	margin: 1rem 0 0.7rem 1.4rem;
 `;
 

--- a/src/components/DashboardPage/DatePickerPlaceholder.tsx
+++ b/src/components/DashboardPage/DatePickerPlaceholder.tsx
@@ -27,10 +27,12 @@ export default DatePickerPlaceholder;
 
 const PlaceholderWrapper = styled.div<{ isHover: boolean; isPressed: boolean }>`
 	display: flex;
+	gap: 1.2rem;
 	align-items: center;
 	box-sizing: border-box;
+	width: 37.5rem;
 	height: 4rem;
-	padding: 0.4rem 1.2rem;
+	padding: 0.3rem 1.1rem;
 
 	background-color: ${({ theme }) => theme.textButton.WHITE.DEFAULT.BG};
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
@@ -58,7 +60,10 @@ const PlaceholderWrapper = styled.div<{ isHover: boolean; isPressed: boolean }>`
 `;
 
 const DateText = styled.p`
-	padding: 0.5rem 1.6rem;
+	display: flex;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 13.9rem;
 
 	color: ${({ theme }) => theme.textButton.WHITE.DEFAULT.TEXT};
 	${({ theme }) => theme.fontTheme.BODY_02};

--- a/src/components/DashboardPage/DatePickerPlaceholder.tsx
+++ b/src/components/DashboardPage/DatePickerPlaceholder.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Icons from '@/assets/svg/index';
-import formatDatetoString from '@/utils/formatDatetoString';
+import formatDatetoStrinKor from '@/utils/formatDatetoStringKor';
 
 interface DatePickerPlaceholderProps {
 	isHover: boolean;
@@ -16,9 +16,9 @@ function DatePickerPlaceholder({ isHover, isPressed, startDate, endDate, handleC
 	return (
 		<PlaceholderWrapper isHover={isHover} isPressed={isPressed} onClick={handleClick}>
 			<StlyedCalendarIcon />
-			<DateText>{formatDatetoString(startDate)}</DateText>
+			<DateText>{formatDatetoStrinKor(startDate)}</DateText>
 			<StyledArrowIcon />
-			<DateText>{formatDatetoString(endDate)}</DateText>
+			<DateText>{formatDatetoStrinKor(endDate)}</DateText>
 		</PlaceholderWrapper>
 	);
 }

--- a/src/components/DashboardPage/DatePickerPlaceholder.tsx
+++ b/src/components/DashboardPage/DatePickerPlaceholder.tsx
@@ -16,9 +16,9 @@ function DatePickerPlaceholder({ isHover, isPressed, startDate, endDate, handleC
 	return (
 		<PlaceholderWrapper isHover={isHover} isPressed={isPressed} onClick={handleClick}>
 			<StlyedCalendarIcon />
-			<DateText>{formatDatetoString(endDate)}</DateText>
-			<StyledArrowIcon />
 			<DateText>{formatDatetoString(startDate)}</DateText>
+			<StyledArrowIcon />
+			<DateText>{formatDatetoString(endDate)}</DateText>
 		</PlaceholderWrapper>
 	);
 }

--- a/src/components/DashboardPage/DatePickerPlaceholder.tsx
+++ b/src/components/DashboardPage/DatePickerPlaceholder.tsx
@@ -7,8 +7,8 @@ import formatDatetoString from '@/utils/formatDatetoString';
 interface DatePickerPlaceholderProps {
 	isHover: boolean;
 	isPressed: boolean;
-	startDate: Date;
-	endDate: Date;
+	startDate: Date | null;
+	endDate: Date | null;
 	handleClick: () => void;
 }
 

--- a/src/components/DashboardPage/DatePickerPlaceholder.tsx
+++ b/src/components/DashboardPage/DatePickerPlaceholder.tsx
@@ -8,7 +8,7 @@ interface DatePickerPlaceholderProps {
 	isHover: boolean;
 	isPressed: boolean;
 	startDate: Date;
-	endDate: Date | null | undefined;
+	endDate: Date;
 	handleClick: () => void;
 }
 

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -1,5 +1,4 @@
 import { ko } from 'date-fns/locale';
-// import { useEffect, useRef, useState } from 'react';
 import { useRef } from 'react';
 import DatePicker from 'react-datepicker';
 

--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -1,40 +1,37 @@
 import { ko } from 'date-fns/locale';
-import { useEffect, useRef, useState } from 'react';
+// import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 import TextBtn from '../button/textBtn/TextBtn';
+import ModalBackdrop from '../modal/ModalBackdrop';
 
 import CustomHeader from './CustomHeader';
 import CalendarStyle from './DatePickerStyle';
 
 import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef } from '@/utils/refStatus';
-import ModalBackdrop from '../modal/ModalBackdrop';
 
 interface DatePickerCustomProps {
 	isOpen: boolean;
 	onClose: () => void;
+	startDate: Date | null;
+	endDate: Date | null;
+	handleStartDate: (date: Date | null) => void;
+	handleEndDate: (date: Date | null) => void;
 }
 
-function DatePickerCustom({ isOpen, onClose }: DatePickerCustomProps) {
-	const [startDate, setStartDate] = useState<Date | null>(new Date());
-	const [endDate, setEndDate] = useState<Date | null>(null);
+function DatePickerCustom({
+	isOpen,
+	onClose,
+	startDate,
+	endDate,
+	handleStartDate,
+	handleEndDate,
+}: DatePickerCustomProps) {
 	const startDateTextRef = useRef<HTMLInputElement>(null);
 	const endDateTextRef = useRef<HTMLInputElement>(null);
-
-	// 초기값 이주 전으로 설정
-	useEffect(() => {
-		if (startDate) {
-			const newEndDate = new Date(startDate);
-			newEndDate.setDate(startDate.getDate() - 13);
-			setEndDate(newEndDate);
-			if (endDateTextRef.current) {
-				const inputElement = endDateTextRef.current.querySelector('input');
-				if (inputElement) inputElement.placeholder = formatDatetoString(newEndDate);
-			}
-		}
-	}, []);
 
 	/** ref 안에 Input DOM 있는지 검사하고 있다면 반환, 없으면 false 반환 */
 	const inputElementOfRef = (ref: React.RefObject<HTMLInputElement>) => {
@@ -50,7 +47,7 @@ function DatePickerCustom({ isOpen, onClose }: DatePickerCustomProps) {
 	/** 캘린더에서 날짜 선택할 경우 변경 */
 	const onChange = (dates: [Date | null, Date | null]) => {
 		const [start, end] = dates;
-		setStartDate(start);
+		handleStartDate(start);
 		blurRef(startDateTextRef);
 		// 캘린더에서 선택한 시작시간 인풋에 반영
 		const startInputEle = inputElementOfRef(startDateTextRef);
@@ -69,7 +66,7 @@ function DatePickerCustom({ isOpen, onClose }: DatePickerCustomProps) {
 
 		// 캘린더에서 선택한 마감시간 인풋에 반영
 		if (endInputEle) endInputEle.value = formatDatetoString(end);
-		setEndDate(end);
+		handleEndDate(end);
 		blurRef(endDateTextRef);
 	};
 
@@ -77,10 +74,10 @@ function DatePickerCustom({ isOpen, onClose }: DatePickerCustomProps) {
 	const onDateChange = (date: Date, mode: 'start' | 'end') => {
 		if (mode === 'start') {
 			blurRef(startDateTextRef);
-			setStartDate(date);
+			handleStartDate(date);
 		} else {
 			blurRef(endDateTextRef);
-			setEndDate(date);
+			handleEndDate(date);
 		}
 	};
 
@@ -109,7 +106,7 @@ function DatePickerCustom({ isOpen, onClose }: DatePickerCustomProps) {
 				>
 					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed onClick={onClose} />
 				</DatePicker>
-				<ModalBackdrop onClick={onClose}></ModalBackdrop>
+				<ModalBackdrop onClick={onClose} />
 			</>
 		)
 	);

--- a/src/constants/getPastDate.ts
+++ b/src/constants/getPastDate.ts
@@ -1,0 +1,6 @@
+const GETPASTDATE = {
+	getPastDateWeek: 6,
+	getPastDateMonth: 30,
+};
+
+export default GETPASTDATE;

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import CategoryBox from '@/components/calendarPage/CategoryBox';
 import MiniCalendar from '@/components/calendarPage/miniCalendar/MiniCalendar';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
-import { useState } from 'react';
 
 function Calendar() {
 	const today = new Date();
@@ -21,7 +21,7 @@ function Calendar() {
 			</LeftSection>
 			<RightSection>
 				<FullCalendarBoxWapper>
-					<FullCalendarBox size="big" selectDate={selectDate}/>
+					<FullCalendarBox size="big" selectDate={selectDate} />
 				</FullCalendarBoxWapper>
 			</RightSection>
 		</CalendarLayout>

--- a/src/utils/formatDatetoStringKor.ts
+++ b/src/utils/formatDatetoStringKor.ts
@@ -1,0 +1,14 @@
+/** Date 형식을 0000년 00월 00일 형식 string 으로 반환합니다
+ * undefined, null 의 경우 '시간' 텍스트를 반환합니다
+ */
+const formatDatetoStrinKor = (date: Date | undefined | null) => {
+	if (date) {
+		const year = date.getFullYear();
+		const month = '0'.concat((date.getMonth() + 1).toString()).slice(-2);
+		const day = '0'.concat(date.getDate().toString()).slice(-2);
+		return `${year}년 ${month}월 ${day}일`;
+	}
+	return '';
+};
+
+export default formatDatetoStrinKor;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- datePicker 상위 컴포넌트에서 관리하는 useState 값을 date picker 에도 인자로 내려주었습니다!
- 모달에서 날짜를 선택하면 버튼에 반영이 됩니당
- 데이트 피커에서 어떤 날짜값을 입력하든, 1주 전, 1달 전 버튼을 누르면 현재 날짜 & 현재 날짜 기준 1주/1달 전 날짜가 나오도록 설정했습니다. (사이드 이펙트 오져버려서 애좀 먹었어요..)
- 데이트피커에서 실시간으로 선택하는 값에 따라 placeholder에 Null 값이 들어가지 않도록 했습니다! (빈 공백이 placeholder에 렌더링되지 않도록)

## 알게된 점 :rocket:

> 기록하며 개발하기!

- setter 함수를 직접 사용하는 걸 지양하는게 좋다고 해서 handleStart/EndDate로 한번 선언해준 뒤 사용해주었습니다!
- 타입 에러를 잡는게 조금 어려웠습니다.. 자스의 Date 객체를 자주 활용하고 깊이 알아갈 수 있는 기회였습니다,, 
- 초기값 설정, 그리고 useEffect와 더 친해지는 계기였습니다. 여기저기 초기값이 다르고 렌더링되는 시점이 달라 개짜증나는 사이드 이펙트와 싸워야했어요..

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 하나 수정할 때마다 다른 에러 발생하고, 에러가 팡팡팡 미친듯이 나고 사이드 이펙트 지려버리고 타입 에러도 오져버려서 type 선언에서 date|null을 남발하였습니다.  혹시 좋지 않은 방식이라면 피드백 주세요!! 
- 아래와 같은 에러가 뜨는데, 해당 로직은 placeholder에서 가장 처음에 {현재 날짜} 와 {2주 전 날짜}를 보여주는 기능입니다. 때문에 초기값만 2주 전 날짜가 필요하고, 이후에는 딱히 필요하지 않아서 아래와 같이 코드를 짠 것인데, 뭔가 해결할 수 있는 부분이 없을까요?? 감사합니다!!!!!\

`React Hook useEffect has a missing dependency: 'today'. Either include it or remove the dependency array.`

```
useEffect(() => {
		const initialStartDate = new Date(today);
		initialStartDate.setDate(today.getDate() - 13);
		handleStartDate(initialStartDate);
	}, []);
```



- _타입 에러 때문에 어쩔 수 없이 startDate와 endDate (setter에도)의 타입을 `Date | null`로 설정해두었습니다. 그렇기 때문에 아래 영상과 같이 새로운 값을 고를 경우 placeholder가 비기도 하는데요, 이렇게 하는게 최선일까요..? 피드백 부탁드리겠습니다 ㅜㅜ_ >>>>> 저 잡았어요 이거 하하 이젠 왕초보 아니고 초보. ㅋㅋ

## 관련 이슈

close #136

## 스크린샷

https://github.com/user-attachments/assets/646f03c7-fb00-4c54-8009-d92a6c1049fa


