### PR TITLE
[HOTFIX] 할 일 앤터로 입력 시 마지막 글자가 한 번 더 입력되는 버그 수정

### DIFF
--- a/src/apis/tasks/createTask/query.ts
+++ b/src/apis/tasks/createTask/query.ts
@@ -3,12 +3,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import createTask from './axios';
 import { CreateTaskType } from './CreateTaskType';
 /** Task 추가 */
-const useCreateTask = () => {
+const useCreateTask = (clearTask: () => void) => {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation({
 		mutationFn: ({ name, deadLine }: CreateTaskType) => createTask({ name, deadLine }),
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ['today'] });
+			clearTask(); // 성공했을 때 clearTask 호출
+		},
 	});
 
 	return { mutate: mutation.mutate };

--- a/src/apis/tasks/createTask/query.ts
+++ b/src/apis/tasks/createTask/query.ts
@@ -3,14 +3,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import createTask from './axios';
 import { CreateTaskType } from './CreateTaskType';
 /** Task 추가 */
-const useCreateTask = (clearTask: () => void) => {
+const useCreateTask = () => {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation({
 		mutationFn: ({ name, deadLine }: CreateTaskType) => createTask({ name, deadLine }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['today'] });
-			clearTask(); // 성공했을 때 clearTask 호출
 		},
 	});
 

--- a/src/apis/tasks/createTask/query.ts
+++ b/src/apis/tasks/createTask/query.ts
@@ -8,9 +8,7 @@ const useCreateTask = () => {
 
 	const mutation = useMutation({
 		mutationFn: ({ name, deadLine }: CreateTaskType) => createTask({ name, deadLine }),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ['today'] });
-		},
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
 	});
 
 	return { mutate: mutation.mutate };

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -11,7 +11,6 @@ import formatDatetoString from '@/utils/formatDatetoString';
 
 function TextInputStaging() {
 	const [taskName, setTaskName] = useState('');
-	const { mutate } = useCreateTask();
 	const [date, setDate] = useState<Date | null>(null);
 	const [time, setTime] = useState<string | null>(null);
 	const nameRef = useRef<HTMLTextAreaElement>(null);
@@ -32,6 +31,15 @@ function TextInputStaging() {
 		setTaskName(e.target.value);
 	};
 
+	const clearTask = () => {
+		setTaskName('');
+		if (nameRef.current) nameRef.current.value = '';
+		setDate(null);
+		setTime(null);
+	};
+
+	const { mutate } = useCreateTask(clearTask);
+
 	/** 태스크 쏟아내기 전송 */
 	const onSubmit = () => {
 		const formattedDate = date ? formatDatetoLocalDate(date) : null;
@@ -44,15 +52,11 @@ function TextInputStaging() {
 				},
 			});
 		}
-		setDate(null);
-		setTime(null);
-		if (nameRef.current) nameRef.current.value = '';
-		setTaskName('');
 	};
 
 	/** 엔터키로 쏟아내기 전송 */
 	const handleEnterPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter') {
+		if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
 			e.preventDefault();
 			onSubmit();
 		}

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -31,14 +31,7 @@ function TextInputStaging() {
 		setTaskName(e.target.value);
 	};
 
-	const clearTask = () => {
-		setTaskName('');
-		if (nameRef.current) nameRef.current.value = '';
-		setDate(null);
-		setTime(null);
-	};
-
-	const { mutate } = useCreateTask(clearTask);
+	const { mutate } = useCreateTask();
 
 	/** 태스크 쏟아내기 전송 */
 	const onSubmit = () => {
@@ -51,6 +44,10 @@ function TextInputStaging() {
 					time,
 				},
 			});
+			setTaskName('');
+			if (nameRef.current) nameRef.current.value = '';
+			setDate(null);
+			setTime(null);
 		}
 	};
 

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -56,7 +56,7 @@ function TextInputStaging() {
 
 	/** 엔터키로 쏟아내기 전송 */
 	const handleEnterPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+		if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
 			e.preventDefault();
 			onSubmit();
 		}

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -44,11 +44,11 @@ function TextInputStaging() {
 					time,
 				},
 			});
-			setTaskName('');
-			if (nameRef.current) nameRef.current.value = '';
-			setDate(null);
-			setTime(null);
 		}
+		setTaskName('');
+		if (nameRef.current) nameRef.current.value = '';
+		setDate(null);
+		setTime(null);
 	};
 
 	/** 엔터키로 쏟아내기 전송 */


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 할 일 앤터로 입력 시 마지막 글자가 한 번 더 입력되는 버그 수정하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 한글을 입력할 때만 마지막 글자가 한 번 더 입력되는 오류가 발생했는데 크롬 브라우저에서 한글을 사용하는 경우, 한글 입력 시 입력 중인 글자 아래 검은 밑줄이 생기는데 해당 밑줄이 있는 상황에서 키보드 이벤트 발생 시 이벤트핸들러가 두 번 호출 되는 문제가 존재한다고 합니다. 한글의 경우 자음과 모음의 조합으로 한 음절이 만들어지는 조합 문자이기 때문에 글자가 조합 중인지, 조합이 끝난 상태인지를 알 수 없기 때문에 발생하는 오류였습니다. 
- 해당 문제를  해결하기 위해 키보드 이벤트에 isComposing을 통해 입력 문자가 조합 문자인지 아닌지를 boolean값으로 반환하는 프로퍼티가 있었고 이를 통해서 조합문자일때만 이벤트를 호출하도록 코드를 추가하였습니다.
- `!e.nativeEvent.isComposing`


## 관련 이슈

close #256 

## 스크린샷 (선택)
