### PR TITLE
[FEAT] 세팅 페이지 취소, 삭제 버튼 추가

### DIFF
--- a/src/components/SettingPage/AccountArea.tsx
+++ b/src/components/SettingPage/AccountArea.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import google_calendar from '@/assets/images/google_calendar.png';
 import Icons from '@/assets/svg/index';
-import SettingCheckBtn from '@/components/common/button/settingBtn/SettingCheckBtn';
+import AccountDeleteBtn from '@/components/SettingPage/AccountDeleteBtn';
 import USERS from '@/constants/users';
 
 function AccountArea() {
@@ -19,7 +19,7 @@ function AccountArea() {
 				</CalendarContainer>
 				<InputBox>
 					<EmailWrapper>{USERS.data.email}</EmailWrapper>
-					<SettingCheckBtn size="small" type="close" isHover isPressed={false} isActive />
+					<AccountDeleteBtn />
 				</InputBox>
 			</AccountWrapper>
 		</AccountAreaWrapper>

--- a/src/components/SettingPage/AccountDeleteBtn.tsx
+++ b/src/components/SettingPage/AccountDeleteBtn.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+import SettingCheckBtn from '@/components/common/button/settingBtn/SettingCheckBtn';
+import ModalDeleteDetail from '@/components/common/modal/ModalDeleteDetail';
+
+function AccountDeleteBtn() {
+	const [isModalOpen, setModalOpen] = useState(false);
+
+	const handleClickBtn = () => {
+		setModalOpen((prev) => !prev);
+	};
+
+	const handleCloseModal = () => {
+		setModalOpen(false);
+	};
+	return (
+		<AccountDeleteBtnContainer>
+			<SettingCheckBtn size="small" type="close" isHover isPressed={false} isActive onClick={handleClickBtn} />
+			{isModalOpen && <ModalDeleteDetail onClose={handleCloseModal} top={321} left={482} />}
+		</AccountDeleteBtnContainer>
+	);
+}
+
+const AccountDeleteBtnContainer = styled.div`
+	position: relative;
+`;
+
+export default AccountDeleteBtn;

--- a/src/components/common/button/DeleteCancelBtn.tsx
+++ b/src/components/common/button/DeleteCancelBtn.tsx
@@ -3,10 +3,19 @@ import styled from '@emotion/styled';
 
 interface DeleteCancelBtnProps {
 	status: 'delete' | 'cancel';
+	onClick?: () => void;
 }
 
-function DeleteCancelBtn({ status }: DeleteCancelBtnProps) {
-	return <div>{status === 'delete' ? <DeleteBtn>삭제</DeleteBtn> : <CancelBtn>취소</CancelBtn>}</div>;
+function DeleteCancelBtn({ status, onClick }: DeleteCancelBtnProps) {
+	return (
+		<div>
+			{status === 'delete' ? (
+				<DeleteBtn onClick={onClick}>삭제</DeleteBtn>
+			) : (
+				<CancelBtn onClick={onClick}>취소</CancelBtn>
+			)}
+		</div>
+	);
 }
 
 export default DeleteCancelBtn;

--- a/src/components/common/button/DeleteCancelBtn.tsx
+++ b/src/components/common/button/DeleteCancelBtn.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 interface DeleteCancelBtnProps {
 	status: 'delete' | 'cancel';
-	onClick?: () => void;
+	onClick?: (e: React.MouseEvent) => void;
 }
 
 function DeleteCancelBtn({ status, onClick }: DeleteCancelBtnProps) {

--- a/src/components/common/modal/ModalDeleteDetail.tsx
+++ b/src/components/common/modal/ModalDeleteDetail.tsx
@@ -1,19 +1,20 @@
 import styled from '@emotion/styled';
 
-import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 import ModalBackdrop from './ModalBackdrop';
+
+import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 
 interface ModalDeleteDetailProps {
 	top: number;
 	left: number;
-	onClose: React.MouseEventHandler;
+	onClose: () => void;
 }
 
 function ModalDeleteDetail({ top, left, onClose }: ModalDeleteDetailProps) {
 	return (
 		<ModalBackdrop onClick={onClose}>
 			<ModalDeleteDetailLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
-				<DeleteCancelBtn status="cancel" />
+				<DeleteCancelBtn status="cancel" onClick={onClose} />
 				<DeleteCancelBtn status="delete" />
 			</ModalDeleteDetailLayout>
 		</ModalBackdrop>

--- a/src/components/common/modal/ModalDeleteDetail.tsx
+++ b/src/components/common/modal/ModalDeleteDetail.tsx
@@ -7,7 +7,7 @@ import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
 interface ModalDeleteDetailProps {
 	top: number;
 	left: number;
-	onClose: () => void;
+	onClose: (e: React.MouseEvent) => void;
 }
 
 function ModalDeleteDetail({ top, left, onClose }: ModalDeleteDetailProps) {

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -1,60 +1,18 @@
 import styled from '@emotion/styled';
 
-import DeleteCancelBtn from '@/components/common/button/DeleteCancelBtn';
-import EnterBtn from '@/components/common/button/EnterBtn';
-import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
-import ProgressBtn from '@/components/common/button/ProgressBtn';
-import RefreshBtn from '@/components/common/button/RefreshBtn';
-import SettingCheck from '@/components/common/button/settingBtn/SettingCheckBtn';
-import SettingDeleteBtn from '@/components/common/button/settingBtn/SettingDeleteBtn';
-import SortBtn from '@/components/common/button/SortBtn';
-import StatusDoneBtn from '@/components/common/button/statusBtn/StatusDoneBtn';
-import StatusInProgressBtn from '@/components/common/button/statusBtn/StatusInProgressBtn';
-import StatusStagingBtn from '@/components/common/button/statusBtn/StatusStagingBtn';
-import StatusTodoBtn from '@/components/common/button/statusBtn/StatusTodoBtn';
-import TextBtn from '@/components/common/button/textBtn/TextBtn';
-import TimelineDeleteBtn from '@/components/common/button/TimelineDeleteBtn';
-import TodayPlusBtn from '@/components/common/button/TodayPlusBtn';
-import NavBar from '@/components/common/NavBar';
 import AccountArea from '@/components/SettingPage/AccountArea';
 import LogOutBtn from '@/components/SettingPage/LogOutBtn';
 import ProfileArea from '@/components/SettingPage/ProfileArea';
 
 function Setting() {
 	return (
-		<div>
-			<NavBar />
-			<TextBtn size="big" text="전체" color="BLUE" mode="LIGHT" isHover isPressed />
-			<TextBtn size="big" text="전체" color="BLUE" mode="DEFAULT" isHover isPressed />
-			<SortBtn text="최신 등록순" />
-			<DeleteCancelBtn status="delete" />
-			<EnterBtn isDisabled={false} />
-			<OkayCancelBtn type="okay" />
-			<ProgressBtn type="defaultProgress" />
-			<RefreshBtn isDisabled={false} />
-
-			<SettingDeleteBtn size="big" isHover isPressed={false} isActive />
-			<StatusDoneBtn />
-			<StatusInProgressBtn />
-			<StatusStagingBtn />
-			<TimelineDeleteBtn />
-			<TodayPlusBtn />
-
-			<StatusDoneBtn />
-			<StatusInProgressBtn />
-			<StatusStagingBtn />
-			<StatusTodoBtn />
-			<SettingCheck size="big" type="complete" isHover isPressed={false} isActive />
-			<SettingCheck size="big" type="complete" isHover isPressed={false} isActive />
-			<SettingCheck size="big" type="close" isHover isPressed={false} isActive />
-			<SettingContainer>
-				<Wrapper>
-					<ProfileArea />
-					<AccountArea />
-				</Wrapper>
-				<LogOutBtn />
-			</SettingContainer>
-		</div>
+		<SettingContainer>
+			<Wrapper>
+				<ProfileArea />
+				<AccountArea />
+			</Wrapper>
+			<LogOutBtn />
+		</SettingContainer>
 	);
 }
 
@@ -70,5 +28,5 @@ const SettingContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	height: 100vh;
+	height: 100%;
 `;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 세팅 페이지에서 계정 삭제 버튼을 누를 때 취소, 삭제 버튼이 나타나도록 했습니다.
- 기존에 만들어두었던 ModalDeleteDetail 컴포넌트를 사용하였습니다.
- 기존에는 버튼에 onClick이 없어서 props에 onClick을 추가하고 취소 버튼에는 close 함수를 연결하였습니다. 

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 확인해보시고 추가 수정할 부분 말씀해주세요!

## 관련 이슈

close #153 

## 스크린샷 (선택)
![Jul-16-2024 22-34-18](https://github.com/user-attachments/assets/e8eb7917-0243-4b05-ab97-379825ea557c)
