### PR TITLE
[FIX] 모달안에 datepicker 가려짐 수정

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -169,7 +169,7 @@ const BtnDateLayout = styled.div<{
 	box-sizing: border-box;
 	width: fit-content;
 	min-width: 1.8rem;
-	height: ${({ size }) => (size === 'long' ? '2.2rem' : '2rem')};
+	height: ${({ size }) => (size === 'long' ? '3.2rem' : '2rem')};
 	padding: ${({ size }) => (size === 'long' ? '0.5rem 1rem' : '0rem 1rem')};
 	${({ size }) =>
 		size !== 'short' &&

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -7,9 +7,9 @@ const CalendarStyle = styled.div`
 	flex-shrink: 0;
 	align-items: center;
 	width: 22.8rem;
-	height: fit-content;
+	height: 27rem;
 	padding: 1.6rem 0;
-	overflow: hidden;
+	overflow: auto;
 
 	box-shadow: 0 3px 7px 0 rgb(0 0 0 / 38%);
 	border: 0;
@@ -119,6 +119,22 @@ const CalendarStyle = styled.div`
 	}
 
 	/* stylelint-enable selector-class-pattern */
+
+	::-webkit-scrollbar {
+		width: 0.6rem;
+	}
+
+	::-webkit-scrollbar-thumb {
+		width: 0.6rem;
+
+		background-color: ${({ theme }) => theme.palette.Grey.Grey6};
+		visibility: hidden;
+		border-radius: 3px;
+	}
+
+	&:hover::-webkit-scrollbar-thumb {
+		visibility: visible;
+	}
 `;
 
 export default CalendarStyle;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

-  모달안에서 데이트픽커를 열 때 overflow:hidden으로 데이트픽커 모달이 사라져서 이를 수정하였습니다.
- 모달 안에서 dateBtn의 크기가 맞지 않아서 해당 내용을 수정하였습니다.

## 관련 이슈

close #234

## 스크린샷 (선택)
<img width="397" alt="image" src="https://github.com/user-attachments/assets/dfb7aa52-7f70-4447-a19a-fdb1c39176a2">
