### PR TITLE
[REFACTOR] TimeBlock 삭제 방식 개선

### DIFF
--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -7,10 +7,11 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import { DateSelectArg, EventResizeDoneArg } from 'fullcalendar/index.js';
 import { useState, useRef, useEffect } from 'react';
 
-import Modal from '../modal/Modal';
+import ModalDeleteDetail from '../modal/ModalDeleteDetail';
 
 import processEvents from './processEvents';
 
+import useDeleteTimeBlock from '@/apis/timeBlocks/deleteTimeBlock/query';
 import useGetTimeBlock from '@/apis/timeBlocks/getTimeBlock/query';
 import usePostTimeBlock from '@/apis/timeBlocks/postTimeBlock/query';
 import useUpdateTimeBlock from '@/apis/timeBlocks/updateTimeBlock/query';
@@ -89,9 +90,10 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 	const handleEventClick = (info: EventClickArg) => {
 		const rect = info.el.getBoundingClientRect();
 		const calculatedTop = rect.top;
-		const adjustedTop = Math.min(calculatedTop, MODAL.SCREEN_HEIGHT - MODAL.TASK_MODAL_HEIGHT);
+		const screenHeight = window.innerHeight;
+		const adjustedTop = Math.min(calculatedTop, screenHeight - MODAL.TASK_DELETE_HEIGHT);
 		setTop(adjustedTop);
-		setLeft(rect.left - MODAL.TASK_MODAL_WIDTH + 40);
+		setLeft(rect.left - MODAL.TASK_DELETE_WIDTH);
 
 		const clickedEvent = info.event.extendedProps;
 
@@ -165,6 +167,20 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 		}
 	};
 
+	const { mutate } = useDeleteTimeBlock();
+
+	const handleDelete = () => {
+		console.log('taskId, timeBlockId', modalTaskId, modalTimeBlockId);
+
+		if (modalTaskId && modalTimeBlockId) {
+			mutate({ taskId: modalTaskId, timeBlockId: modalTimeBlockId });
+		} else {
+			console.error('taskId 또는 timeBlockId가 존재하지 않습니다.');
+		}
+
+		setModalOpen(false);
+	};
+
 	return (
 		<FullCalendarLayout size={size}>
 			<CustomButtonContainer>
@@ -229,15 +245,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				eventResize={updateEvent} // 기존 이벤트 리사이즈 수정 핸들러
 			/>
 			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
-				<Modal
-					isOpen={isModalOpen}
-					sizeType={{ type: 'short' }}
-					top={top}
-					left={left}
-					onClose={closeModal}
-					taskId={modalTaskId}
-					timeBlockId={modalTimeBlockId}
-				/>
+				<ModalDeleteDetail top={top} left={left} onClose={closeModal} onDelete={handleDelete} />
 			)}
 		</FullCalendarLayout>
 	);

--- a/src/constants/modalLocation.ts
+++ b/src/constants/modalLocation.ts
@@ -5,6 +5,9 @@ const MODAL = {
 	TASK_MODAL_HEIGHT: 362,
 	TASK_MODAL_WIDTH: 372,
 
+	TASK_DELETE_HEIGHT: 74,
+	TASK_DELETE_WIDTH: 136,
+
 	// 날짜 & 시간 세팅하는 DateCorrectionModal 모달
 	DATE_CORRECTION: {
 		SET_DEADLINE: {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

TimeBlock 삭제 방식을 개선하였습니다.
- 기존: 상세정보 모달의 삭제버튼을 통해 제거
- 현재: TimeBlock 클릭 시 삭제 모달 바로 띄움

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 로직을 개선시켰습니다!

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

-  로직을 개선시켰습니다! 더블클릭이 아닌 클릭 시 모달을 띄우는 것으로 결정되었습니다.

## 관련 이슈

close #233 

## 스크린샷 (선택)

![Jul-19-2024 19-17-46](https://github.com/user-attachments/assets/cbcedf3a-2a1a-47c4-b45b-69cebe6d5b3b)

