### PR TITLE
[FEAT] 화면 백그라운드 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
+import BackGroundLayout from './components/common/BackGroundLayout';
 import Router from './router/Router';
 
 function App() {
-	return <Router />;
+	return (
+		<BackGroundLayout>
+			<Router />
+		</BackGroundLayout>
+	);
 }
 
 export default App;

--- a/src/components/common/BackGroundLayout.tsx
+++ b/src/components/common/BackGroundLayout.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+interface BackGroundLayoutProps {
+	children: React.ReactNode;
+}
+function BackGroundLayout({ children }: BackGroundLayoutProps) {
+	return <BGLayout>{children}</BGLayout>;
+}
+const BGLayout = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100vw;
+	height: 100vh;
+
+	background-color: #000;
+`;
+export default BackGroundLayout;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -33,7 +33,7 @@ function NavBar() {
 	);
 }
 const NavBarLayout = styled.div`
-	position: fixed;
+	position: absolute;
 	left: 0;
 	z-index: 2;
 	display: flex;
@@ -41,10 +41,11 @@ const NavBarLayout = styled.div`
 	gap: 12rem;
 	align-items: center;
 	width: 7.2rem;
-	height: 100vh;
+	height: 76.8rem;
 
 	background-color: ${({ theme }) => theme.palette.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
+	border-radius: 8px 0 0 8px;
 `;
 const ProfileImg = styled.img`
 	width: 4.4rem;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -27,10 +27,14 @@ function Login() {
 }
 
 const LoginLayout = styled.div`
+	position: relative;
 	display: flex;
 	justify-content: space-between;
-	width: 100vw;
-	height: 100vh;
+	width: 136.6rem;
+	height: 76.8rem;
+
+	background-color: ${({ theme }) => theme.palette.Grey.White};
+	border-radius: 8px;
 `;
 
 const LeftSection = styled.section`
@@ -46,6 +50,8 @@ const LeftSection = styled.section`
 const LoginImg = styled.img`
 	width: 50%;
 	height: 100%;
+
+	border-radius: 0 8px 8px 0;
 `;
 
 const LogoTitleImg = styled.img`

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -12,12 +12,13 @@ function MainLayout() {
 	);
 }
 const MainLayOutContainer = styled.div`
-	box-sizing: border-box;
+	position: relative;
 	width: 136.6rem;
 	height: 76.8rem;
 	padding-left: 7.2rem;
 
-	border: 1px solid ${({ theme }) => theme.palette.Orange.Orange5};
+	background-color: ${({ theme }) => theme.palette.Grey.White};
+	border-radius: 8px;
 `;
 
 export default MainLayout;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -22,18 +22,15 @@ function NotFound() {
 }
 
 const NotFoundBgImg = styled.img`
-	position: absolute;
+	position: relative;
+	display: flex;
+	width: 136.6rem;
+	height: 76.8rem;
 
-	/* 이후 고정값으로 배경 보여줘야 할 경우 주석 풀어서 쓰세요 */
-
-	/* width: 136.6rem; */
-
-	/* height: 76.8rem; */
-	width: 100%;
-	height: 100%;
-
+	background-color: ${({ theme }) => theme.palette.Grey.White};
 	background-repeat: no-repeat;
 	background-size: contain;
+	border-radius: 8px;
 `;
 const SmallLogoImg = styled.img`
 	width: 4.3rem;
@@ -56,8 +53,8 @@ const ContentWrapper = styled.div`
 `;
 const ContentContainer = styled.div`
 	position: absolute;
-	top: 25rem;
-	left: 27.5rem;
+	top: 38rem;
+	left: 36rem;
 	z-index: 1;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 디바이스 화면 크기 대응을 위해 백그라운드를 설정했습니다
- 백그라운드 색상은 쌩블랙으로 설정했고, 
- 화면 border-radius 8px 로 설정했어요

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 기존에 Navbar를 fixed로 만들어둬서 absolute 로 고치고 상위 컴포넌트에 relative 속성 주었습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 잘되나 봐주삼

## 관련 이슈

close #208 

## 스크린샷 (선택)
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/705f2c49-a020-4d94-a7f8-6b07c2bc819a">
