### PR TITLE
[HOTFIX] 달력 모달 위치 조정

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -82,11 +82,9 @@ function BtnDate(props: BtnDateProps) {
 			{isClicked && (
 				<>
 					<DateCorrectionModal
-						top={
-							handleDate && handleTime ? MODAL.DATE_CORRECTION.SET_DEADLINE.top : MODAL.DATE_CORRECTION.TASK_MODAL.top
-						}
+						top={size.type !== 'long' ? MODAL.DATE_CORRECTION.SET_DEADLINE.top : MODAL.DATE_CORRECTION.TASK_MODAL.top}
 						left={
-							handleDate && handleTime ? MODAL.DATE_CORRECTION.SET_DEADLINE.left : MODAL.DATE_CORRECTION.TASK_MODAL.left
+							size.type !== 'long' ? MODAL.DATE_CORRECTION.SET_DEADLINE.left : MODAL.DATE_CORRECTION.TASK_MODAL.left
 						}
 						date={date}
 						time={time}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 달력 모달이 안보이는 것이 아닌 보이지 않는 위치에 띄워짐을 알았습니다.
- 하여, 해당 위치 조정하였습니다.
- `size.type == 'long'` 인 경우와 아닌 경우로 나눠서 구분해두었습니다!  (`size.type === 'long'` 일때만 클릭됨을 고려함.)

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 모달 위치 설정에 따라 모달이 보이지 않는 곳에 위치할 수도 있음을 알았습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 혹시 해당 모달이 다른 부분에서 쓰인다면, 추가 수정이 필요합니다! 본인이 퍼블리싱한 뷰에 해당 모달이 뜬다면, 꼭꼭 알려주세요!!

## 관련 이슈

close #257 

## 스크린샷 (선택)
![Jul-20-2024 04-04-11](https://github.com/user-attachments/assets/9068cbf0-e9f4-47da-820e-fbf5c42c1d5b)
