### PR TITLE
[FEAT] 로그아웃 api 연결

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 
 import { LoginResponse } from '@/apis/login/loginInterface';
 import MESSAGES from '@/apis/messages';
@@ -24,17 +24,22 @@ export const privateInstance = axios.create({
 
 // refresh token api
 export async function postRefreshToken() {
-	const response = await axios.post<LoginResponse>(
-		`${API_URL}/api/auth/re-issue`,
-		{},
-		{
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
-			},
-		}
-	);
-	return response;
+	try {
+		const response = await axios.post<LoginResponse>(
+			`${API_URL}/api/auth/re-issue`,
+			{},
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+				},
+			}
+		);
+		return response;
+	} catch (error) {
+		if (isAxiosError(error)) throw error;
+		else throw new Error(MESSAGES.UNKNOWN_ERROR);
+	}
 }
 
 privateInstance.interceptors.response.use(
@@ -49,23 +54,24 @@ privateInstance.interceptors.response.use(
 		// 토큰이 만료되을 때
 		if (status === 401) {
 			const originRequest = config;
-			const response = await postRefreshToken();
-
-			// 리프레시 토큰 요청이 성공할 때
-			if (response.status === 200) {
-				const newAccessToken = response.data.data.accessToken;
-				localStorage.setItem('accessToken', newAccessToken);
-				localStorage.setItem('refreshToken', response.data.data.refreshToken);
-				axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
-				// 진행중이던 요청 이어서하기
-				originRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-				return axios(originRequest);
-			}
-			if (response.status === 401) {
+			try {
+				const response = await postRefreshToken();
+				// 리프레시 토큰 요청이 성공할 때
+				if (response.status === 200) {
+					const newAccessToken = response.data.data.accessToken;
+					localStorage.setItem('accessToken', newAccessToken);
+					localStorage.setItem('refreshToken', response.data.data.refreshToken);
+					axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+					// 진행중이던 요청 이어서하기
+					originRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+					return await axios(originRequest);
+				}
+			} catch (err) {
+				// 리프레시 토큰 요청이 실패할 때
+				localStorage.removeItem('accessToken');
+				localStorage.removeItem('refreshToken');
 				alert(MESSAGES.LOGIN.EXPIRED);
 				window.location.replace('/');
-			} else {
-				alert(MESSAGES.UNKNOWN_ERROR);
 			}
 		}
 		return Promise.reject(error);

--- a/src/apis/logout/logoutAxios.ts
+++ b/src/apis/logout/logoutAxios.ts
@@ -1,0 +1,20 @@
+import { isAxiosError } from 'axios';
+
+import { privateInstance } from '@/apis/instance';
+import MESSAGES from '@/apis/messages';
+
+const AUTH_URL = {
+	LOGOUT: '/api/auth/logout',
+};
+
+const userLogout = async () => {
+	try {
+		const response = await privateInstance.delete(AUTH_URL.LOGOUT);
+		return response.data;
+	} catch (error) {
+		if (isAxiosError(error)) throw error;
+		else throw new Error(MESSAGES.UNKNOWN_ERROR);
+	}
+};
+
+export default userLogout;

--- a/src/components/SettingPage/LogOutBtn.tsx
+++ b/src/components/SettingPage/LogOutBtn.tsx
@@ -4,14 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import userLogout from '@/apis/logout/logoutAxios';
 
 function LogOutBtn() {
-	const navigator = useNavigate();
+	const navigate = useNavigate();
 
 	const handleLogoutButton = async () => {
 		try {
 			await userLogout();
 			localStorage.removeItem('accessToken');
 			localStorage.removeItem('refreshToken');
-			navigator('/');
+			navigate('/');
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/components/SettingPage/LogOutBtn.tsx
+++ b/src/components/SettingPage/LogOutBtn.tsx
@@ -1,7 +1,23 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import userLogout from '@/apis/logout/logoutAxios';
 
 function LogOutBtn() {
-	return <LogOutBox>로그아웃</LogOutBox>;
+	const navigator = useNavigate();
+
+	const handleLogoutButton = async () => {
+		try {
+			await userLogout();
+			localStorage.removeItem('accessToken');
+			localStorage.removeItem('refreshToken');
+			navigator('/');
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
+	return <LogOutBox onClick={handleLogoutButton}>로그아웃</LogOutBox>;
 }
 
 export default LogOutBtn;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 로그아웃 시 localstorage를 지우고 로그인 페이지로 redirect 되도록 하였습니다.
- accessToken과 refreshToken이 둘 다 만료 또는 유효하지 않을 시 "로그인이 만료되었습니다. 다시 시도해주세요." 라는 alet이 뜨고 로그인 페이지로 redirect 되도록 코드를 수정하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 폴더구조 변경 혹은 더 추가로 로그인페이지로 리다이렉트가 필요한 부분이 있다면 말씀해주세요!

## 관련 이슈

close #167 

## 스크린샷 (선택)

https://github.com/user-attachments/assets/aa3fd34b-a468-4e2d-bdfd-281f72be0f33


