### PR TITLE
[FEAT] Task 상세 조회 api 연결

### DIFF
--- a/src/apis/tasks/taskDescription/TaskDescriptionType.ts
+++ b/src/apis/tasks/taskDescription/TaskDescriptionType.ts
@@ -3,21 +3,3 @@ export interface TaskDescriptionType {
 	targetDate?: string | null;
 	isOpen?: boolean;
 }
-
-// export interface TaskDescriptionResponseType {
-// 	code: string;
-// 	data?: {
-// 		name: string;
-// 		description?: string;
-// 		deadLine?: {
-// 			date?: Date;
-// 			time?: string;
-// 		};
-// 		status: string;
-// 		timeBlock?: {
-// 			id: number;
-// 			startTime: Date;
-// 			endTime: Date;
-// 		};
-// 	};
-// }

--- a/src/apis/tasks/taskDescription/TaskDescriptionType.ts
+++ b/src/apis/tasks/taskDescription/TaskDescriptionType.ts
@@ -1,0 +1,4 @@
+export interface TaskDescriptionType {
+	taskId: number;
+	targetDate?: string | null;
+}

--- a/src/apis/tasks/taskDescription/TaskDescriptionType.ts
+++ b/src/apis/tasks/taskDescription/TaskDescriptionType.ts
@@ -1,4 +1,23 @@
 export interface TaskDescriptionType {
 	taskId: number;
 	targetDate?: string | null;
+	isOpen?: boolean;
 }
+
+// export interface TaskDescriptionResponseType {
+// 	code: string;
+// 	data?: {
+// 		name: string;
+// 		description?: string;
+// 		deadLine?: {
+// 			date?: Date;
+// 			time?: string;
+// 		};
+// 		status: string;
+// 		timeBlock?: {
+// 			id: number;
+// 			startTime: Date;
+// 			endTime: Date;
+// 		};
+// 	};
+// }

--- a/src/apis/tasks/taskDescription/axios.ts
+++ b/src/apis/tasks/taskDescription/axios.ts
@@ -8,7 +8,6 @@ const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType) => {
 			targetDate,
 		},
 	});
-	console.log(data);
 	return data;
 };
 

--- a/src/apis/tasks/taskDescription/axios.ts
+++ b/src/apis/tasks/taskDescription/axios.ts
@@ -8,6 +8,7 @@ const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType) => {
 			targetDate,
 		},
 	});
+	console.log(data);
 	return data;
 };
 

--- a/src/apis/tasks/taskDescription/axios.ts
+++ b/src/apis/tasks/taskDescription/axios.ts
@@ -1,0 +1,11 @@
+import { TaskDescriptionType } from './taskDescriptionType';
+
+import { privateInstance } from '@/apis/instance';
+
+const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType) => {
+	await privateInstance.get(`/api/tasks/${taskId}`, {
+		targetDate,
+	});
+};
+
+export default taskDescription;

--- a/src/apis/tasks/taskDescription/axios.ts
+++ b/src/apis/tasks/taskDescription/axios.ts
@@ -1,11 +1,14 @@
-import { TaskDescriptionType } from './taskDescriptionType';
+import { TaskDescriptionType } from './TaskDescriptionType';
 
 import { privateInstance } from '@/apis/instance';
 
 const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType) => {
-	await privateInstance.get(`/api/tasks/${taskId}`, {
-		targetDate,
+	const { data } = await privateInstance.get(`/api/tasks/${taskId}`, {
+		params: {
+			targetDate,
+		},
 	});
+	return data;
 };
 
 export default taskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -11,6 +11,8 @@ const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType)
 		enabled: isOpen,
 	});
 
+	console.log('상세설명조회 taskId, targetDate', taskId, targetDate);
+
 	return data;
 };
 export default useTaskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 
 import taskDescription from './axios';
-import { TaskDescriptionType } from './taskDescriptionType';
+import { TaskDescriptionType } from './TaskDescriptionType';
 
 // Task 상세 설명 조회
-const useTaskDescription = ({ targetDate }: TaskDescriptionType) =>
+const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType) =>
 	useQuery({
-		queryKey: ['today', targetDate],
-		queryFn: () => taskDescription({ targetDate }),
+		queryKey: ['today', 'taskDesc', taskId, targetDate],
+		queryFn: () => taskDescription({ taskId, targetDate }),
+		enabled: isOpen,
 	});
 
 export default useTaskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -4,11 +4,13 @@ import taskDescription from './axios';
 import { TaskDescriptionType } from './TaskDescriptionType';
 
 // Task 상세 설명 조회
-const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType) =>
-	useQuery({
+const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType) => {
+	const data = useQuery({
 		queryKey: ['today', 'taskDesc', taskId, targetDate],
 		queryFn: () => taskDescription({ taskId, targetDate }),
 		enabled: isOpen,
 	});
 
+	return data;
+};
 export default useTaskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import taskDescription from './axios';
+import { TaskDescriptionType } from './taskDescriptionType';
+
+// Task 상세 설명 조회
+const useTaskDescription = ({ targetDate }: TaskDescriptionType) =>
+	useQuery({
+		queryKey: ['today', targetDate],
+		queryFn: () => taskDescription({ targetDate }),
+	});
+
+export default useTaskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -11,8 +11,6 @@ const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType)
 		enabled: isOpen,
 	});
 
-	console.log('상세설명조회 taskId, targetDate', taskId, targetDate);
-
 	return data;
 };
 export default useTaskDescription;

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -43,7 +43,7 @@ function BtnTask(props: BtnTaskProps) {
 		btnStatus,
 		preventDoubleClick = false,
 		isDragging = false,
-		targetDate,
+		targetDate = null,
 	} = props;
 	const [isModalOpen, setModalOpen] = useState(false);
 	const [isHovered, setIsHovered] = useState(false);

--- a/src/components/common/BtnTask/BtnTask.tsx
+++ b/src/components/common/BtnTask/BtnTask.tsx
@@ -2,12 +2,11 @@ import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
-import Modal from '../modal/Modal';
-
 import IconHoverContainer from './IconHoverContainer';
 
 import Icons from '@/assets/svg/index';
 import BtnDate from '@/components/common/BtnDate/BtnDate';
+import Modal from '@/components/common/modal/Modal';
 import MODAL from '@/constants/modalLocation';
 import { theme } from '@/styles/theme';
 import { TaskType } from '@/types/tasks/taskType';
@@ -127,7 +126,15 @@ function BtnTask(props: BtnTaskProps) {
 					targetDate={targetDate}
 				/>
 			</BtnTaskLayout>
-			<Modal isOpen={isModalOpen} sizeType={{ type: 'short' }} top={top} left={left} onClose={closeModal} taskId={id} />
+			<Modal
+				isOpen={isModalOpen}
+				sizeType={{ type: 'short' }}
+				top={top}
+				left={left}
+				onClose={closeModal}
+				taskId={id}
+				targetDate={targetDate}
+			/>
 		</ModalLayout>
 	);
 }

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -15,12 +15,7 @@ interface StagingAreaTaskContainerProps {
 	targetDate: string;
 }
 
-function StagingAreaTaskContainer({
-	handleSelectedTarget,
-	selectedTarget,
-	tasks,
-	targetDate,
-}: StagingAreaTaskContainerProps) {
+function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget, tasks }: StagingAreaTaskContainerProps) {
 	return (
 		<StagingAreaTaskContainerLayout>
 			<BtnTaskContainer type="staging">
@@ -48,7 +43,6 @@ function StagingAreaTaskContainer({
 											handleSelectedTarget={handleSelectedTarget}
 											selectedTarget={selectedTarget}
 											isDragging={snapshot.isDragging}
-											targetDate={targetDate}
 										/>
 									</div>
 								)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -99,8 +99,11 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullC
 	};
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
+=======
+>>>>>>> 75c073b (fix: 삽질)
 	// Get timeblock
 	const { data: timeBlockData } = useGetTimeBlock({ startDate, range });
 	console.log('timeBlockData.data.data', timeBlockData?.data.data);
@@ -108,37 +111,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullC
 	const { mutate } = usePostTimeBlock();
 
 	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data) : [];
-=======
-	const calendarEvents = [
-		{ title: 'Meeting', start: '2024-07-16T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
-		{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },
-		{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00', classNames: 'tasks' },
-		{
-			title: 'All Day Event',
-			start: '2024-07-08T10:00:00',
-			end: '2024-07-08T12:00:00',
-			allDay: true,
-			classNames: 'task',
-		},
-		{ title: 'Meeting', start: '2024-07-15T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
-		{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
-		{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
-		{
-			title: 'All Day Event',
-			start: '2024-07-12T10:00:00',
-			end: '2024-07-12T12:00:00',
-			allDay: true,
-			classNames: 'schedule',
-		},
-		{
-			title: '안녕',
-			start: '2024-07-19T10:00:00',
-			end: '2024-07-19T12:00:00',
-			allDay: false,
-			classNames: 'schedule',
-		},
-	];
->>>>>>> 0ed8365 (feat: staging area 모달 api 연결)
 
 	/** 드래그해서 이벤트 추가하기 */
 >>>>>>> 6f9f435 (feat: staging area 모달 api 연결)

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -25,10 +25,10 @@ interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
 	selectedTarget?: TaskType | null;
-	targetDate: Date | null;
+	targetDate?: Date | null;
 }
 
-function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate, selectedTarget, targetDate = null }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const todayDate = new Date().toISOString().split('T')[0];
 	const [currentView, setCurrentView] = useState('timeGridWeek');
@@ -98,22 +98,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullC
 		setModalOpen(false);
 	};
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
->>>>>>> 75c073b (fix: 삽질)
-	// Get timeblock
-	const { data: timeBlockData } = useGetTimeBlock({ startDate, range });
-	console.log('timeBlockData.data.data', timeBlockData?.data.data);
-
-	const { mutate } = usePostTimeBlock();
-
-	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data) : [];
-
-	/** 드래그해서 이벤트 추가하기 */
->>>>>>> 6f9f435 (feat: staging area 모달 api 연결)
 	const addEventWhenDragged = (selectInfo: DateSelectArg) => {
 		if (calendarRef.current && (selectedTarget?.id === 0 || selectedTarget)) {
 			const calendarApi = calendarRef.current.getApi();
@@ -241,12 +225,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullC
 					top={top}
 					left={left}
 					onClose={closeModal}
-<<<<<<< HEAD
-					taskId={5} // 예시 taskId, 실제 데이터로 교체 필요
-=======
 					taskId={5}
-					targetDate={targetDate}
->>>>>>> 0ec9b61 (feat: time block 모달 상세 구현)
+					targetDate={targetDate?.toString()}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -25,7 +25,7 @@ interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
 	selectedTarget?: TaskType | null;
-	targetDate: string | null;
+	targetDate: Date | null;
 }
 
 function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullCalendarBoxProps) {
@@ -98,6 +98,50 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullC
 		setModalOpen(false);
 	};
 
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+	// Get timeblock
+	const { data: timeBlockData } = useGetTimeBlock({ startDate, range });
+	console.log('timeBlockData.data.data', timeBlockData?.data.data);
+
+	const { mutate } = usePostTimeBlock();
+
+	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data) : [];
+=======
+	const calendarEvents = [
+		{ title: 'Meeting', start: '2024-07-16T10:00:00', end: '2024-07-06T12:00:00', classNames: 'tasks' },
+		{ title: 'Lunch', start: '2024-07-07T12:00:00', end: '2024-07-07T12:45:00', classNames: 'tasks' },
+		{ title: 'Lunch', start: '2024-07-08T12:00:00', end: '2024-07-08T12:30:00', classNames: 'tasks' },
+		{
+			title: 'All Day Event',
+			start: '2024-07-08T10:00:00',
+			end: '2024-07-08T12:00:00',
+			allDay: true,
+			classNames: 'task',
+		},
+		{ title: 'Meeting', start: '2024-07-15T10:00:00', end: '2024-07-11T12:00:00', classNames: 'schedule' },
+		{ title: 'Lunch', start: '2024-07-12T12:00:00', end: '2024-07-12T12:45:00', classNames: 'schedule' },
+		{ title: 'Lunch', start: '2024-07-11T12:00:00', end: '2024-07-11T12:30:00', classNames: 'schedule' },
+		{
+			title: 'All Day Event',
+			start: '2024-07-12T10:00:00',
+			end: '2024-07-12T12:00:00',
+			allDay: true,
+			classNames: 'schedule',
+		},
+		{
+			title: '안녕',
+			start: '2024-07-19T10:00:00',
+			end: '2024-07-19T12:00:00',
+			allDay: false,
+			classNames: 'schedule',
+		},
+	];
+>>>>>>> 0ed8365 (feat: staging area 모달 api 연결)
+
+	/** 드래그해서 이벤트 추가하기 */
+>>>>>>> 6f9f435 (feat: staging area 모달 api 연결)
 	const addEventWhenDragged = (selectInfo: DateSelectArg) => {
 		if (calendarRef.current && (selectedTarget?.id === 0 || selectedTarget)) {
 			const calendarApi = calendarRef.current.getApi();

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -25,9 +25,10 @@ interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
 	selectedTarget?: TaskType | null;
+	targetDate: string | null;
 }
 
-function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate, selectedTarget, targetDate }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const todayDate = new Date().toISOString().split('T')[0];
 	const [currentView, setCurrentView] = useState('timeGridWeek');
@@ -224,7 +225,12 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 					top={top}
 					left={left}
 					onClose={closeModal}
+<<<<<<< HEAD
 					taskId={5} // 예시 taskId, 실제 데이터로 교체 필요
+=======
+					taskId={5}
+					targetDate={targetDate}
+>>>>>>> 0ec9b61 (feat: time block 모달 상세 구현)
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -25,10 +25,9 @@ interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
 	selectedTarget?: TaskType | null;
-	targetDate?: Date | null;
 }
 
-function FullCalendarBox({ size, selectDate, selectedTarget, targetDate = null }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxProps) {
 	const today = new Date().toDateString();
 	const todayDate = new Date().toISOString().split('T')[0];
 	const [currentView, setCurrentView] = useState('timeGridWeek');
@@ -37,6 +36,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate = null }
 	const [isModalOpen, setModalOpen] = useState(false);
 	const [top, setTop] = useState(0);
 	const [left, setLeft] = useState(0);
+	const [modalTaskId, setModalTaskId] = useState<number | null>(null);
+	const [modalTimeBlockId, setModalTimeBlockId] = useState<number | null>(null);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -91,11 +92,20 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate = null }
 		const adjustedTop = Math.min(calculatedTop, MODAL.SCREEN_HEIGHT - MODAL.TASK_MODAL_HEIGHT);
 		setTop(adjustedTop);
 		setLeft(rect.left - MODAL.TASK_MODAL_WIDTH + 40);
-		setModalOpen(true);
+
+		const clickedEvent = info.event.extendedProps;
+
+		if (clickedEvent) {
+			setModalTaskId(clickedEvent.taskId);
+			setModalTimeBlockId(clickedEvent.timeBlockId);
+			setModalOpen(true);
+		}
 	};
 
 	const closeModal = () => {
 		setModalOpen(false);
+		setModalTaskId(null);
+		setModalTimeBlockId(null);
 	};
 
 	const addEventWhenDragged = (selectInfo: DateSelectArg) => {
@@ -218,15 +228,15 @@ function FullCalendarBox({ size, selectDate, selectedTarget, targetDate = null }
 				eventDrop={updateEvent} // 기존 이벤트 드래그 수정 핸들러
 				eventResize={updateEvent} // 기존 이벤트 리사이즈 수정 핸들러
 			/>
-			{isModalOpen && (
+			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
 				<Modal
 					isOpen={isModalOpen}
 					sizeType={{ type: 'short' }}
 					top={top}
 					left={left}
 					onClose={closeModal}
-					taskId={5}
-					targetDate={targetDate?.toString()}
+					taskId={modalTaskId}
+					timeBlockId={modalTimeBlockId}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -22,9 +22,8 @@ interface ModalProps {
 	timeBlockId?: number;
 	targetDate?: string | null;
 }
-
 function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, timeBlockId }: ModalProps) {
-	const { data } = useTaskDescription({
+	const { data, isFetched } = useTaskDescription({
 		taskId,
 		targetDate, // : formatDatetoLocalDate(targetDate)//
 		isOpen,
@@ -59,26 +58,24 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, timeB
 
 		onClose();
 	};
-
+	if (!isOpen || !isFetched) return null;
 	return (
-		isOpen && (
-			<ModalBackdrop onClick={onClose}>
-				<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
-					<ModalHeader>
-						<BtnDate date={data.data.deadLine.date} time={data.data.deadLine.time} />
-						<ModalHeaderBtn type={sizeType.type} onDelete={handleDelete} />
-					</ModalHeader>
-					<ModalBody>
-						<TextInputBox type={sizeType.type} name={data.data.name} desc={data.data.description} />
-						{sizeType.type === 'long' && <ModalTextInputTime />}
-					</ModalBody>
-					<ModalFooter>
-						<OkayCancelBtn type="cancel" onClick={onClose} />
-						<OkayCancelBtn type="okay" onClick={onClose} />
-					</ModalFooter>
-				</ModalLayout>
-			</ModalBackdrop>
-		)
+		<ModalBackdrop onClick={onClose}>
+			<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
+				<ModalHeader>
+					<BtnDate date={data.data.deadLine.date} time={data.data.deadLine.time} />
+					<ModalHeaderBtn type={sizeType.type} onDelete={handleDelete} />
+				</ModalHeader>
+				<ModalBody>
+					<TextInputBox type={sizeType.type} name={data.data.name} desc={data.data.description} />
+					{sizeType.type === 'long' && <ModalTextInputTime />}
+				</ModalBody>
+				<ModalFooter>
+					<OkayCancelBtn type="cancel" onClick={onClose} />
+					<OkayCancelBtn type="okay" onClick={onClose} />
+				</ModalFooter>
+			</ModalLayout>
+		</ModalBackdrop>
 	);
 }
 

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import ModalBackdrop from './ModalBackdrop';
 
+import useTaskDescription from '@/apis/tasks/taskDescription/query';
 import useDeleteTimeBlock from '@/apis/timeBlocks/deleteTimeBlock/query';
 import BtnDate from '@/components/common/BtnDate/BtnDate';
 import OkayCancelBtn from '@/components/common/button/OkayCancelBtn';
@@ -9,6 +10,7 @@ import ModalHeaderBtn from '@/components/common/modal/ModalHeaderBtn';
 import ModalTextInputTime from '@/components/common/modal/ModalTextInputTime';
 import TextInputBox from '@/components/common/modal/TextInputBox';
 import { SizeType } from '@/types/textInputType';
+// import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface ModalProps {
 	isOpen: boolean;
@@ -16,26 +18,33 @@ interface ModalProps {
 	top: number;
 	left: number;
 	onClose: () => void;
-	taskId?: number;
+	taskId: number;
 	timeBlockId?: number;
+	targetDate?: string | null;
 }
 
-function Modal({ isOpen, sizeType, top, left, onClose, taskId, timeBlockId }: ModalProps) {
-	const dummyData = {
-		id: taskId,
-		name: 'task name',
-		description: 'task description',
-		deadLine: {
-			date: '2024-06-30',
-			time: '12:30',
-		},
-		status: '진행 중', // 수정
-		timeBlock: {
-			id: 1,
-			startTime: '2024-07-08T12:30',
-			endTime: '2024-07-08T14:30',
-		},
-	};
+function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, timeBlockId }: ModalProps) {
+	const { data } = useTaskDescription({
+		taskId,
+		targetDate, // : formatDatetoLocalDate(targetDate)//
+		isOpen,
+	});
+	console.log(data);
+	// const dummyData = {
+	// 	id: taskId,
+	// 	name: 'task name',
+	// 	description: 'task description',
+	// 	deadLine: {
+	// 		date: '2024-06-30',
+	// 		time: '12:30',
+	// 	},
+	// 	status: '진행 중', // 수정
+	// 	timeBlock: {
+	// 		id: 1,
+	// 		startTime: '2024-07-08T12:30',
+	// 		endTime: '2024-07-08T14:30',
+	// 	},
+	// };
 
 	const { mutate } = useDeleteTimeBlock();
 
@@ -56,11 +65,11 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, timeBlockId }: Mo
 			<ModalBackdrop onClick={onClose}>
 				<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
 					<ModalHeader>
-						<BtnDate date={dummyData.deadLine.date} time={dummyData.deadLine.time} />
+						<BtnDate date={data.data.deadLine.date} time={data.data.deadLine.time} />
 						<ModalHeaderBtn type={sizeType.type} onDelete={handleDelete} />
 					</ModalHeader>
 					<ModalBody>
-						<TextInputBox type={sizeType.type} name={dummyData.name} desc={dummyData.description} />
+						<TextInputBox type={sizeType.type} name={data.data.name} desc={data.data.description} />
 						{sizeType.type === 'long' && <ModalTextInputTime />}
 					</ModalBody>
 					<ModalFooter>

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -10,7 +10,7 @@ import ModalHeaderBtn from '@/components/common/modal/ModalHeaderBtn';
 import ModalTextInputTime from '@/components/common/modal/ModalTextInputTime';
 import TextInputBox from '@/components/common/modal/TextInputBox';
 import { SizeType } from '@/types/textInputType';
-// import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
+import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface ModalProps {
 	isOpen: boolean;
@@ -22,13 +22,13 @@ interface ModalProps {
 	timeBlockId?: number;
 	targetDate?: string | null;
 }
-function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, timeBlockId }: ModalProps) {
+function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate = null, timeBlockId }: ModalProps) {
 	const { data, isFetched } = useTaskDescription({
 		taskId,
-		targetDate, // : formatDatetoLocalDate(targetDate)//
+		targetDate: formatDatetoLocalDate(targetDate),
 		isOpen,
 	});
-	console.log(data);
+	console.log('data', data);
 	// const dummyData = {
 	// 	id: taskId,
 	// 	name: 'task name',

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -28,22 +28,6 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate = null
 		targetDate: formatDatetoLocalDate(targetDate),
 		isOpen,
 	});
-	console.log('data', data);
-	// const dummyData = {
-	// 	id: taskId,
-	// 	name: 'task name',
-	// 	description: 'task description',
-	// 	deadLine: {
-	// 		date: '2024-06-30',
-	// 		time: '12:30',
-	// 	},
-	// 	status: '진행 중', // 수정
-	// 	timeBlock: {
-	// 		id: 1,
-	// 		startTime: '2024-07-08T12:30',
-	// 		endTime: '2024-07-08T14:30',
-	// 	},
-	// };
 
 	const { mutate } = useDeleteTimeBlock();
 

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -5,8 +5,10 @@ import TargetAreaDate from './TargetAreaDate';
 import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
 
+// import useTaskDescription from '@/apis/tasks/taskDescription/query';
 import { TaskType } from '@/types/tasks/taskType';
 import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
+// import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface TargetAreaProps extends TargetControlSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
@@ -24,6 +26,7 @@ function TargetArea({
 	onClickDatePicker,
 	targetDate,
 }: TargetAreaProps) {
+	// const { data } = useTaskDescription({ taskId: selectedTarget.id, targetDate: formatDatetoLocalDate(targetDate) });
 	return (
 		<TargetAreaLayout>
 			{/* 날짜 */}
@@ -47,6 +50,7 @@ function TargetArea({
 							handleSelectedTarget={handleSelectedTarget}
 							selectedTarget={selectedTarget}
 							tasks={tasks}
+							targetDate={targetDate}
 						/>
 						{provided.placeholder}
 					</div>

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -5,10 +5,8 @@ import TargetAreaDate from './TargetAreaDate';
 import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
 
-// import useTaskDescription from '@/apis/tasks/taskDescription/query';
 import { TaskType } from '@/types/tasks/taskType';
 import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
-// import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface TargetAreaProps extends TargetControlSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
@@ -26,7 +24,6 @@ function TargetArea({
 	onClickDatePicker,
 	targetDate,
 }: TargetAreaProps) {
-	// const { data } = useTaskDescription({ taskId: selectedTarget.id, targetDate: formatDatetoLocalDate(targetDate) });
 	return (
 		<TargetAreaLayout>
 			{/* 날짜 */}

--- a/src/components/targetArea/TargetAreaDate.tsx
+++ b/src/components/targetArea/TargetAreaDate.tsx
@@ -4,11 +4,12 @@ import formatDatetoStrinKor from '@/utils/formatDatetoStringKor';
 
 /** nnnn년 nn월 nn일 */
 interface TargetAreaDateProps {
-	targetDate: Date;
+	targetDate: string;
 }
 
 function TargetAreaDate({ targetDate }: TargetAreaDateProps) {
-	const formatDate = formatDatetoStrinKor(targetDate);
+	const dateTypeDate = new Date(targetDate);
+	const formatDate = formatDatetoStrinKor(dateTypeDate);
 	return <DateText>{formatDate}</DateText>;
 }
 

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -11,7 +11,7 @@ interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
 	tasks: TaskType[];
-	targetDate: Date;
+	targetDate: string;
 }
 function TargetTaskSection(props: TargetTaskSectionProps) {
 	const { handleSelectedTarget, selectedTarget, tasks, targetDate } = props;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -11,9 +11,10 @@ interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
 	selectedTarget: TaskType | null;
 	tasks: TaskType[];
+	targetDate: Date;
 }
 function TargetTaskSection(props: TargetTaskSectionProps) {
-	const { handleSelectedTarget, selectedTarget, tasks } = props;
+	const { handleSelectedTarget, selectedTarget, tasks, targetDate } = props;
 
 	return (
 		<BtnTaskContainer type="target">
@@ -44,6 +45,7 @@ function TargetTaskSection(props: TargetTaskSectionProps) {
 										handleSelectedTarget={handleSelectedTarget}
 										selectedTarget={selectedTarget}
 										isDragging={snapshot.isDragging}
+										targetDate={targetDate}
 									/>
 								</div>
 							)}

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -136,7 +136,7 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} />
+				<FullCalendarBox size="small" selectedTarget={selectedTarget} targetDate={targetDate} />
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -136,7 +136,7 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} targetDate={selectedDate} />
+				<FullCalendarBox size="small" selectedTarget={selectedTarget} />
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -131,7 +131,7 @@ function Today() {
 						onClickNextDate={handleNextBtn}
 						onClickTodayDate={handleTodayBtn}
 						onClickDatePicker={handleChangeDate}
-						targetDate={selectedDate}
+						targetDate={selectedDate.toString()}
 					/>
 				)}
 			</DragDropContext>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -136,7 +136,7 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} targetDate={targetDate} />
+				<FullCalendarBox size="small" selectedTarget={selectedTarget} targetDate={selectedDate} />
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/types/today/TargetControlSectionProps.ts
+++ b/src/types/today/TargetControlSectionProps.ts
@@ -3,5 +3,5 @@ export interface TargetControlSectionProps {
 	onClickNextDate: () => void;
 	onClickTodayDate: () => void;
 	onClickDatePicker: (target: Date) => void;
-	targetDate: Date;
+	targetDate: string;
 }

--- a/src/utils/formatDatetoLocalDate.ts
+++ b/src/utils/formatDatetoLocalDate.ts
@@ -1,9 +1,10 @@
 /** Date 형식을 0000-00-00 형식 string 으로 반환합니다 */
-const formatDatetoLocalDate = (date: Date | null) => {
+const formatDatetoLocalDate = (date: Date | null | string) => {
 	if (date) {
-		const year = date.getFullYear();
-		const month = '0'.concat((date.getMonth() + 1).toString()).slice(-2);
-		const day = '0'.concat(date.getDate().toString()).slice(-2);
+		const dateTypeDate = new Date(date);
+		const year = dateTypeDate.getFullYear();
+		const month = '0'.concat((dateTypeDate.getMonth() + 1).toString()).slice(-2);
+		const day = '0'.concat(dateTypeDate.getDate().toString()).slice(-2);
 		return `${year}-${month}-${day}`;
 	}
 	return '';

--- a/src/utils/formatDatetoString.ts
+++ b/src/utils/formatDatetoString.ts
@@ -1,11 +1,12 @@
 /** Date 형식을 0000.00.00 형식 string 으로 반환합니다
  * undefined, null 의 경우 '시간' 텍스트를 반환합니다
  */
-const formatDatetoString = (date: Date | undefined | null) => {
+const formatDatetoString = (date: Date | undefined | null | string) => {
 	if (date) {
-		const year = date.getFullYear();
-		const month = '0'.concat((date.getMonth() + 1).toString()).slice(-2);
-		const day = '0'.concat(date.getDate().toString()).slice(-2);
+		const dateTypeDate = new Date(date);
+		const year = dateTypeDate.getFullYear();
+		const month = '0'.concat((dateTypeDate.getMonth() + 1).toString()).slice(-2);
+		const day = '0'.concat(dateTypeDate.getDate().toString()).slice(-2);
 		return `${year}.${month}.${day}`;
 	}
 	return '';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- staging area와 target area에서 task 더블 클릭 시 상세 정보를 모달에 get 해오는 api를 연결했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 으,,앙 ㅜㅜ 너무 많은 걸 알게 되었고, 기존에 제가 작업하던 api 연결과는 많이 다른 부분이 있어 어제 오늘 대가리 깨며 많이 배운 것 같습니다,, 사실 아직도 많이 이해가 필요하지만, 그래도 비교적 쉬운 get 부분을 처음으로 작업하면서 내려주기만 하면 되는 부분이 대부분이라 감 잡는데 정말 많은 도움이 되었습니다. 제가 get 부분에 온전히 집중할 수 있도록 다른 부분을 작업해준 승연이에게 고맙습니다... 타입 에러 잡아준 지원이와 많은 질문을 받아준 성희도,, 사실 제가 한건 없더요 ㅜㅜ
- 옵셔널,, 을 많이 썼어요,, ㅋ
- - staging area에서는 targetDate가 없습니다. 요 부분이 좀 어려웠는데요, (왜냐면 staging area와 target area가 결국 modal이라는 같은 하위 컴포넌트를 공유하고 있기 때문에) staging area에서는 targetDate = null로 해주면서 해결하였습니다. 땡스 투 지원

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 원래는 time block에서도 상세 정보 모달이 노출되어야 하는데, 삭제 모달만 뜨는 것으로 수정되었습니다! 참고해주세요
- targetDate 타입에러 때문에 애를 먹었는데요, 과정에서 유틸함수에 string을 추가해주었습니다. 괜찮은지 한번 봐주시면 감사하겠습니다!

## 관련 이슈

close #194 

## 스크린샷

https://github.com/user-attachments/assets/4d55e5af-1de3-4f98-a6ec-f6eac084066c
