### PR TITLE
[FEAT] 구글 소셜 로그인 api 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 *storybook.log
+
+.env

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@emotion/react": "^11.11.4",
 		"@emotion/styled": "^11.11.5",
 		"@fullcalendar/react": "^6.1.14",
+		"@react-oauth/google": "^0.12.1",
 		"@svgr/cli": "^8.1.0",
 		"@tanstack/react-query": "^5.51.1",
 		"@tanstack/react-query-devtools": "^5.51.1",

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -2,11 +2,75 @@ import axios from 'axios';
 
 const API_URL = `${import.meta.env.VITE_BASE_URL}`;
 
+const MESSAGES = {
+	LOGIN: {
+		SUCCESS: '로그인에 성공하였습니다.',
+		EXPIRED: '로그인이 만료되었습니다. 다시 시도해주세요.',
+	},
+	UNKNOWN_ERROR: '로그인이 만료되었습니다. 다시 시도해주세요.',
+};
+
+// 토큰이 필요없는 api요청을 보내는 axios인스턴스
 const instance = axios.create({
 	baseURL: API_URL,
 	headers: {
 		'Content-Type': 'application/json',
 	},
 });
+
+// 토큰이 필요한 api요청을 보내는 axios인스턴스
+export const privateInstance = axios.create({
+	baseURL: API_URL,
+	headers: {
+		'Content-Type': 'application/json',
+		Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+	},
+});
+
+// refresh token api
+export async function postRefreshToken() {
+	const response = await privateInstance.post('/api/auth/re-issue', {
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+		},
+	});
+	return response;
+}
+
+privateInstance.interceptors.response.use(
+	(response) => response,
+
+	async (error) => {
+		const {
+			config,
+			response: { status },
+		} = error;
+
+		// 토큰이 만료되을 때
+		if (status === 401) {
+			const originRequest = config;
+			const response = await postRefreshToken();
+
+			// 리프레시 토큰 요청이 성공할 때
+			if (response.status === 200) {
+				const newAccessToken = response.data.token;
+				localStorage.setItem('accessToken', response.data.token);
+				localStorage.setItem('refreshToken', response.data.refreshToken);
+				axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+				// 진행중이던 요청 이어서하기
+				originRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+				return axios(originRequest);
+			}
+			if (response.status === 404) {
+				alert(MESSAGES.LOGIN.EXPIRED);
+				window.location.replace('/');
+			} else {
+				alert(MESSAGES.UNKNOWN_ERROR);
+			}
+		}
+		return Promise.reject(error);
+	}
+);
 
 export default instance;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -9,7 +9,7 @@ const MESSAGES = {
 		SUCCESS: '로그인에 성공하였습니다.',
 		EXPIRED: '로그인이 만료되었습니다. 다시 시도해주세요.',
 	},
-	UNKNOWN_ERROR: '로그인이 만료되었습니다. 다시 시도해주세요.',
+	UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
 };
 
 // 토큰이 필요없는 api요청을 보내는 axios인스턴스

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const API_URL = `${import.meta.env.VITE_BASE_URL}`;
+
+const instance = axios.create({
+	baseURL: API_URL,
+	headers: {
+		'Content-Type': 'application/json',
+	},
+});
+
+export default instance;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -61,7 +61,7 @@ privateInstance.interceptors.response.use(
 			// 리프레시 토큰 요청이 성공할 때
 			if (response.status === 200) {
 				const newAccessToken = response.data.data.accessToken;
-				localStorage.setItem('accessToken', response.data.data.accessToken);
+				localStorage.setItem('accessToken', newAccessToken);
 				localStorage.setItem('refreshToken', response.data.data.refreshToken);
 				axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
 				// 진행중이던 요청 이어서하기

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,16 +1,9 @@
 import axios from 'axios';
 
 import { LoginResponse } from '@/apis/login/loginInterface';
+import MESSAGES from '@/apis/messages';
 
 const API_URL = `${import.meta.env.VITE_BASE_URL}`;
-
-const MESSAGES = {
-	LOGIN: {
-		SUCCESS: '로그인에 성공하였습니다.',
-		EXPIRED: '로그인이 만료되었습니다. 다시 시도해주세요.',
-	},
-	UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
-};
 
 // 토큰이 필요없는 api요청을 보내는 axios인스턴스
 const instance = axios.create({

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { LoginResponse } from '@/apis/login/loginInterface';
+
 const API_URL = `${import.meta.env.VITE_BASE_URL}`;
 
 const MESSAGES = {
@@ -29,7 +31,7 @@ export const privateInstance = axios.create({
 
 // refresh token api
 export async function postRefreshToken() {
-	const response = await axios.post(
+	const response = await axios.post<LoginResponse>(
 		`${API_URL}/api/auth/re-issue`,
 		{},
 		{
@@ -58,15 +60,15 @@ privateInstance.interceptors.response.use(
 
 			// 리프레시 토큰 요청이 성공할 때
 			if (response.status === 200) {
-				const newAccessToken = response.data.token;
-				localStorage.setItem('accessToken', response.data.token);
-				localStorage.setItem('refreshToken', response.data.refreshToken);
+				const newAccessToken = response.data.data.accessToken;
+				localStorage.setItem('accessToken', response.data.data.accessToken);
+				localStorage.setItem('refreshToken', response.data.data.refreshToken);
 				axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
 				// 진행중이던 요청 이어서하기
 				originRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 				return axios(originRequest);
 			}
-			if (response.status === 404) {
+			if (response.status === 401) {
 				alert(MESSAGES.LOGIN.EXPIRED);
 				window.location.replace('/');
 			} else {

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -29,12 +29,16 @@ export const privateInstance = axios.create({
 
 // refresh token api
 export async function postRefreshToken() {
-	const response = await privateInstance.post('/api/auth/re-issue', {
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
-		},
-	});
+	const response = await axios.post(
+		`${API_URL}/api/auth/re-issue`,
+		{},
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+			},
+		}
+	);
 	return response;
 }
 

--- a/src/apis/login/loginAxios.ts
+++ b/src/apis/login/loginAxios.ts
@@ -2,13 +2,10 @@ import { isAxiosError } from 'axios';
 
 import instance from '@/apis/instance';
 import { LoginResponse } from '@/apis/login/loginInterface';
+import MESSAGES from '@/apis/messages';
 
 const AUTH_URL = {
 	LOGIN: '/api/auth/login/google',
-};
-
-const MESSAGES = {
-	UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
 };
 
 const userLogin = async (code: string): Promise<LoginResponse> => {

--- a/src/apis/login/loginAxios.ts
+++ b/src/apis/login/loginAxios.ts
@@ -5,7 +5,9 @@ const AUTH_URL = {
 };
 
 const userLogin = async (code: string) => {
-	const response = await instance.post(AUTH_URL.LOGIN, code);
+	const response = await instance.post(AUTH_URL.LOGIN, null, {
+		params: { code },
+	});
 	return response;
 };
 

--- a/src/apis/login/loginAxios.ts
+++ b/src/apis/login/loginAxios.ts
@@ -1,0 +1,12 @@
+import instance from '@/apis/instance';
+
+const AUTH_URL = {
+	LOGIN: '/api/auth/login/google',
+};
+
+const userLogin = async (code: string) => {
+	const response = await instance.post(AUTH_URL.LOGIN, code);
+	return response;
+};
+
+export default userLogin;

--- a/src/apis/login/loginAxios.ts
+++ b/src/apis/login/loginAxios.ts
@@ -1,14 +1,26 @@
+import { isAxiosError } from 'axios';
+
 import instance from '@/apis/instance';
+import { LoginResponse } from '@/apis/login/loginInterface';
 
 const AUTH_URL = {
 	LOGIN: '/api/auth/login/google',
 };
 
-const userLogin = async (code: string) => {
-	const response = await instance.post(AUTH_URL.LOGIN, null, {
-		params: { code },
-	});
-	return response;
+const MESSAGES = {
+	UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
+};
+
+const userLogin = async (code: string): Promise<LoginResponse> => {
+	try {
+		const response = await instance.post<LoginResponse>(AUTH_URL.LOGIN, null, {
+			params: { code },
+		});
+		return response.data;
+	} catch (error) {
+		if (isAxiosError(error)) throw error;
+		else throw new Error(MESSAGES.UNKNOWN_ERROR);
+	}
 };
 
 export default userLogin;

--- a/src/apis/login/loginInterface.ts
+++ b/src/apis/login/loginInterface.ts
@@ -1,0 +1,10 @@
+export interface AuthToken {
+	accessToken: string;
+	refreshToken: string;
+}
+
+export interface LoginResponse {
+	code: string;
+	data: AuthToken;
+	message: string | null;
+}

--- a/src/apis/messages.ts
+++ b/src/apis/messages.ts
@@ -1,0 +1,9 @@
+const MESSAGES = {
+	LOGIN: {
+		SUCCESS: '로그인에 성공하였습니다.',
+		EXPIRED: '로그인이 만료되었습니다. 다시 시도해주세요.',
+	},
+	UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
+};
+
+export default MESSAGES;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,7 +16,6 @@ const CLIENT_ID = import.meta.env.VITE_GOOGLE_LOGIN_CLIENT_ID;
 const queryClient = new QueryClient();
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<GoogleOAuthProvider clientId={CLIENT_ID}>
-		
 		<React.StrictMode>
 			<QueryClientProvider client={queryClient}>
 				<GlobalStyle />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from '@emotion/react';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
@@ -10,15 +11,20 @@ import { theme } from '@/styles/theme.ts';
 
 import '@/styles/font.css';
 
+const CLIENT_ID = import.meta.env.VITE_GOOGLE_LOGIN_CLIENT_ID;
+
 const queryClient = new QueryClient();
 ReactDOM.createRoot(document.getElementById('root')!).render(
-	<React.StrictMode>
-		<QueryClientProvider client={queryClient}>
-			<GlobalStyle />
-			<ThemeProvider theme={theme}>
-				<App />
-			</ThemeProvider>
-			<ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" position="left" />
-		</QueryClientProvider>
-	</React.StrictMode>
+	<GoogleOAuthProvider clientId={CLIENT_ID}>
+		
+		<React.StrictMode>
+			<QueryClientProvider client={queryClient}>
+				<GlobalStyle />
+				<ThemeProvider theme={theme}>
+					<App />
+				</ThemeProvider>
+				<ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" position="left" />
+			</QueryClientProvider>
+		</React.StrictMode>
+	</GoogleOAuthProvider>
 );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,30 @@
-import { GoogleLogin } from '@react-oauth/google';
+import styled from '@emotion/styled';
+import { useGoogleLogin } from '@react-oauth/google';
+
+import userLogin from '@/apis/login/loginAxios';
 
 function Login() {
-	const responseMessage = (response) => {
-		console.log(response);
-	};
-	const errorMessage = (error) => {
-		console.log(error);
-	};
-	return <GoogleLogin onSuccess={responseMessage} onError={errorMessage} />;
+	const googleSocialLogin = useGoogleLogin({
+		scope: 'email profile',
+		onSuccess: async ({ code }) => {
+			try {
+				const response = await userLogin(code);
+				console.log(response);
+			} catch (error) {
+				console.error(error);
+			}
+		},
+		onError: (errorResponse) => {
+			console.error(errorResponse);
+		},
+		flow: 'auth-code',
+	});
+
+	return <GoogleBtn onClick={googleSocialLogin}>Google Button</GoogleBtn>;
 }
+
+const GoogleBtn = styled.button`
+	width: 30rem;
+`;
 
 export default Login;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,14 +1,19 @@
 import styled from '@emotion/styled';
 import { useGoogleLogin } from '@react-oauth/google';
+import { useNavigate } from 'react-router-dom';
 
 import userLogin from '@/apis/login/loginAxios';
 
 function Login() {
+	const navigate = useNavigate();
+
 	const googleSocialLogin = useGoogleLogin({
 		onSuccess: async ({ code }) => {
 			try {
 				const response = userLogin(code);
-				console.log(response);
+				if ((await response).code === 'success') {
+					navigate('/today');
+				}
 			} catch (error) {
 				console.error(error);
 			}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,10 +5,9 @@ import userLogin from '@/apis/login/loginAxios';
 
 function Login() {
 	const googleSocialLogin = useGoogleLogin({
-		scope: 'email profile',
 		onSuccess: async ({ code }) => {
 			try {
-				const response = await userLogin(code);
+				const response = userLogin(code);
 				console.log(response);
 			} catch (error) {
 				console.error(error);
@@ -18,6 +17,7 @@ function Login() {
 			console.error(errorResponse);
 		},
 		flow: 'auth-code',
+		scope: 'email profile',
 	});
 
 	return <GoogleBtn onClick={googleSocialLogin}>Google Button</GoogleBtn>;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,10 +10,10 @@ function Login() {
 	const googleSocialLogin = useGoogleLogin({
 		onSuccess: async ({ code }) => {
 			try {
-				const response = userLogin(code);
-				if ((await response).code === 'success') {
-					localStorage.setItem('accessToken', (await response).data.accessToken);
-					localStorage.setItem('refreshToken', (await response).data.refreshToken);
+				const response = await userLogin(code);
+				if (response.code === 'success') {
+					localStorage.setItem('accessToken', response.data.accessToken);
+					localStorage.setItem('refreshToken', response.data.refreshToken);
 					navigate('/today');
 				}
 			} catch (error) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,6 +12,8 @@ function Login() {
 			try {
 				const response = userLogin(code);
 				if ((await response).code === 'success') {
+					localStorage.setItem('accessToken', (await response).data.accessToken);
+					localStorage.setItem('refreshToken', (await response).data.refreshToken);
 					navigate('/today');
 				}
 			} catch (error) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,13 @@
+import { GoogleLogin } from '@react-oauth/google';
+
 function Login() {
-	return <>login</>;
+	const responseMessage = (response) => {
+		console.log(response);
+	};
+	const errorMessage = (error) => {
+		console.log(error);
+	};
+	return <GoogleLogin onSuccess={responseMessage} onError={errorMessage} />;
 }
 
 export default Login;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
   integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
 
+"@react-oauth/google@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.12.1.tgz#b76432c3a525e9afe076f787d2ded003fcc1bee9"
+  integrity sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==
+
 "@remix-run/router@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.17.1.tgz#bf93997beb81863fde042ebd05013a2618471362"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- react-oauth/google 라이브러리를 이용해서 구글 로그인을 구현하였습니다.
- 토큰이 필요없는 api요청을 보내는 axios인스턴스와 토큰이 필요한 api요청을 보내는 axios인스턴스를 각각 만들고, interceptors를 이용해서 Refresh token으로 다시 access Token을 요청할 수 있게 하였습니다. 
- ex3

## 알게된 점 :rocket:

> 기록하며 개발하기!

-  useGoogleLogin를 사용하면 라이브러리 자체에서 알아서 리다이렉트가 진행되는데 해당 url은 localhost:5174라고 합니다.
- axios.post 메소드를 호출할 때, 세 번째 인수로 params를 전달하기 위해 두 번째 인수로 null을 넣어야 합니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- api 폴더구조를 고민하다가 현재처럼 하였는데 더 좋은 대안이 있다면 말씀해주세요!
- interceptors 구조도 좋지 않은 것 같아서 코드 리뷰 바랍니다. 
- 카카오톡에 공유한 env는 해당 pr이 머지하고 추가해주세요! 안그러면 커밋하다가 env가 올라갈 위험이 있습니당

## 관련 이슈

close #131 

## 스크린샷 (선택)
