### PR TITLE
[FEAT] 풀캘린더 영역 넘어가는 이벤트 글자 처리

### DIFF
--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -14,7 +14,7 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 
 	/* 이벤트 박스 */
 	.fc-event-main {
-		display: flex;
+		display: inline-block;
 		align-items: center;
 		width: 100%;
 		height: 100%;
@@ -26,6 +26,15 @@ const FullCalendarLayout = styled.div<{ size: string }>`
 		border: none;
 		border-radius: 4px;
 		${({ theme }) => theme.fontTheme.CAPTION_03};
+	}
+
+	/** 넘어가는 텍스트 처리 */
+	.fc-event-title {
+		flex-shrink: 1;
+		overflow: hidden;
+
+		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 
 	.fc-event-main .tasks {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 풀캘린더 영역 넘어가는 이벤트 글자 처리를 하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- text-overflow: ellipsis; 를 하면 텍스트가 넘칠 때. ..으로 표시해줌을 알았습니다.


## 관련 이슈

close #218

## 스크린샷 (선택)
<img width="193" alt="image" src="https://github.com/user-attachments/assets/af7ca853-187d-4edd-ac56-ac3b7dd75e3d">
