### PR TITLE
[FEAT] Task type별 리스트 조회 api 연결

### DIFF
--- a/src/apis/dashboard/tasksToday/TasksTodayType.ts
+++ b/src/apis/dashboard/tasksToday/TasksTodayType.ts
@@ -1,0 +1,1 @@
+export type TasksTodayType = 'upcoming' | 'inprogress' | 'deferred';

--- a/src/apis/dashboard/tasksToday/axios.ts
+++ b/src/apis/dashboard/tasksToday/axios.ts
@@ -1,0 +1,14 @@
+import { TasksTodayType } from './TasksTodayType';
+
+import { privateInstance } from '@/apis/instance';
+
+const getTasksToday = async (type: TasksTodayType) => {
+	const { data } = await privateInstance.get('/api/tasks/today', {
+		params: {
+			type,
+		},
+	});
+	return data;
+};
+
+export default getTasksToday;

--- a/src/apis/dashboard/tasksToday/query.ts
+++ b/src/apis/dashboard/tasksToday/query.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import getTasksToday from './axios';
+import { TasksTodayType } from './TasksTodayType';
+
+/** TaskToday 리스트 조회 */
+const useGetTasksToday = (type: TasksTodayType) =>
+	useQuery({
+		queryKey: ['dashboard', type],
+		queryFn: () => getTasksToday(type),
+	});
+
+export default useGetTasksToday;

--- a/src/apis/dashboard/tasksToday/query.ts
+++ b/src/apis/dashboard/tasksToday/query.ts
@@ -3,11 +3,37 @@ import { useQuery } from '@tanstack/react-query';
 import getTasksToday from './axios';
 import { TasksTodayType } from './TasksTodayType';
 
+const placeholderData = {
+	code: 'success',
+	data: {
+		tasks: [
+			{
+				id: 1,
+				name: 'task name',
+				deadLine: {
+					date: '2024-06-30',
+					time: '12:30',
+				},
+			},
+			{
+				id: 2,
+				name: 'task name',
+				deadLine: {
+					date: '2024-06-30',
+					time: '12:30',
+				},
+			},
+		],
+	},
+	message: null,
+};
+
 /** TaskToday 리스트 조회 */
 const useGetTasksToday = (type: TasksTodayType) =>
 	useQuery({
 		queryKey: ['dashboard', type],
 		queryFn: () => getTasksToday(type),
+		placeholderData,
 	});
 
 export default useGetTasksToday;

--- a/src/apis/tasks/getTask/axios.ts
+++ b/src/apis/tasks/getTask/axios.ts
@@ -1,16 +1,26 @@
+import { isAxiosError } from 'axios';
+
 import { GetTasksType } from './GetTasksType';
 
 import { privateInstance } from '@/apis/instance';
 
 const getTasks = async ({ isTotal, sortOrder, targetDate }: GetTasksType) => {
-	const { data } = await privateInstance.get('/api/tasks', {
-		params: {
-			isTotal,
-			order: sortOrder,
-			targetDate,
-		},
-	});
-	return data;
+	try {
+		const { data } = await privateInstance.get('/api/tasks', {
+			params: {
+				isTotal,
+				order: sortOrder,
+				targetDate,
+			},
+		});
+		return data;
+	} catch (error) {
+		if (isAxiosError(error)) {
+			console.log('Axios error occurred:', error.message);
+		} else {
+			throw new Error('An unexpected error occurred');
+		}
+	}
 };
 
 export default getTasks;

--- a/src/apis/tasks/getTask/axios.ts
+++ b/src/apis/tasks/getTask/axios.ts
@@ -20,6 +20,7 @@ const getTasks = async ({ isTotal, sortOrder, targetDate }: GetTasksType) => {
 		} else {
 			throw new Error('An unexpected error occurred');
 		}
+		return null;
 	}
 };
 

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -62,11 +62,9 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 									iconType="active"
 								/>
 							))}
-							<ScrollGradient />
 						</>
 					)
 				)}
-
 				<ScrollGradient />
 			</ScrollArea>
 		</TaskLayout>

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -1,16 +1,17 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
+import useGetTasksToday from '@/apis/dashboard/tasksToday/query';
 import BtnTask from '@/components/common/BtnTask/BtnTask';
 import ScrollGradient from '@/components/common/ScrollGradient';
 import TODAY from '@/constants/tasksToday';
 import { TaskType } from '@/types/tasks/taskType';
 
 interface DashboardTaskProps {
-	text: 'upcoming' | 'postponed' | 'inprogress';
 	taskStatus: string;
 	emptyStatus: string;
 	emptyImg: string;
+	text: 'upcoming' | 'deferred' | 'inprogress';
 }
 function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTaskProps) {
 	const [selectedTarget, setSelectedTarget] = useState<TaskType | null>(null);
@@ -24,48 +25,8 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 		height: auto;
 	`;
 
-	const dummyTaskList: TaskType[] = [
-		{
-			id: 10,
-			name: '바보~',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: false,
-			status: '진행중',
-		},
-		{
-			id: 11,
-			name: '넛수레',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '지연',
-		},
-		{
-			id: 12,
-			name: '콘하스',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '완료',
-		},
-		{
-			id: 13,
-			name: '김지원',
-			deadLine: {
-				date: '2024-06-30',
-				time: '12:30',
-			},
-			hasDescription: true,
-			status: '미완료',
-		},
-	];
+	const { isFetched, data } = useGetTasksToday(text);
+
 	return (
 		<TaskLayout>
 			<TextBox>
@@ -75,6 +36,7 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 					<NumberText>개</NumberText>
 				</NumberTextBox>
 			</TextBox>
+
 			<ScrollArea>
 				{TODAY.data.tasks.length === 0 ? (
 					<EmptyWrapper>
@@ -84,24 +46,28 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 						<EmptyText text={text}>{emptyStatus}</EmptyText>
 					</EmptyWrapper>
 				) : (
-					<>
-						{dummyTaskList.map((task) => (
-							<BtnTask
-								key={task.id + task.name}
-								hasDescription={task.hasDescription}
-								id={task.id}
-								name={task.name}
-								status={task.status}
-								deadLine={task.deadLine}
-								selectedTarget={selectedTarget}
-								preventDoubleClick
-								handleSelectedTarget={handleSelectedTarget}
-								iconType="active"
-							/>
-						))}
-						<ScrollGradient />
-					</>
+					isFetched && (
+						<>
+							{data.data.tasks.map((task: TaskType) => (
+								<BtnTask
+									key={task.id + task.name}
+									hasDescription={task.hasDescription}
+									id={task.id}
+									name={task.name}
+									status={task.status}
+									deadLine={task.deadLine}
+									selectedTarget={selectedTarget}
+									preventDoubleClick
+									handleSelectedTarget={handleSelectedTarget}
+									iconType="active"
+								/>
+							))}
+							<ScrollGradient />
+						</>
+					)
 				)}
+
+				<ScrollGradient />
 			</ScrollArea>
 		</TaskLayout>
 	);

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 
 import useGetTasksToday from '@/apis/dashboard/tasksToday/query';
 import BtnTask from '@/components/common/BtnTask/BtnTask';
-import ScrollGradient from '@/components/common/ScrollGradient';
 import TODAY from '@/constants/tasksToday';
 import { TaskType } from '@/types/tasks/taskType';
 
@@ -65,7 +64,6 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 						</>
 					)
 				)}
-				<ScrollGradient />
 			</ScrollArea>
 		</TaskLayout>
 	);

--- a/src/components/DashboardPage/DashboardTask.tsx
+++ b/src/components/DashboardPage/DashboardTask.tsx
@@ -24,7 +24,7 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 		height: auto;
 	`;
 
-	const { isFetched, data } = useGetTasksToday(text);
+	const { data } = useGetTasksToday(text);
 
 	return (
 		<TaskLayout>
@@ -37,7 +37,7 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 			</TextBox>
 
 			<ScrollArea>
-				{TODAY.data.tasks.length === 0 ? (
+				{data.data.tasks.length === 0 ? (
 					<EmptyWrapper>
 						<EmptyImageWrapper>
 							<ImageComponent src={emptyImg} />
@@ -45,24 +45,22 @@ function DashboardTask({ text, taskStatus, emptyStatus, emptyImg }: DashboardTas
 						<EmptyText text={text}>{emptyStatus}</EmptyText>
 					</EmptyWrapper>
 				) : (
-					isFetched && (
-						<>
-							{data.data.tasks.map((task: TaskType) => (
-								<BtnTask
-									key={task.id + task.name}
-									hasDescription={task.hasDescription}
-									id={task.id}
-									name={task.name}
-									status={task.status}
-									deadLine={task.deadLine}
-									selectedTarget={selectedTarget}
-									preventDoubleClick
-									handleSelectedTarget={handleSelectedTarget}
-									iconType="active"
-								/>
-							))}
-						</>
-					)
+					<>
+						{data.data.tasks.map((task: TaskType) => (
+							<BtnTask
+								key={task.id + task.name}
+								hasDescription={task.hasDescription}
+								id={task.id}
+								name={task.name}
+								status={task.status}
+								deadLine={task.deadLine}
+								selectedTarget={selectedTarget}
+								preventDoubleClick
+								handleSelectedTarget={handleSelectedTarget}
+								iconType="active"
+							/>
+						))}
+					</>
 				)}
 			</ScrollArea>
 		</TaskLayout>

--- a/src/components/DashboardPage/DashboardTaskWrapper.tsx
+++ b/src/components/DashboardPage/DashboardTaskWrapper.tsx
@@ -14,7 +14,7 @@ function DashboardTaskWrapper() {
 				emptyImg={Images.EMPTY.taskImg}
 			/>
 			<DashboardTask
-				text="postponed"
+				text="deferred"
 				taskStatus={DASHBOARD_TASK_TYPE.POSTPONED}
 				emptyStatus={DASHBOARD_TASK_TYPE.EMPTYPOSTPONE}
 				emptyImg={Images.EMPTY.postponeImg}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- Task type별 리스트 조회 api 연결


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 프론트에서 상태 중에 postponed 를 서버 상태와 통일하기 위해 deferred 로 변경했습니다

## 관련 이슈

close #179 

## 스크린샷 (선택)
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/110804d1-e0d5-4b87-8527-a49cf8882647">
