### PR TITLE
[FEAT] 구글 캘린더 동기화 버튼 api 구현

### DIFF
--- a/src/apis/timeBlocks/googleTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/googleTimeBlock/axios.ts
@@ -1,0 +1,9 @@
+import { privateInstance } from '@/apis/instance';
+
+/** 구글 캘린더 일정 동기화 요청 axios */
+const syncGoogleTimeBlock = async () => {
+	const response = await privateInstance.post(`/api/google/calendars/sync`);
+	return response;
+};
+
+export default syncGoogleTimeBlock;

--- a/src/apis/timeBlocks/googleTimeBlock/query.ts
+++ b/src/apis/timeBlocks/googleTimeBlock/query.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import syncGoogleTimeBlock from '@/apis/timeBlocks/googleTimeBlock/axios';
+
+/** 구글 캘린더 일정 동기화 react-query */
+const useSyncGoogleTimeBlock = () => {
+	const queryClient = useQueryClient();
+
+	const { mutate, isPending } = useMutation({
+		mutationFn: () => syncGoogleTimeBlock(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['timeblock'],
+			});
+		},
+	});
+
+	return { mutate, isPending };
+};
+
+export default useSyncGoogleTimeBlock;

--- a/src/components/common/button/RefreshBtn.tsx
+++ b/src/components/common/button/RefreshBtn.tsx
@@ -1,15 +1,26 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import useSyncGoogleTimeBlock from '@/apis/timeBlocks/googleTimeBlock/query';
 import Icons from '@/assets/svg/index';
+import LoadingSpinner from '@/components/common/spinner/Spinner';
 
 interface RefreshProps {
 	isDisabled: boolean;
 }
 
 function RefreshBtn({ isDisabled }: RefreshProps) {
+	const { mutate: refreshGoogle, isPending } = useSyncGoogleTimeBlock();
+
+	if (isPending) {
+		return <LoadingSpinner />;
+	}
+
+	const handleSyncBtn = () => {
+		refreshGoogle();
+	};
 	return (
-		<RefreshBtnLayout isDisabled={isDisabled} disabled={isDisabled}>
+		<RefreshBtnLayout isDisabled={isDisabled} disabled={isDisabled} onClick={handleSyncBtn}>
 			<StyledRefreshIcon />
 			<Text>동기화</Text>
 		</RefreshBtnLayout>

--- a/src/components/common/spinner/Spinner.tsx
+++ b/src/components/common/spinner/Spinner.tsx
@@ -23,11 +23,12 @@ const SpinnerContainer = styled.div`
 	align-items: center;
 	justify-content: center;
 	height: 100%;
+	margin-top: -0.8rem;
 `;
 
 const Spinner = styled.div`
-	width: 3rem;
-	height: 3rem;
+	width: 2.6rem;
+	height: 2.6rem;
 
 	border: 4px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-top: 4px solid ${({ theme }) => theme.palette.Primary};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 캘린더에서 동기화 버트을 누를 시 구글 캘린더에서 데이터베이스로 캘린더 일정이 동기화 돼서 동기화 후에 다시 캘린더 타임라인을 불러오도록 하였씁니다. 

## 알게된 점 :rocket:

> 기록하며 개발하기!

- useMuation에는 isLoading이 없어서 isPending으로 로딩 상태를 걸어 스피너를 추가하였습니다.

## 관련 이슈

close #226 

## 스크린샷 (선택)

https://github.com/user-attachments/assets/5a788b43-b2e1-4863-9d83-38e10712d656

