### PR TITLE
[FEAT] 풀캘린더 일정 선택 관련 기능 추가 

### DIFF
--- a/src/apis/timeBlocks/postTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/postTimeBlock/axios.ts
@@ -1,17 +1,29 @@
+import { isAxiosError } from 'axios';
+
 import { PostTimeBlokType } from './PostTimeBlockType';
 
 import { privateInstance } from '@/apis/instance';
+import MESSAGES from '@/apis/messages';
+import { TimeBlockResponse } from '@/apis/timeBlocks/postTimeBlock/timeblockType';
 
-const CreateTimeBlock = async ({ taskId, startTime, endTime }: PostTimeBlokType) => {
+const CreateTimeBlock = async ({
+	taskId,
+	startTime,
+	endTime,
+}: PostTimeBlokType): Promise<TimeBlockResponse | undefined> => {
 	try {
-		await privateInstance.post(`/api/tasks/${taskId}/time-blocks`, {
+		const response = await privateInstance.post(`/api/tasks/${taskId}/time-blocks`, {
 			startTime,
 			endTime,
 		});
+		return {
+			code: response.data.code,
+			data: response.data.data,
+			message: response.data.message,
+		};
 	} catch (error) {
-		console.error('Error creating time block:', error);
-	} finally {
-		console.log('taskId, startDate, endDate', taskId, startTime, endTime);
+		if (isAxiosError(error)) throw error;
+		else throw new Error(MESSAGES.UNKNOWN_ERROR);
 	}
 };
 

--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -3,15 +3,26 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import CreateTimeBlock from './axios';
 import { PostTimeBlokType } from './PostTimeBlockType';
 
+import { useToast } from '@/components/toast/ToastContext';
+
 const usePostTimeBlock = () => {
 	const queryClient = useQueryClient();
+	const { addToast } = useToast();
 
-	const mutation = useMutation({
-		mutationFn: ({ taskId, startTime, endTime }: PostTimeBlokType) => CreateTimeBlock({ taskId, startTime, endTime }),
+	const { mutate, isError } = useMutation({
+		mutationFn: async ({ taskId, startTime, endTime }: PostTimeBlokType) => {
+			const response = await CreateTimeBlock({ taskId, startTime, endTime });
+			/** response.code가 conflict일 때 타임블록 에러 토스트 출력 */
+			if (response && response.code === 'conflict') {
+				addToast(response.message);
+				throw new Error('conflict');
+			}
+			return response;
+		},
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),
 	});
 
-	return { mutate: mutation.mutate };
+	return { mutate, isError };
 };
 
 export default usePostTimeBlock;

--- a/src/apis/timeBlocks/postTimeBlock/timeblockType.ts
+++ b/src/apis/timeBlocks/postTimeBlock/timeblockType.ts
@@ -1,0 +1,5 @@
+export interface TimeBlockResponse {
+	code: string;
+	data: null;
+	message: string;
+}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -166,6 +166,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 			addEventWhenDragged(selectInfo);
 		}
 	};
+	const isSelectable = !!selectedTarget;
 
 	const { mutate } = useDeleteTimeBlock();
 
@@ -209,7 +210,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				}}
 				slotDuration="00:30:00"
 				editable
-				selectable
+				selectable={isSelectable}
 				nowIndicator
 				dayMaxEvents
 				events={calendarEvents}

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -61,5 +61,9 @@ function TargetTaskSection(props: TargetTaskSectionProps) {
 export default TargetTaskSection;
 
 const EmptyLayout = styled.div`
-	margin: 14.85rem 0 27.95rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 90%;
 `;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import { useEffect } from 'react';
+
+interface ToastProps {
+	message: string;
+	onClose: () => void;
+}
+
+function Toast({ message, onClose }: ToastProps) {
+	useEffect(() => {
+		const timer = setTimeout(onClose, 3000);
+		return () => clearTimeout(timer);
+	}, [onClose]);
+
+	return <ToastMessage>{message}</ToastMessage>;
+}
+
+const ToastMessage = styled.div`
+	display: flex;
+	align-items: center;
+	padding: 1rem 2rem;
+
+	color: ${({ theme }) => theme.palette.Grey.Black};
+	${({ theme }) => theme.fontTheme.LABEL_02};
+
+	background-color: #fff;
+	box-shadow: 0 16px 35px 0 rgb(72 87 120 / 25%);
+	transform: translateX(100%);
+	opacity: 0;
+	border-radius: 5px;
+
+	animation:
+		slide-in 0.3s forwards,
+		fade-out 0.3s forwards 2.7s;
+
+	&::before {
+		margin-right: 1rem;
+
+		color: ${({ theme }) => theme.palette.Primary};
+		font-weight: bold;
+
+		content: '!';
+	}
+
+	@keyframes slide-in {
+		to {
+			transform: translateX(0);
+			opacity: 1;
+		}
+	}
+
+	@keyframes fade-out {
+		to {
+			transform: translateX(100%);
+			opacity: 0;
+		}
+	}
+`;
+
+export default Toast;

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+import Toast from '@/components/toast/Toast';
+import { useToast } from '@/components/toast/ToastContext';
+
+function ToastContainer() {
+	const { toasts, removeToast } = useToast();
+
+	return (
+		<Container>
+			{toasts.map((toast) => (
+				<Toast key={toast.id} message={toast.message} onClose={() => removeToast(toast.id)} />
+			))}
+		</Container>
+	);
+}
+
+const Container = styled.div`
+	position: fixed;
+	right: 2rem;
+	bottom: 5rem;
+	z-index: 10;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+`;
+
+export default ToastContainer;

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useState, useMemo, ReactNode } from 'react';
+
+import ToastContainer from '@/components/toast/ToastContainer';
+
+interface ToastItem {
+	id: number;
+	message: string;
+}
+
+interface ToastContextProps {
+	toasts: ToastItem[];
+	addToast: (message: string) => void;
+	removeToast: (id: number) => void;
+}
+
+const ToastContext = createContext<ToastContextProps | null>(null);
+
+export const useToast = () => {
+	const context = useContext(ToastContext);
+	if (!context) {
+		throw new Error('useToast must be used within a ToastProvider');
+	}
+	return context;
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+	const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+	const addToast = (message: string) => {
+		const id = new Date().getTime();
+		setToasts((prevToasts) => [...prevToasts, { id, message }]);
+	};
+
+	const removeToast = (id: number) => {
+		setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+	};
+
+	const value = useMemo(
+		() => ({
+			toasts,
+			addToast,
+			removeToast,
+		}),
+		[toasts]
+	);
+
+	return (
+		<ToastContext.Provider value={value}>
+			{children}
+			<ToastContainer />
+		</ToastContext.Provider>
+	);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import ReactDOM from 'react-dom/client';
 
 import App from '@/App.tsx';
+import { ToastProvider } from '@/components/toast/ToastContext';
 import GlobalStyle from '@/styles/GlobalStyle.tsx';
 import { theme } from '@/styles/theme.ts';
 
@@ -21,7 +22,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 	<QueryClientProvider client={queryClient}>
 		<GlobalStyle />
 		<ThemeProvider theme={theme}>
-			<App />
+			<ToastProvider>
+				<App />
+			</ToastProvider>
 		</ThemeProvider>
 		<ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" position="left" />
 	</QueryClientProvider>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -136,7 +136,7 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} />
+				<FullCalendarBox size="small" selectedTarget={selectedTarget} selectDate={selectedDate} />
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -151,7 +151,7 @@ const style = css`
 	}
 
 	:root {
-		--fc-highlight-color: #f0f5ff;
+		--fc-highlight-color: #dfe9ff;
 		--fc-event-border-color: #ffff;
 	}
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 일정을 클릭했을 때만 타임블록을 긁을 수 있도록 하였습니다
- 일정을 긁을 수 없는 곳을 긁을 때는 토스트 알림이 뜨도록 토스트를 구현하였습니다.

close #241 

## 스크린샷 (선택)

https://github.com/user-attachments/assets/70a96072-5900-48df-a7ac-e833e7191b45

