### PR TITLE
[FEAT] 모달에 정보 연결하기

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -3,13 +3,13 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 
 import DateCorrectionModal from '../datePicker/DateCorrectionModal';
+import ModalBackdrop from '../modal/ModalBackdrop';
 
 import BtnDateText, { TextWrapper } from './BtnDateText';
 
 import Icons from '@/assets/svg/index';
-import { SizeType } from '@/types/textInputType';
 import MODAL from '@/constants/modalLocation';
-import ModalBackdrop from '../modal/ModalBackdrop';
+import { SizeType } from '@/types/textInputType';
 import formatDatetoString from '@/utils/formatDatetoString';
 
 interface BtnDateProps {

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -10,6 +10,7 @@ import Icons from '@/assets/svg/index';
 import { SizeType } from '@/types/textInputType';
 import MODAL from '@/constants/modalLocation';
 import ModalBackdrop from '../modal/ModalBackdrop';
+import formatDatetoString from '@/utils/formatDatetoString';
 
 interface BtnDateProps {
 	date?: string;
@@ -29,7 +30,11 @@ function BtnDate(props: BtnDateProps) {
 	} = props;
 	const [isPressed, setIsPressed] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
+	const [currentDate, setCurrentDate] = useState(date ? new Date(date) : null);
 
+	const handleCurrentDate = (newDate: Date | null) => {
+		setCurrentDate(newDate);
+	};
 	const handleMouseDown = () => {
 		if (size.type !== 'short') setIsPressed(true);
 	};
@@ -58,7 +63,7 @@ function BtnDate(props: BtnDateProps) {
 			>
 				<BtnDateText
 					icon={<CalanderIcon isDelayed={isDelayed} />}
-					text={date}
+					text={formatDatetoString(currentDate)}
 					isDefault={isDefaultDate}
 					size={size.type}
 				/>
@@ -76,6 +81,9 @@ function BtnDate(props: BtnDateProps) {
 					<DateCorrectionModal
 						top={MODAL.DATE_CORRECTION.TASK_MODAL.top}
 						left={MODAL.DATE_CORRECTION.TASK_MODAL.left}
+						date={date}
+						onClick={handleMouseUp}
+						handleCurrentDate={handleCurrentDate}
 					/>
 					<ModalBackdrop onClick={handleMouseUp} />
 				</>

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -19,37 +19,36 @@ interface BtnDateProps {
 	isDelayed?: boolean;
 	isDisabled?: boolean;
 }
+// date, time 각각 Date|null, String|null 로 관리
+// 값이 없으면 '마감 기한' 등 텍스트 설정,
+// 스타일 변경은 date, time null 여부로 결정
 
 function BtnDate(props: BtnDateProps) {
-	const {
-		date = '마감 기한',
-		time = '마감 시간',
-		size = { type: 'long' },
-		isDelayed = false,
-		isDisabled = false,
-	} = props;
+	const { date = null, time = null, size = { type: 'long' }, isDelayed = false, isDisabled = false } = props;
 	const [isPressed, setIsPressed] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
-	const [currentDate, setCurrentDate] = useState(date ? new Date(date) : null);
-	const [currentTime, setCurrentTime] = useState(time ? time : null);
-	const handleCurrentDate = (newDate: Date | null) => {
+	// 받아온 date, time 값을 초기값으로 설정, 이후 모달에서 수정시 변경
+	const [currentDate, setCurrentDate] = useState<Date | null>(date ? new Date(date) : null);
+	const [currentTime, setCurrentTime] = useState<string | null>(time);
+
+	const handleCurrentDate = (newDate: Date) => {
 		setCurrentDate(newDate);
 	};
-	const handleCurrentTime = (newTime: string | null) => {
+	const handleCurrentTime = (newTime: string) => {
 		setCurrentTime(newTime);
 	};
+
 	const handleMouseDown = () => {
 		if (size.type !== 'short') setIsPressed(true);
 	};
-
 	const handleMouseUp = () => {
 		if (size.type !== 'short') {
 			setIsPressed(false);
 			setIsClicked((prev) => !prev);
 		}
 	};
-	const isDefaultDate = date === '마감 기한';
-	const isDefaultTime = time === '마감 시간';
+	const isDefaultDate = date === null;
+	const isDefaultTime = time === null;
 
 	return (
 		<ModalLayout>
@@ -66,14 +65,14 @@ function BtnDate(props: BtnDateProps) {
 			>
 				<BtnDateText
 					icon={<CalanderIcon isDelayed={isDelayed} />}
-					text={formatDatetoString(currentDate)}
+					text={formatDatetoString(currentDate) || '마감 기한'}
 					isDefault={isDefaultDate}
 					size={size.type}
 				/>
 				<LineIcon size={size.type} isDelayed={isDelayed} />
 				<BtnDateText
 					icon={<ClockIcon isDelayed={isDelayed} />}
-					text={currentTime ? currentTime : ''}
+					text={currentTime || '마감 시간'}
 					isDefault={isDefaultTime}
 					size={size.type}
 				/>
@@ -84,8 +83,8 @@ function BtnDate(props: BtnDateProps) {
 					<DateCorrectionModal
 						top={MODAL.DATE_CORRECTION.TASK_MODAL.top}
 						left={MODAL.DATE_CORRECTION.TASK_MODAL.left}
-						date={date}
-						time={time}
+						date={formatDatetoString(currentDate) || '마감 기한'}
+						time={currentTime || '마감 시간'}
 						onClick={handleMouseUp}
 						handleCurrentDate={handleCurrentDate}
 						handleCurrentTime={handleCurrentTime}

--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -13,8 +13,8 @@ import ModalBackdrop from '../modal/ModalBackdrop';
 import formatDatetoString from '@/utils/formatDatetoString';
 
 interface BtnDateProps {
-	date?: string;
-	time?: string;
+	date: string | null;
+	time: string | null;
 	size?: SizeType;
 	isDelayed?: boolean;
 	isDisabled?: boolean;
@@ -31,9 +31,12 @@ function BtnDate(props: BtnDateProps) {
 	const [isPressed, setIsPressed] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
 	const [currentDate, setCurrentDate] = useState(date ? new Date(date) : null);
-
+	const [currentTime, setCurrentTime] = useState(time ? time : null);
 	const handleCurrentDate = (newDate: Date | null) => {
 		setCurrentDate(newDate);
+	};
+	const handleCurrentTime = (newTime: string | null) => {
+		setCurrentTime(newTime);
 	};
 	const handleMouseDown = () => {
 		if (size.type !== 'short') setIsPressed(true);
@@ -70,7 +73,7 @@ function BtnDate(props: BtnDateProps) {
 				<LineIcon size={size.type} isDelayed={isDelayed} />
 				<BtnDateText
 					icon={<ClockIcon isDelayed={isDelayed} />}
-					text={time}
+					text={currentTime ? currentTime : ''}
 					isDefault={isDefaultTime}
 					size={size.type}
 				/>
@@ -82,8 +85,10 @@ function BtnDate(props: BtnDateProps) {
 						top={MODAL.DATE_CORRECTION.TASK_MODAL.top}
 						left={MODAL.DATE_CORRECTION.TASK_MODAL.left}
 						date={date}
+						time={time}
 						onClick={handleMouseUp}
 						handleCurrentDate={handleCurrentDate}
+						handleCurrentTime={handleCurrentTime}
 					/>
 					<ModalBackdrop onClick={handleMouseUp} />
 				</>

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -86,8 +86,8 @@ function BtnTask(props: BtnTaskProps) {
 						{name}
 					</BtnTaskTextWrapper>
 					<BtnDate
-						date={deadLine?.date}
-						time={deadLine?.time}
+						date={deadLine?.date || null}
+						time={deadLine?.time || null}
 						size={{ type: 'short' }}
 						isDelayed={btnType === 'delayed'}
 					/>

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -94,7 +94,7 @@ function BtnTask(props: BtnTaskProps) {
 				</BtnTaskContainer>
 				<IconHoverContainer btnType={btnType} status={status} />
 			</BtnTaskLayout>
-			<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />
+			<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} taskId={id} />
 		</ModalLayout>
 	);
 }

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -1,5 +1,6 @@
-import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
+
+import { theme } from '@/styles/theme';
 
 const BtnTaskContainer = styled.div<{ type: string }>`
 	position: relative;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
 
+import BtnTaskContainer from '../BtnTaskContainer';
+
 import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
 import { TaskType } from '@/types/tasks/taskType';
-import BtnTaskContainer from '../BtnTaskContainer';
 
 interface StagingAreaTaskContainerProps {
 	handleSelectedTarget: (task: TaskType | null) => void;

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -11,7 +11,7 @@ interface CustomHeaderProps {
 	increaseMonth: () => void;
 	prevMonthButtonDisabled: boolean;
 	nextMonthButtonDisabled: boolean;
-	onChange: (date: Date) => void;
+	onChange: (date: Date | null) => void;
 	dateTextRef: React.RefObject<HTMLInputElement>;
 }
 
@@ -30,7 +30,7 @@ function CorrectionCustomHeader({
 				<TextboxInput
 					variant="date"
 					placeholder={formatDatetoString(prevDate)}
-					onChange={onChange}
+					onDateChange={onChange}
 					dateTextRef={dateTextRef}
 				/>
 				<div className="react-datepicker__navigation-wrapper">

--- a/src/components/common/datePicker/CustomHeader.tsx
+++ b/src/components/common/datePicker/CustomHeader.tsx
@@ -38,30 +38,34 @@ function CustomHeader({
 		diff = Math.ceil(diff / (1000 * 60 * 60 * 24)) + 1;
 	}
 	const stripTime = (date: Date) => new Date(date.setHours(0, 0, 0, 0));
-	const onStartChange = (date: Date) => {
-		const strippedEndDate = endDate ? stripTime(endDate) : null;
-		const strippedDate = stripTime(date);
+	const onStartChange = (date: Date | null) => {
+		if (date) {
+			const strippedEndDate = endDate ? stripTime(endDate) : null;
+			const strippedDate = stripTime(date);
 
-		if (strippedEndDate && strippedEndDate < strippedDate) {
-			warnRef(startDateTextRef);
-			if (startDateTextRef.current) {
-				Object.assign(startDateTextRef.current, { value: '' });
+			if (strippedEndDate && strippedEndDate < strippedDate) {
+				warnRef(startDateTextRef);
+				if (startDateTextRef.current) {
+					Object.assign(startDateTextRef.current, { value: '' });
+				}
+			} else {
+				onChange(date, 'start');
 			}
-		} else {
-			onChange(date, 'start');
 		}
 	};
-	const onEndChange = (date: Date) => {
-		const strippedStartDate = startDate ? stripTime(startDate) : null;
-		const strippedDate = stripTime(date);
+	const onEndChange = (date: Date | null) => {
+		if (date) {
+			const strippedStartDate = startDate ? stripTime(startDate) : null;
+			const strippedDate = stripTime(date);
 
-		if (strippedStartDate && strippedDate < strippedStartDate) {
-			warnRef(endDateTextRef);
-			if (endDateTextRef.current) {
-				Object.assign(endDateTextRef.current, { value: '' });
+			if (strippedStartDate && strippedDate < strippedStartDate) {
+				warnRef(endDateTextRef);
+				if (endDateTextRef.current) {
+					Object.assign(endDateTextRef.current, { value: '' });
+				}
+			} else {
+				onChange(date, 'end');
 			}
-		} else {
-			onChange(date, 'end');
 		}
 	};
 	return (
@@ -71,13 +75,13 @@ function CustomHeader({
 					<TextboxInput
 						variant="smallDate"
 						placeholder={formatDatetoString(startDate)}
-						onChange={onStartChange}
+						onDateChange={onStartChange}
 						dateTextRef={startDateTextRef}
 					/>
 					<TextboxInput
 						variant="smallDate"
 						placeholder={formatDatetoString(new Date())}
-						onChange={onEndChange}
+						onDateChange={onEndChange}
 						dateTextRef={endDateTextRef}
 					/>
 				</InfoWrapper>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -17,10 +17,20 @@ interface DateCorrectionModalProps {
 	isDateOnly?: boolean;
 	top?: number;
 	left?: number;
+	date: string;
+	onClick: () => void;
+	handleCurrentDate: (newDate: Date | null) => void;
 }
 
-function DateCorrectionModal({ isDateOnly = false, top = 0, left = 0 }: DateCorrectionModalProps) {
-	const prevDate: Date = new Date();
+function DateCorrectionModal({
+	isDateOnly = false,
+	top = 0,
+	left = 0,
+	date,
+	onClick,
+	handleCurrentDate,
+}: DateCorrectionModalProps) {
+	const prevDate: Date = new Date(date);
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
 
 	const dateTextRef = useRef<HTMLInputElement>(null);
@@ -34,6 +44,12 @@ function DateCorrectionModal({ isDateOnly = false, top = 0, left = 0 }: DateCorr
 		}
 	};
 
+	/** 모달 확인, 닫기버튼 */
+	const onSave = () => {
+		console.log('save');
+		handleCurrentDate(currentDate);
+		onClick();
+	};
 	return (
 		<DateCorrectionModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
 			<DatePicker
@@ -48,7 +64,7 @@ function DateCorrectionModal({ isDateOnly = false, top = 0, left = 0 }: DateCorr
 			>
 				<BottomBtnWrapper>
 					{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
-					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed />
+					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed onClick={onSave} />
 				</BottomBtnWrapper>
 			</DatePicker>
 		</DateCorrectionModalLayout>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -70,7 +70,14 @@ function DateCorrectionModal({
 				)}
 			>
 				<BottomBtnWrapper>
-					{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} onTimeChange={onTimeChange} />}
+					{!isDateOnly && (
+						<TextboxInput
+							variant="time"
+							dateTextRef={timeTextRef}
+							onTimeChange={onTimeChange}
+							currentTime={currentTime}
+						/>
+					)}
 					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed onClick={onSave} />
 				</BottomBtnWrapper>
 			</DatePicker>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -17,9 +17,11 @@ interface DateCorrectionModalProps {
 	isDateOnly?: boolean;
 	top?: number;
 	left?: number;
-	date: string;
+	date: string | null;
+	time: string | null;
 	onClick: () => void;
 	handleCurrentDate: (newDate: Date | null) => void;
+	handleCurrentTime: (newTime: string | null) => void;
 }
 
 function DateCorrectionModal({
@@ -27,14 +29,17 @@ function DateCorrectionModal({
 	top = 0,
 	left = 0,
 	date,
+	time,
 	onClick,
 	handleCurrentDate,
+	handleCurrentTime,
 }: DateCorrectionModalProps) {
-	const prevDate: Date = new Date(date);
+	const prevDate = date ? new Date(date) : null;
 	const [currentDate, setCurrentDate] = useState<Date | null>(null);
-
+	const [currentTime, setCurrentTime] = useState<string | null>(time);
 	const dateTextRef = useRef<HTMLInputElement>(null);
 	const timeTextRef = useRef<HTMLInputElement>(null);
+
 	const onChange = (date: Date | null) => {
 		setCurrentDate(date);
 		if (dateTextRef.current) {
@@ -43,11 +48,14 @@ function DateCorrectionModal({
 			blurRef(dateTextRef);
 		}
 	};
-
+	const onTimeChange = (time: string | null) => {
+		setCurrentTime(time);
+	};
 	/** 모달 확인, 닫기버튼 */
 	const onSave = () => {
 		console.log('save');
 		handleCurrentDate(currentDate);
+		handleCurrentTime(currentTime);
 		onClick();
 	};
 	return (
@@ -63,7 +71,7 @@ function DateCorrectionModal({
 				)}
 			>
 				<BottomBtnWrapper>
-					{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} />}
+					{!isDateOnly && <TextboxInput variant="time" dateTextRef={timeTextRef} onTimeChange={onTimeChange} />}
 					<TextBtn text="닫기" color="BLACK" size="small" mode="DEFAULT" isHover isPressed onClick={onSave} />
 				</BottomBtnWrapper>
 			</DatePicker>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -20,8 +20,8 @@ interface DateCorrectionModalProps {
 	date: string | null;
 	time: string | null;
 	onClick: () => void;
-	handleCurrentDate: (newDate: Date) => void;
-	handleCurrentTime: (newTime: string) => void;
+	handleCurrentDate?: (newDate: Date) => void;
+	handleCurrentTime?: (newTime: string) => void;
 }
 
 function DateCorrectionModal({
@@ -53,8 +53,8 @@ function DateCorrectionModal({
 	};
 	/** 모달 확인, 닫기버튼 */
 	const onSave = () => {
-		if (currentDate) handleCurrentDate(currentDate);
-		if (currentTime) handleCurrentTime(currentTime);
+		if (handleCurrentDate && currentDate) handleCurrentDate(currentDate);
+		if (handleCurrentTime && currentTime) handleCurrentTime(currentTime);
 		onClick();
 	};
 	return (

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -20,8 +20,8 @@ interface DateCorrectionModalProps {
 	date: string | null;
 	time: string | null;
 	onClick: () => void;
-	handleCurrentDate: (newDate: Date | null) => void;
-	handleCurrentTime: (newTime: string | null) => void;
+	handleCurrentDate: (newDate: Date) => void;
+	handleCurrentTime: (newTime: string) => void;
 }
 
 function DateCorrectionModal({
@@ -35,7 +35,7 @@ function DateCorrectionModal({
 	handleCurrentTime,
 }: DateCorrectionModalProps) {
 	const prevDate = date ? new Date(date) : null;
-	const [currentDate, setCurrentDate] = useState<Date | null>(null);
+	const [currentDate, setCurrentDate] = useState<Date | null>(prevDate);
 	const [currentTime, setCurrentTime] = useState<string | null>(time);
 	const dateTextRef = useRef<HTMLInputElement>(null);
 	const timeTextRef = useRef<HTMLInputElement>(null);
@@ -53,9 +53,8 @@ function DateCorrectionModal({
 	};
 	/** 모달 확인, 닫기버튼 */
 	const onSave = () => {
-		console.log('save');
-		handleCurrentDate(currentDate);
-		handleCurrentTime(currentTime);
+		if (currentDate) handleCurrentDate(currentDate);
+		if (currentTime) handleCurrentTime(currentTime);
 		onClick();
 	};
 	return (

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -40,16 +40,16 @@ function DateCorrectionModal({
 	const dateTextRef = useRef<HTMLInputElement>(null);
 	const timeTextRef = useRef<HTMLInputElement>(null);
 
-	const onChange = (date: Date | null) => {
-		setCurrentDate(date);
+	const onChange = (newDate: Date | null) => {
+		setCurrentDate(newDate);
 		if (dateTextRef.current) {
 			const inputElement = dateTextRef.current.querySelector('input');
-			if (inputElement) inputElement.value = formatDatetoString(date);
+			if (inputElement) inputElement.value = formatDatetoString(newDate);
 			blurRef(dateTextRef);
 		}
 	};
-	const onTimeChange = (time: string | null) => {
-		setCurrentTime(time);
+	const onTimeChange = (newTime: string | null) => {
+		setCurrentTime(newTime);
 	};
 	/** 모달 확인, 닫기버튼 */
 	const onSave = () => {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -172,7 +172,15 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				select={addEventWhenDragged}
 			/>
 			{isModalOpen && (
-				<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} />
+				// 🚨 임시 taskID ... 데이터 형식 확정 후 수정할 것 🚨
+				<Modal
+					isOpen={isModalOpen}
+					sizeType={{ type: 'short' }}
+					top={top}
+					left={left}
+					onClose={closeModal}
+					taskId={5}
+				/>
 			)}
 		</FullCalendarLayout>
 	);

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -14,19 +14,34 @@ interface ModalProps {
 	top: number;
 	left: number;
 	onClose: () => void;
+	taskId: number;
 }
 
 function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
+	const dummyData = {
+		name: 'task name',
+		description: 'task description',
+		deadLine: {
+			date: '2024-06-30',
+			time: '12:30',
+		},
+		status: '진행 중', //수정
+		timeBlock: {
+			id: 1,
+			startTime: '2024-07-08T12:30',
+			endTime: '2024-07-08T14:30',
+		},
+	};
 	return (
 		isOpen && (
 			<ModalBackdrop onClick={onClose}>
 				<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
 					<ModalHeader>
-						<BtnDate />
+						<BtnDate date={dummyData.deadLine.date} time={dummyData.deadLine.time} />
 						<ModalHeaderBtn type={sizeType.type} />
 					</ModalHeader>
 					<ModalBody>
-						<TextInputBox type={sizeType.type} />
+						<TextInputBox type={sizeType.type} name={dummyData.name} desc={dummyData.description} />
 						{sizeType.type === 'long' && <ModalTextInputTime />}
 					</ModalBody>
 					<ModalFooter>

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -18,8 +18,10 @@ interface ModalProps {
 	taskId: number;
 }
 
-function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
+function Modal({ isOpen, sizeType, top, left, onClose, taskId }: ModalProps) {
+	// taskId 가지고 api로 상세정보 요청하면 됨
 	const dummyData = {
+		id: taskId, // 안쓰는 변수 린트 통과용 필드
 		name: 'task name',
 		description: 'task description',
 		deadLine: {

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
 
+import ModalBackdrop from './ModalBackdrop';
+
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
 import ModalHeaderBtn from '@/components/common/modal/ModalHeaderBtn';
 import ModalTextInputTime from '@/components/common/modal/ModalTextInputTime';
 import TextInputBox from '@/components/common/modal/TextInputBox';
 import { SizeType } from '@/types/textInputType';
-import ModalBackdrop from './ModalBackdrop';
 
 interface ModalProps {
 	isOpen: boolean;
@@ -25,7 +26,7 @@ function Modal({ isOpen, sizeType, top, left, onClose }: ModalProps) {
 			date: '2024-06-30',
 			time: '12:30',
 		},
-		status: '진행 중', //수정
+		status: '진행 중', // 수정
 		timeBlock: {
 			id: 1,
 			startTime: '2024-07-08T12:30',

--- a/src/components/common/modal/ModalDeleteDetail.tsx
+++ b/src/components/common/modal/ModalDeleteDetail.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 
-import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 import ModalBackdrop from './ModalBackdrop';
+
+import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 
 interface ModalDeleteDetailProps {
 	top: number;

--- a/src/components/common/modal/TextInputBox.tsx
+++ b/src/components/common/modal/TextInputBox.tsx
@@ -4,11 +4,15 @@ import TextInputDesc from '@/components/common/textbox/TextInputDesc';
 import TextInputTitle from '@/components/common/textbox/TextInputTitle';
 import { SizeType } from '@/types/textInputType';
 
-function TextInputBox({ type }: SizeType) {
+interface TextInputBoxProps extends SizeType {
+	name: string;
+	desc: string;
+}
+function TextInputBox({ type, name, desc }: TextInputBoxProps) {
 	return (
 		<TextInputBoxLayout>
-			<TextInputTitle type={type} />
-			<TextInputDesc type={type} />
+			<TextInputTitle type={type} name={name} />
+			<TextInputDesc type={type} desc={desc} />
 		</TextInputBoxLayout>
 	);
 }

--- a/src/components/common/textbox/TextInputDesc.tsx
+++ b/src/components/common/textbox/TextInputDesc.tsx
@@ -2,8 +2,11 @@ import styled from '@emotion/styled';
 
 import { SizeType } from '@/types/textInputType';
 
-function TextInputDesc({ type }: SizeType) {
-	return <TextInputDescLayout placeholder="설명 추가" type={type} maxLength={120} />;
+interface TextInputDescProps extends SizeType {
+	desc: string;
+}
+function TextInputDesc({ type, desc }: TextInputDescProps) {
+	return <TextInputDescLayout placeholder="설명 추가" type={type} value={desc} maxLength={120} />;
 }
 
 const TextInputDescLayout = styled.textarea<{ type: string }>`

--- a/src/components/common/textbox/TextInputDesc.tsx
+++ b/src/components/common/textbox/TextInputDesc.tsx
@@ -6,7 +6,7 @@ interface TextInputDescProps extends SizeType {
 	desc: string;
 }
 function TextInputDesc({ type, desc }: TextInputDescProps) {
-	return <TextInputDescLayout placeholder="설명 추가" type={type} value={desc} maxLength={120} />;
+	return <TextInputDescLayout placeholder="설명 추가" type={type} defaultValue={desc} maxLength={120} />;
 }
 
 const TextInputDescLayout = styled.textarea<{ type: string }>`

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -29,6 +29,9 @@ function TextInputStaging() {
 							<DateCorrectionModal
 								top={MODAL.DATE_CORRECTION.SET_DEADLINE.top}
 								left={MODAL.DATE_CORRECTION.SET_DEADLINE.left}
+								onClick={handleCloseModal}
+								time={null}
+								date={null}
 							/>
 							<ModalBackdrop onClick={handleCloseModal} />
 						</>

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -4,8 +4,9 @@ import { useState } from 'react';
 import BtnStagingDate from '../BtnDate/BtnStagingDate';
 import EnterBtn from '../button/EnterBtn';
 import DateCorrectionModal from '../datePicker/DateCorrectionModal';
-import MODAL from '@/constants/modalLocation';
 import ModalBackdrop from '../modal/ModalBackdrop';
+
+import MODAL from '@/constants/modalLocation';
 
 function TextInputStaging() {
 	const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/common/textbox/TextInputTitle.tsx
+++ b/src/components/common/textbox/TextInputTitle.tsx
@@ -2,8 +2,11 @@ import styled from '@emotion/styled';
 
 import { SizeType } from '@/types/textInputType';
 
-function TextInputTitle({ type }: SizeType) {
-	return <TextInputTitleLayout placeholder="제목 추가" type={type} maxLength={20} />;
+interface TextInputTitleProps extends SizeType {
+	name: string;
+}
+function TextInputTitle({ type, name }: TextInputTitleProps) {
+	return <TextInputTitleLayout placeholder="제목 추가" type={type} value={name} maxLength={20} />;
 }
 const TextInputTitleLayout = styled.input<{ type: string }>`
 	${({ theme }) => theme.fontTheme.BODY_02};

--- a/src/components/common/textbox/TextInputTitle.tsx
+++ b/src/components/common/textbox/TextInputTitle.tsx
@@ -6,7 +6,7 @@ interface TextInputTitleProps extends SizeType {
 	name: string;
 }
 function TextInputTitle({ type, name }: TextInputTitleProps) {
-	return <TextInputTitleLayout placeholder="제목 추가" type={type} value={name} maxLength={20} />;
+	return <TextInputTitleLayout placeholder="제목 추가" type={type} defaultValue={name} maxLength={20} />;
 }
 const TextInputTitleLayout = styled.input<{ type: string }>`
 	${({ theme }) => theme.fontTheme.BODY_02};

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -15,8 +15,16 @@ interface TextboxInputProps {
 	onTimeChange?: (time: string | null) => void;
 	dateTextRef?: React.RefObject<HTMLInputElement>;
 	placeholder?: string;
+	currentTime?: string | null;
 }
-function TextboxInput({ variant, onDateChange, onTimeChange, dateTextRef, placeholder }: TextboxInputProps) {
+function TextboxInput({
+	variant,
+	onDateChange,
+	onTimeChange,
+	dateTextRef,
+	placeholder,
+	currentTime,
+}: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { value } = e.target;
 		const formattedInput = variant === 'time' ? dotFormatTime(value) : dotFormatDate(value);
@@ -50,6 +58,7 @@ function TextboxInput({ variant, onDateChange, onTimeChange, dateTextRef, placeh
 				maxLength={10}
 				variant={variant}
 				onChange={handleDateChange}
+				defaultValue={currentTime ?? undefined}
 			/>
 		</InputContainer>
 	);

--- a/src/components/common/textbox/TextboxInput.tsx
+++ b/src/components/common/textbox/TextboxInput.tsx
@@ -11,11 +11,12 @@ import { blurRef, focusRef, warnRef } from '@/utils/refStatus';
 
 interface TextboxInputProps {
 	variant: 'date' | 'time' | 'smallDate';
-	onChange?: (date: Date) => void;
+	onDateChange?: (date: Date | null) => void;
+	onTimeChange?: (time: string | null) => void;
 	dateTextRef?: React.RefObject<HTMLInputElement>;
 	placeholder?: string;
 }
-function TextboxInput({ variant, onChange, dateTextRef, placeholder }: TextboxInputProps) {
+function TextboxInput({ variant, onDateChange, onTimeChange, dateTextRef, placeholder }: TextboxInputProps) {
 	const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { value } = e.target;
 		const formattedInput = variant === 'time' ? dotFormatTime(value) : dotFormatDate(value);
@@ -26,16 +27,17 @@ function TextboxInput({ variant, onChange, dateTextRef, placeholder }: TextboxIn
 			if (!isValid && dateTextRef) {
 				// 유효하지 않음
 				warnRef(dateTextRef);
-				// 유효하지 않은 경우 인풋 삭제 필요?
+				// 유효하지 않은 경우 인풋 삭제
 				e.target.value = '';
-			} else if ((variant === 'date' || variant === 'smallDate') && onChange) {
+			} else if ((variant === 'date' || variant === 'smallDate') && onDateChange) {
 				// 유효하고 date 인 경우
 				const valueDate = new Date(formattedInput);
 				if (dateTextRef) blurRef(dateTextRef);
-				onChange(valueDate);
+				onDateChange(valueDate);
 			} else if (dateTextRef) {
 				// 유효하고 time 인 경우
 				blurRef(dateTextRef);
+				if (onTimeChange) onTimeChange(e.target.value);
 			}
 		}
 	};

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -30,7 +30,13 @@ function TargetControlSection() {
 				<ModalLayout>
 					<ArrangeBtn color="WHITE" mode="DEFAULT" size="small" type="calendar" onClick={handleArrangeBtnClick} />
 					{isModalOpen && (
-						<DateCorrectionModal top={MODAL.DATE_CORRECTION.TARGET.top} left={MODAL.DATE_CORRECTION.TARGET.left} />
+						<DateCorrectionModal
+							top={MODAL.DATE_CORRECTION.TARGET.top}
+							left={MODAL.DATE_CORRECTION.TARGET.left}
+							date={null}
+							time={null}
+							onClick={handleCloseModal}
+						/>
 					)}
 				</ModalLayout>
 			</TargetControlSectionLayout>

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -3,10 +3,10 @@ import { useState } from 'react';
 
 import ArrangeBtn from '../common/arrangeBtn/ArrangeBtn';
 import DateCorrectionModal from '../common/datePicker/DateCorrectionModal';
+import ModalBackdrop from '../common/modal/ModalBackdrop';
 
 import TextBtn from '@/components/common/button/textBtn/TextBtn';
 import MODAL from '@/constants/modalLocation';
-import ModalBackdrop from '../common/modal/ModalBackdrop';
 
 function TargetControlSection() {
 	const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -14,8 +14,8 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget }: TargetTaskS
 			id: 0,
 			name: '바보~',
 			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
+				date: null,
+				time: null,
 			},
 			hasDescription: false,
 			status: '진행중',

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,8 +1,8 @@
 import BtnTask from '../common/BtnTask/BtnTask';
+import BtnTaskContainer from '../common/BtnTaskContainer';
 import ScrollGradient from '../common/ScrollGradient';
 
 import { TaskType } from '@/types/tasks/taskType';
-import BtnTaskContainer from '../common/BtnTaskContainer';
 
 interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -24,8 +24,8 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget }: TargetTaskS
 			id: 1,
 			name: '넛수레',
 			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
+				date: '2024-08-29',
+				time: '10:30',
 			},
 			hasDescription: true,
 			status: '지연',

--- a/src/stories/Button/OkayCancelBtn.stories.ts
+++ b/src/stories/Button/OkayCancelBtn.stories.ts
@@ -1,6 +1,7 @@
-import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
+
+import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
 
 const meta = {
 	title: 'Button/OkayCancelBtn', // 스토리북에 올릴 component폴더 계층 구조,

--- a/src/types/tasks/taskType.ts
+++ b/src/types/tasks/taskType.ts
@@ -2,8 +2,8 @@ export interface TaskType {
 	id: number;
 	name: string;
 	deadLine?: {
-		date: string;
-		time: string;
+		date?: string | null;
+		time?: string | null;
 	};
 	hasDescription: boolean;
 	status: '진행중' | '미완료' | '완료' | '지연';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 모달과 데이트피커 날짜, 시간 정보를 연결했습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- `Modal` 컴포넌트에 `taskId`를 props 로 받게 해주어서 상세정보 요청을 `taskId`로 하시면 됩니다! 임시로 5로 박아둔 상태고 나중에 값 연결할 때 데이터 형식 잘 확인하고 연결하면 될 것 같아요  

- 타입 관리를 용이하게 하기 위해서 기존에 date, time이 `Date|'마감 시간'` 와 같은 구조로 되어있던 것을 `Date|null` 로 변경하고, null 일 경우에 마감시간 마감기한 등 스트링을 주고 스타일링도 변경하는 방식으로 변경했습니다.  

- `BtnTask` 내의 정보는 리스트 불러오는 api 에서 가져오고, 모달에 있는 정보는 `taskId`를 이용해서 상세정보를 불러오기 때문에 모달에만 시간 날짜를 임시저장하고 정보 등록하는 api 호출에 사용할 수 있도록 state를 사용했습니다.  
- 더 나은 구조가 있다면 리뷰로 달아주세요!

## 관련 이슈

close #142 

## 스크린샷 (선택)
<img width="595" alt="image" src="https://github.com/user-attachments/assets/326bd72c-6a66-41ae-b3a7-9f42ebb0a05d">
<img width="322" alt="image" src="https://github.com/user-attachments/assets/1d6d432c-ed67-4904-8d0c-2a045575fbfc">
