### PR TITLE
[FEAT] Task 상태 수정 api (드래그앤드롭 부분 우선 구현)

### DIFF
--- a/src/apis/tasks/getTask/GetTasksResponse.ts
+++ b/src/apis/tasks/getTask/GetTasksResponse.ts
@@ -1,0 +1,9 @@
+import { TaskType } from '@/types/tasks/taskType';
+
+export interface GetTasksResponse {
+	code: string;
+	data: {
+		tasks: TaskType[];
+	};
+	message: string | null;
+}

--- a/src/apis/tasks/getTask/query.ts
+++ b/src/apis/tasks/getTask/query.ts
@@ -3,31 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import getTasks from './axios';
 import { GetTasksType } from './GetTasksType';
 
-const placeholderData = {
-	code: 'success',
-	data: {
-		tasks: [
-			{
-				id: 1,
-				name: 'task name',
-				deadLine: {
-					date: '2024-06-30',
-					time: '12:30',
-				},
-			},
-			{
-				id: 2,
-				name: 'task name',
-				deadLine: {
-					date: '2024-06-30',
-					time: '12:30',
-				},
-			},
-		],
-	},
-	message: null,
-};
-
 /** Task 리스트 조회 */
 const useGetTasks = ({ isTotal, sortOrder, targetDate }: GetTasksType) =>
 	useQuery({

--- a/src/apis/tasks/getTask/query.ts
+++ b/src/apis/tasks/getTask/query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import getTasks from './axios';
+import { GetTasksResponse } from './GetTasksResponse';
 import { GetTasksType } from './GetTasksType';
 
 const placeholderData = {
@@ -29,7 +30,7 @@ const placeholderData = {
 };
 
 /** Task 리스트 조회 */
-const useGetTasks = ({ isTotal, sortOrder, targetDate }: GetTasksType) =>
+const useGetTasks = ({ isTotal, sortOrder, targetDate }: GetTasksType, placeholderData?: GetTasksResponse) =>
 	useQuery({
 		queryKey: ['today', isTotal, sortOrder, targetDate],
 		queryFn: () => getTasks({ isTotal, sortOrder, targetDate }),

--- a/src/apis/tasks/getTask/query.ts
+++ b/src/apis/tasks/getTask/query.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
 import getTasks from './axios';
-import { GetTasksResponse } from './GetTasksResponse';
 import { GetTasksType } from './GetTasksType';
 
 const placeholderData = {
@@ -30,11 +29,17 @@ const placeholderData = {
 };
 
 /** Task 리스트 조회 */
-const useGetTasks = ({ isTotal, sortOrder, targetDate }: GetTasksType, placeholderData?: GetTasksResponse) =>
+const useGetTasks = ({ isTotal, sortOrder, targetDate }: GetTasksType) =>
 	useQuery({
 		queryKey: ['today', isTotal, sortOrder, targetDate],
 		queryFn: () => getTasks({ isTotal, sortOrder, targetDate }),
-		placeholderData,
+		placeholderData: {
+			code: 'success',
+			data: {
+				tasks: [],
+			},
+			message: null,
+		},
 	});
 
 export default useGetTasks;

--- a/src/apis/tasks/updateTaskStatus/UpdateTaskStatusType.ts
+++ b/src/apis/tasks/updateTaskStatus/UpdateTaskStatusType.ts
@@ -1,0 +1,5 @@
+export interface UpdateTaskStatusType {
+	taskId: number;
+	targetDate: string | null;
+	status: string;
+}

--- a/src/apis/tasks/updateTaskStatus/UpdateTaskStatusType.ts
+++ b/src/apis/tasks/updateTaskStatus/UpdateTaskStatusType.ts
@@ -1,5 +1,5 @@
 export interface UpdateTaskStatusType {
 	taskId: number;
-	targetDate: string | null;
-	status: string;
+	targetDate?: string | null;
+	status?: string | null;
 }

--- a/src/apis/tasks/updateTaskStatus/axios.ts
+++ b/src/apis/tasks/updateTaskStatus/axios.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+import { UpdateTaskStatusType } from './UpdateTaskStatusType';
+
+const updateTaskStatus = async ({ taskId, targetDate, status }: UpdateTaskStatusType) => {
+	await axios.patch(`/api/tasks/${taskId}`, {
+		targetDate,
+		status,
+	});
+};
+
+export default updateTaskStatus;

--- a/src/apis/tasks/updateTaskStatus/axios.ts
+++ b/src/apis/tasks/updateTaskStatus/axios.ts
@@ -1,9 +1,9 @@
-import axios from 'axios';
-
 import { UpdateTaskStatusType } from './UpdateTaskStatusType';
 
+import { privateInstance } from '@/apis/instance';
+
 const updateTaskStatus = async ({ taskId, targetDate, status }: UpdateTaskStatusType) => {
-	await axios.patch(`/api/tasks/${taskId}`, {
+	await privateInstance.patch(`/api/tasks/${taskId}/status`, {
 		targetDate,
 		status,
 	});

--- a/src/apis/tasks/updateTaskStatus/query.ts
+++ b/src/apis/tasks/updateTaskStatus/query.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import updateTaskStatus from './axios';
+import { UpdateTaskStatusType } from './UpdateTaskStatusType';
+
+const useUpdateTaskStatus = () => {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: (updateData: UpdateTaskStatusType) => updateTaskStatus(updateData),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
+	});
+
+	return { mutate: mutation.mutate, queryClient };
+};
+
+export default useUpdateTaskStatus;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -3,21 +3,31 @@ import { Droppable } from 'react-beautiful-dnd';
 
 import StagingAreaTaskContainer from './StagingAreaTaskContainer';
 
+import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
 import TextInputStaging from '@/components/common/textbox/TextInputStaging';
 import { TaskType } from '@/types/tasks/taskType';
+import { StagingAreaSettingProps } from '@/types/today/stagingAreaSettingProps';
 
-interface StagingAreaProps {
+interface StagingAreaProps extends StagingAreaSettingProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
 	tasks: TaskType[];
 }
+
 function StagingArea(props: StagingAreaProps) {
-	const { handleSelectedTarget, selectedTarget, tasks } = props;
+	const { handleSelectedTarget, selectedTarget, tasks, activeButton, sortOrder, handleTextBtnClick, handleSortOrder } =
+		props;
 	return (
 		<StagingAreaLayout>
 			<StagingAreaContainer>
 				<StagingAreaUpContainer>
 					<StagingAreaTitle>쏟아내기</StagingAreaTitle>
+					<StagingAreaSetting
+						handleTextBtnClick={handleTextBtnClick}
+						activeButton={activeButton}
+						sortOrder={sortOrder}
+						handleSortOrder={handleSortOrder}
+					/>
 					<Droppable droppableId="staging">
 						{(provided) => (
 							<div ref={provided.innerRef} {...provided.droppableProps}>

--- a/src/components/common/StagingArea/StagingAreaSetting.tsx
+++ b/src/components/common/StagingArea/StagingAreaSetting.tsx
@@ -6,14 +6,8 @@ import TextBtn from '../button/textBtn/TextBtn';
 import ModalArrange from '../modal/ModalArrange/ModalArrange';
 import ModalBackdrop from '../modal/ModalBackdrop';
 
-import { SortOrderType } from '@/types/sortOrderType';
+import { StagingAreaSettingProps } from '@/types/today/stagingAreaSettingProps';
 
-interface StagingAreaSettingProps {
-	handleTextBtnClick: (button: '전체' | '지연') => void;
-	activeButton: '전체' | '지연';
-	sortOrder: SortOrderType;
-	handleSortOrder: (order: SortOrderType) => void;
-}
 function StagingAreaSetting({ handleTextBtnClick, activeButton, sortOrder, handleSortOrder }: StagingAreaSettingProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -1,15 +1,10 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
 import BtnTaskContainer from '../BtnTaskContainer';
 import EmptyContainer from '../EmptyContainer';
-import ScrollGradient from '../ScrollGradient';
 
-import useGetTasks from '@/apis/tasks/getTask/query';
 import BtnTask from '@/components/common/BtnTask/BtnTask';
-import StagingAreaSetting from '@/components/common/StagingArea/StagingAreaSetting';
-import { SortOrderType } from '@/types/sortOrderType';
 import { TaskType } from '@/types/tasks/taskType';
 
 interface StagingAreaTaskContainerProps {
@@ -18,38 +13,15 @@ interface StagingAreaTaskContainerProps {
 	tasks: TaskType[];
 }
 
-function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget }: StagingAreaTaskContainerProps) {
-	const [activeButton, setActiveButton] = useState<'전체' | '지연'>('전체');
-	const [sortOrder, setSortOrder] = useState<SortOrderType>('recent');
-	const isTotal = activeButton === '전체';
-
-	// Task 목록 Get
-	const { data } = useGetTasks({ isTotal, sortOrder });
-
-	/** isTotal 핸들링 함수 */
-	const handleTextBtnClick = (button: '전체' | '지연') => {
-		setActiveButton(button);
-	};
-
-	const handleSortOrder = (order: SortOrderType) => {
-		setSortOrder(order);
-	};
-	console.log(data);
-
+function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget, tasks }: StagingAreaTaskContainerProps) {
 	return (
 		<StagingAreaTaskContainerLayout>
-			<StagingAreaSetting
-				handleTextBtnClick={handleTextBtnClick}
-				activeButton={activeButton}
-				sortOrder={sortOrder}
-				handleSortOrder={handleSortOrder}
-			/>
 			<BtnTaskContainer type="staging">
-				{data.data.tasks.length === 0 ? (
+				{tasks.length === 0 ? (
 					<EmptyContainer />
 				) : (
 					<>
-						{data.data.tasks.map((task: TaskType, index: number) => (
+						{tasks.map((task: TaskType, index: number) => (
 							<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
 								{(provided, snapshot) => (
 									<div
@@ -59,15 +31,15 @@ function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget }: Stag
 										style={{ userSelect: 'none', ...provided.draggableProps.style }}
 									>
 										<BtnTask
-											key={task.id + task.name}
-											iconType="stagingOrDelayed"
+											iconType="active"
+											key={task.id}
 											hasDescription={task.hasDescription}
-											id={task.id}
 											name={task.name}
-											status={task.status}
 											deadLine={task.deadLine}
-											selectedTarget={selectedTarget}
+											status={task.status}
+											id={task.id}
 											handleSelectedTarget={handleSelectedTarget}
+											selectedTarget={selectedTarget}
 											isDragging={snapshot.isDragging}
 										/>
 									</div>
@@ -76,8 +48,6 @@ function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget }: Stag
 						))}
 					</>
 				)}
-
-				<ScrollGradient />
 			</BtnTaskContainer>
 		</StagingAreaTaskContainerLayout>
 	);
@@ -88,7 +58,7 @@ export default StagingAreaTaskContainer;
 const StagingAreaTaskContainerLayout = styled.div`
 	display: flex;
 	flex-direction: column;
-	gap: 1.3rem;
 	align-items: flex-start;
 	align-self: stretch;
+	margin-top: 1.3rem;
 `;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 import { Droppable } from 'react-beautiful-dnd';
 
 import TargetAreaDate from './TargetAreaDate';
@@ -7,36 +6,24 @@ import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
 
 import { TaskType } from '@/types/tasks/taskType';
+import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
 
-interface TargetAreaProps {
+interface TargetAreaProps extends TargetControlSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
 	tasks: TaskType[];
 }
 
-function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
-	const [targetDate, setTargetDate] = useState(new Date());
-
-	const handlePrevBtn = () => {
-		const newDate = new Date(targetDate);
-		newDate.setDate(newDate.getDate() - 1);
-		setTargetDate(newDate);
-	};
-
-	const handleNextBtn = () => {
-		const newDate = new Date(targetDate);
-		newDate.setDate(newDate.getDate() + 1);
-		setTargetDate(newDate);
-	};
-
-	const handleTodayBtn = () => {
-		setTargetDate(new Date());
-	};
-
-	const handleChangeDate = (target: Date) => {
-		setTargetDate(target);
-	};
-
+function TargetArea({
+	handleSelectedTarget,
+	selectedTarget,
+	tasks,
+	onClickPrevDate,
+	onClickNextDate,
+	onClickTodayDate,
+	onClickDatePicker,
+	targetDate,
+}: TargetAreaProps) {
 	return (
 		<TargetAreaLayout>
 			{/* 날짜 */}
@@ -46,10 +33,10 @@ function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
 
 			{/* 버튼 */}
 			<TargetControlSection
-				onClickPrevDate={handlePrevBtn}
-				onClickNextDate={handleNextBtn}
-				onClickTodayDate={handleTodayBtn}
-				onClickDatePicker={handleChangeDate}
+				onClickPrevDate={onClickPrevDate}
+				onClickNextDate={onClickNextDate}
+				onClickTodayDate={onClickTodayDate}
+				onClickDatePicker={onClickDatePicker}
 				targetDate={targetDate}
 			/>
 			{/* 태스크 목록 */}
@@ -59,7 +46,7 @@ function TargetArea({ handleSelectedTarget, selectedTarget }: TargetAreaProps) {
 						<TargetTaskSection
 							handleSelectedTarget={handleSelectedTarget}
 							selectedTarget={selectedTarget}
-							selectedDate={targetDate}
+							tasks={tasks}
 						/>
 						{provided.placeholder}
 					</div>

--- a/src/components/targetArea/TargetAreaDate.tsx
+++ b/src/components/targetArea/TargetAreaDate.tsx
@@ -6,12 +6,15 @@ import formatDatetoStrinKor from '@/utils/formatDatetoStringKor';
 interface TargetAreaDateProps {
 	targetDate: Date;
 }
+
 function TargetAreaDate({ targetDate }: TargetAreaDateProps) {
 	const formatDate = formatDatetoStrinKor(targetDate);
 	return <DateText>{formatDate}</DateText>;
 }
+
 const DateText = styled.h2`
 	${({ theme }) => theme.fontTheme.HEADLINE_02};
 	padding: 0.7rem 0.2rem 0.7rem 1rem;
 `;
+
 export default TargetAreaDate;

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -6,15 +6,8 @@ import TextBtn from '@/components/common/button/textBtn/TextBtn';
 import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
 import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
 import MODAL from '@/constants/modalLocation';
+import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
 import formatDatetoString from '@/utils/formatDatetoString';
-
-interface TargetControlSectionProps {
-	onClickPrevDate: () => void;
-	onClickNextDate: () => void;
-	onClickTodayDate: () => void;
-	onClickDatePicker: (target: Date) => void;
-	targetDate: Date;
-}
 
 function TargetControlSection({
 	onClickPrevDate,

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -5,28 +5,25 @@ import BtnTask from '../common/BtnTask/BtnTask';
 import BtnTaskContainer from '../common/BtnTaskContainer';
 import EmptyContainer from '../common/EmptyContainer';
 
-import useGetTasks from '@/apis/tasks/getTask/query';
 import { TaskType } from '@/types/tasks/taskType';
-import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
-	selectedDate: Date | null;
+	tasks: TaskType[];
 }
 function TargetTaskSection(props: TargetTaskSectionProps) {
-	const { handleSelectedTarget, selectedTarget, selectedDate } = props;
-	const targetDate = formatDatetoLocalDate(selectedDate);
-	const { data } = useGetTasks({ targetDate });
+	const { handleSelectedTarget, selectedTarget, tasks } = props;
+
 	return (
 		<BtnTaskContainer type="target">
-			{data.data.tasks.length === 0 ? (
+			{tasks.length === 0 ? (
 				<EmptyLayout>
 					<EmptyContainer />
 				</EmptyLayout>
 			) : (
 				<>
-					{data.data.tasks.map((task: TaskType, index: number) => (
+					{tasks.map((task: TaskType, index: number) => (
 						<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
 							{(provided, snapshot) => (
 								<div

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
+import { GetTasksResponse } from '@/apis/tasks/getTask/GetTasksResponse';
 import useGetTasks from '@/apis/tasks/getTask/query';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import NavBar from '@/components/common/NavBar';
@@ -55,9 +56,17 @@ function Today() {
 	const isTotal = activeButton === '전체';
 
 	// Task 목록 Get
+	const [previousStagingData, setPreviousStagingData] = useState<GetTasksResponse | undefined>(undefined);
+	const [previousTargetData, setPreviousTargetData] = useState<GetTasksResponse | undefined>(undefined);
 
 	/** StagingArea */
-	const { isFetched: isStagingFetched, data: stagingData } = useGetTasks({ isTotal, sortOrder });
+	const { isFetched: isStagingFetched, data: stagingData } = useGetTasks({ isTotal, sortOrder }, previousStagingData);
+
+	useEffect(() => {
+		if (isStagingFetched && stagingData) {
+			setPreviousStagingData(stagingData);
+		}
+	}, [isStagingFetched, stagingData]);
 
 	console.log('stagingArea_taskList', stagingData);
 
@@ -79,7 +88,13 @@ function Today() {
 
 	const targetDate = formatDatetoLocalDate(selectedDate);
 
-	const { isFetched: isTargetFetched, data: targetData } = useGetTasks({ targetDate });
+	const { isFetched: isTargetFetched, data: targetData } = useGetTasks({ targetDate }, previousTargetData);
+
+	useEffect(() => {
+		if (isTargetFetched && targetData) {
+			setPreviousTargetData(targetData);
+		}
+	}, [isTargetFetched, targetData]);
 
 	console.log('targetArea_taskList', stagingData);
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -1,11 +1,9 @@
 import styled from '@emotion/styled';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
 import useGetTasks from '@/apis/tasks/getTask/query';
-import updateTaskStatus from '@/apis/tasks/updateTaskStatus/axios';
-import { UpdateTaskStatusType } from '@/apis/tasks/updateTaskStatus/UpdateTaskStatusType';
+import useUpdateTaskStatus from '@/apis/tasks/updateTaskStatus/query';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import NavBar from '@/components/common/NavBar';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
@@ -18,12 +16,14 @@ function Today() {
 	const [selectedTarget, setSelectedTarget] = useState<TaskType | null>(null);
 	const [activeButton, setActiveButton] = useState<'전체' | '지연'>('전체');
 	const [sortOrder, setSortOrder] = useState<SortOrderType>('recent');
-	const isTotal = activeButton === '전체';
 	const [selectedDate, setTargetDate] = useState(new Date());
+	const isTotal = activeButton === '전체';
+	const targetDate = formatDatetoLocalDate(selectedDate);
 
 	// Task 목록 Get
-	/** StagingArea */
 	const { data: stagingData } = useGetTasks({ isTotal, sortOrder });
+	const { data: targetData } = useGetTasks({ targetDate });
+	const { mutate, queryClient } = useUpdateTaskStatus();
 
 	/** isTotal 핸들링 함수 */
 	const handleTextBtnClick = (button: '전체' | '지연') => {
@@ -57,18 +57,6 @@ function Today() {
 	const handleChangeDate = (target: Date) => {
 		setTargetDate(target);
 	};
-
-	const targetDate = formatDatetoLocalDate(selectedDate);
-
-	/** TargetArea */
-	const { data: targetData } = useGetTasks({ targetDate });
-
-	const queryClient = useQueryClient();
-
-	const { mutate } = useMutation({
-		mutationFn: (updateData: UpdateTaskStatusType) => updateTaskStatus(updateData),
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
-	});
 
 	const handleDragEnd = (result: DropResult) => {
 		const { source, destination } = result;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -19,10 +19,11 @@ function Today() {
 	const [activeButton, setActiveButton] = useState<'전체' | '지연'>('전체');
 	const [sortOrder, setSortOrder] = useState<SortOrderType>('recent');
 	const isTotal = activeButton === '전체';
+	const [selectedDate, setTargetDate] = useState(new Date());
 
 	// Task 목록 Get
 	/** StagingArea */
-	const { isFetched: isStagingFetched, data: stagingData } = useGetTasks({ isTotal, sortOrder });
+	const { data: stagingData } = useGetTasks({ isTotal, sortOrder });
 
 	/** isTotal 핸들링 함수 */
 	const handleTextBtnClick = (button: '전체' | '지연') => {
@@ -36,13 +37,6 @@ function Today() {
 	const handleSelectedTarget = (task: TaskType | null) => {
 		setSelectedTarget(task);
 	};
-
-	/** TargetArea */
-	const [selectedDate, setTargetDate] = useState(new Date());
-
-	const targetDate = formatDatetoLocalDate(selectedDate);
-
-	const { isFetched: isTargetFetched, data: targetData } = useGetTasks({ targetDate });
 
 	const handlePrevBtn = () => {
 		const newDate = new Date(selectedDate);
@@ -64,7 +58,13 @@ function Today() {
 		setTargetDate(target);
 	};
 
+	const targetDate = formatDatetoLocalDate(selectedDate);
+
+	/** TargetArea */
+	const { data: targetData } = useGetTasks({ targetDate });
+
 	const queryClient = useQueryClient();
+
 	const { mutate } = useMutation({
 		mutationFn: (updateData: UpdateTaskStatusType) => updateTaskStatus(updateData),
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
@@ -120,29 +120,26 @@ function Today() {
 
 			<TodayLayout>
 				<DragDropContext onDragEnd={handleDragEnd}>
-					{isStagingFetched && (
-						<StagingArea
-							handleSelectedTarget={handleSelectedTarget}
-							selectedTarget={selectedTarget}
-							tasks={stagingData.data.tasks}
-							handleSortOrder={handleSortOrder}
-							handleTextBtnClick={handleTextBtnClick}
-							activeButton={activeButton}
-							sortOrder={sortOrder}
-						/>
-					)}
-					{isTargetFetched && (
-						<TargetArea
-							handleSelectedTarget={handleSelectedTarget}
-							selectedTarget={selectedTarget}
-							tasks={targetData.data.tasks}
-							onClickPrevDate={handlePrevBtn}
-							onClickNextDate={handleNextBtn}
-							onClickTodayDate={handleTodayBtn}
-							onClickDatePicker={handleChangeDate}
-							targetDate={selectedDate}
-						/>
-					)}
+					<StagingArea
+						handleSelectedTarget={handleSelectedTarget}
+						selectedTarget={selectedTarget}
+						tasks={stagingData.data.tasks}
+						handleSortOrder={handleSortOrder}
+						handleTextBtnClick={handleTextBtnClick}
+						activeButton={activeButton}
+						sortOrder={sortOrder}
+					/>
+
+					<TargetArea
+						handleSelectedTarget={handleSelectedTarget}
+						selectedTarget={selectedTarget}
+						tasks={targetData.data.tasks}
+						onClickPrevDate={handlePrevBtn}
+						onClickNextDate={handleNextBtn}
+						onClickTodayDate={handleTodayBtn}
+						onClickDatePicker={handleChangeDate}
+						targetDate={selectedDate}
+					/>
 				</DragDropContext>
 				<CalendarWrapper>
 					<FullCalendarBox size="small" />

--- a/src/types/today/TargetControlSectionProps.ts
+++ b/src/types/today/TargetControlSectionProps.ts
@@ -1,0 +1,7 @@
+export interface TargetControlSectionProps {
+	onClickPrevDate: () => void;
+	onClickNextDate: () => void;
+	onClickTodayDate: () => void;
+	onClickDatePicker: (target: Date) => void;
+	targetDate: Date;
+}

--- a/src/types/today/stagingAreaSettingProps.ts
+++ b/src/types/today/stagingAreaSettingProps.ts
@@ -1,0 +1,8 @@
+import { SortOrderType } from '../sortOrderType';
+
+export interface StagingAreaSettingProps {
+	handleTextBtnClick: (button: '전체' | '지연') => void;
+	activeButton: '전체' | '지연';
+	sortOrder: SortOrderType;
+	handleSortOrder: (order: SortOrderType) => void;
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- Task 수정 api를 연결하였습니다.
- stagingArea <-> targetArea 드래그앤드롭 시 수정(Patch) api 호출 및 useMutation을 통한 Task 리스트 자동 업데이트 기능입니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- useQuery에 `placeholderData` 사용 시 한번 불러올 때만 깜빡임이 심하고, 그 이후에는 기존에 캐시된 값으로 깜빡임을 최소화할 수 있다는 것을 알았습니다. 

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 드래그앤드롭 시 나타나는 찰나의(아마 Fetching동안) 다시 제자리로 돌아가는 부분 수정이 필요합니다. 지속적으로 개선중에 있지만 같이 고민해주시면 감사하겠습니다..!

## 관련 이슈

close #174 

## 스크린샷 (선택)
![Jul-18-2024 14-55-06](https://github.com/user-attachments/assets/11976e6b-6965-4fc2-a051-266f2c366118)

