### PR TITLE
[FEAT] task get api TargetArea 연동

### DIFF
--- a/src/apis/tasks/getTask/GetTasksType.ts
+++ b/src/apis/tasks/getTask/GetTasksType.ts
@@ -1,5 +1,5 @@
 export interface GetTasksType {
 	isTotal?: boolean;
 	sortOrder?: string;
-	targetDate?: Date;
+	targetDate?: string;
 }

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -14,7 +14,7 @@ interface TargetAreaProps {
 	tasks: TaskType[];
 }
 
-function TargetArea({ handleSelectedTarget, selectedTarget, tasks }: TargetAreaProps) {
+function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
 	const [targetDate, setTargetDate] = useState(new Date());
 
 	const handlePrevBtn = () => {
@@ -59,7 +59,7 @@ function TargetArea({ handleSelectedTarget, selectedTarget, tasks }: TargetAreaP
 						<TargetTaskSection
 							handleSelectedTarget={handleSelectedTarget}
 							selectedTarget={selectedTarget}
-							tasks={tasks}
+							selectedDate={targetDate}
 						/>
 						{provided.placeholder}
 					</div>

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -5,17 +5,17 @@ import BtnTaskContainer from '../common/BtnTaskContainer';
 
 import useGetTasks from '@/apis/tasks/getTask/query';
 import { TaskType } from '@/types/tasks/taskType';
+import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
-	tasks: TaskType[];
+	selectedDate: Date | null;
 }
 function TargetTaskSection(props: TargetTaskSectionProps) {
-	const { handleSelectedTarget, selectedTarget } = props;
-	const targetDate = '2024-07-17';
+	const { handleSelectedTarget, selectedTarget, selectedDate } = props;
+	const targetDate = formatDatetoLocalDate(selectedDate);
 	const { isFetched, data } = useGetTasks({ targetDate });
-	console.log(data);
 	return (
 		<BtnTaskContainer type="target">
 			{isFetched && (

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -3,6 +3,7 @@ import { Draggable } from 'react-beautiful-dnd';
 import BtnTask from '../common/BtnTask/BtnTask';
 import BtnTaskContainer from '../common/BtnTaskContainer';
 
+import useGetTasks from '@/apis/tasks/getTask/query';
 import { TaskType } from '@/types/tasks/taskType';
 
 interface TargetTaskSectionProps {
@@ -11,35 +12,41 @@ interface TargetTaskSectionProps {
 	tasks: TaskType[];
 }
 function TargetTaskSection(props: TargetTaskSectionProps) {
-	const { handleSelectedTarget, selectedTarget, tasks } = props;
-
+	const { handleSelectedTarget, selectedTarget } = props;
+	const targetDate = '2024-07-17';
+	const { isFetched, data } = useGetTasks({ targetDate });
+	console.log(data);
 	return (
 		<BtnTaskContainer type="target">
-			{tasks.map((task, index) => (
-				<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
-					{(provided, snapshot) => (
-						<div
-							ref={provided.innerRef}
-							{...provided.draggableProps}
-							{...provided.dragHandleProps}
-							style={{ userSelect: 'none', ...provided.draggableProps.style }}
-						>
-							<BtnTask
-								iconType="active"
-								key={task.id}
-								hasDescription={task.hasDescription}
-								name={task.name}
-								deadLine={task.deadLine}
-								status={task.status}
-								id={task.id}
-								handleSelectedTarget={handleSelectedTarget}
-								selectedTarget={selectedTarget}
-								isDragging={snapshot.isDragging}
-							/>
-						</div>
-					)}
-				</Draggable>
-			))}
+			{isFetched && (
+				<>
+					{data.data.tasks.map((task: TaskType, index: number) => (
+						<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
+							{(provided, snapshot) => (
+								<div
+									ref={provided.innerRef}
+									{...provided.draggableProps}
+									{...provided.dragHandleProps}
+									style={{ userSelect: 'none', ...provided.draggableProps.style }}
+								>
+									<BtnTask
+										iconType="active"
+										key={task.id}
+										hasDescription={task.hasDescription}
+										name={task.name}
+										deadLine={task.deadLine}
+										status={task.status}
+										id={task.id}
+										handleSelectedTarget={handleSelectedTarget}
+										selectedTarget={selectedTarget}
+										isDragging={snapshot.isDragging}
+									/>
+								</div>
+							)}
+						</Draggable>
+					))}
+				</>
+			)}
 		</BtnTaskContainer>
 	);
 }

--- a/src/utils/formatDatetoLocalDate.ts
+++ b/src/utils/formatDatetoLocalDate.ts
@@ -1,0 +1,12 @@
+/** Date 형식을 0000-00-00 형식 string 으로 반환합니다 */
+const formatDatetoLocalDate = (date: Date | null) => {
+	if (date) {
+		const year = date.getFullYear();
+		const month = '0'.concat((date.getMonth() + 1).toString()).slice(-2);
+		const day = '0'.concat(date.getDate().toString()).slice(-2);
+		return `${year}-${month}-${day}`;
+	}
+	return '';
+};
+
+export default formatDatetoLocalDate;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- TargetArea 쪽 더미데이터 빼고 api 연결했습니다
- date 전달 위해서 유틸에 LocalDate 포맷으로 변경하는 함수 하나 더 만들었습니다.


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요



## 관련 이슈

close #173 

## 스크린샷 (선택)
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/3ef2bb02-20b3-4f20-a8db-3028779add39">
