### PR TITLE
[HOTFIX] 상태 변경 호버 지속상태 수정

### DIFF
--- a/src/apis/dashboard/tasksToday/query.ts
+++ b/src/apis/dashboard/tasksToday/query.ts
@@ -6,24 +6,7 @@ import { TasksTodayType } from './TasksTodayType';
 const placeholderData = {
 	code: 'success',
 	data: {
-		tasks: [
-			{
-				id: 1,
-				name: 'task name',
-				deadLine: {
-					date: '2024-06-30',
-					time: '12:30',
-				},
-			},
-			{
-				id: 2,
-				name: 'task name',
-				deadLine: {
-					date: '2024-06-30',
-					time: '12:30',
-				},
-			},
-		],
+		tasks: [],
 	},
 	message: null,
 };

--- a/src/apis/tasks/updateTaskStatus/query.ts
+++ b/src/apis/tasks/updateTaskStatus/query.ts
@@ -3,14 +3,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import updateTaskStatus from './axios';
 import { UpdateTaskStatusType } from './UpdateTaskStatusType';
 
-const useUpdateTaskStatus = () => {
+const useUpdateTaskStatus = (handleIconMouseLeave: (() => void) | null) => {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation({
 		mutationFn: (updateData: UpdateTaskStatusType) => updateTaskStatus(updateData),
 		onSuccess: (data, updateData) => {
 			console.log(data);
-			queryClient.invalidateQueries({ queryKey: ['today'] });
+			queryClient.invalidateQueries({ queryKey: ['today'] }).then(() => {
+				if (handleIconMouseLeave) {
+					handleIconMouseLeave();
+				}
+			});
 			if (updateData.status === '미완료') {
 				queryClient.invalidateQueries({ queryKey: ['dashboard'] });
 			}

--- a/src/components/common/BtnTask/TargetIconHoverContainer.tsx
+++ b/src/components/common/BtnTask/TargetIconHoverContainer.tsx
@@ -36,7 +36,7 @@ function TargetIconHoverContainer({ btnStatus, taskId, targetDate }: Props) {
 						/>
 					);
 				}
-				return <StatusDoneBtn taskId={taskId} targetDate={targetDate} />;
+				return <StatusDoneBtn taskId={taskId} targetDate={targetDate} handleIconMouseLeave={handleIconMouseLeave} />;
 
 			case '진행 중':
 				if (!iconHovered) {
@@ -52,13 +52,15 @@ function TargetIconHoverContainer({ btnStatus, taskId, targetDate }: Props) {
 						/>
 					);
 				}
-				return <StatusInProgressBtn targetDate={targetDate} taskId={taskId} />;
+				return (
+					<StatusInProgressBtn targetDate={targetDate} taskId={taskId} handleIconMouseLeave={handleIconMouseLeave} />
+				);
 
 			case '미완료':
 				if (!iconHovered) {
 					return <IconHoverIndicator />;
 				}
-				return <StatusTodoBtn taskId={taskId} targetDate={targetDate} />;
+				return <StatusTodoBtn taskId={taskId} targetDate={targetDate} handleIconMouseLeave={handleIconMouseLeave} />;
 
 			default:
 				return <TodayPlusBtn taskId={taskId} targetDate={targetDate} />;

--- a/src/components/common/button/TodayPlusBtn.tsx
+++ b/src/components/common/button/TodayPlusBtn.tsx
@@ -9,7 +9,7 @@ interface TodayPlusBtnProps {
 	targetDate: string | null;
 }
 function TodayPlusBtn({ taskId, targetDate }: TodayPlusBtnProps) {
-	const { mutate: updateStateMutate } = useUpdateTaskStatus();
+	const { mutate: updateStateMutate } = useUpdateTaskStatus(null);
 	const handleClick = () => {
 		updateStateMutate({ taskId, targetDate, status: '미완료' });
 	};

--- a/src/components/common/button/settingBtn/SettingCheckBtn.tsx
+++ b/src/components/common/button/settingBtn/SettingCheckBtn.tsx
@@ -21,6 +21,7 @@ interface SettingCheckBtnProps {
 	isActive: boolean;
 	taskId?: number;
 	targetDate?: string | null;
+	handleIconMouseLeave?: () => void;
 }
 
 function SettingCheckBtn({
@@ -32,9 +33,10 @@ function SettingCheckBtn({
 	isActive,
 	taskId,
 	targetDate,
+	handleIconMouseLeave,
 }: SettingCheckBtnProps) {
 	const IconComponent = settingIconMap[type];
-	const { mutate: updateStatusMutate } = useUpdateTaskStatus();
+	const { mutate: updateStatusMutate } = useUpdateTaskStatus(handleIconMouseLeave || null);
 	const StyledSettingCheckIcon = styled(IconComponent)<{ size: string }>`
 		${({ size }) => (size === 'small' ? smallIcon : bigIcon)};
 	`;

--- a/src/components/common/button/statusBtn/StatusDoneBtn.tsx
+++ b/src/components/common/button/statusBtn/StatusDoneBtn.tsx
@@ -9,10 +9,11 @@ import TextBtn from '@/components/common/button/textBtn/TextBtn';
 interface StatusDoneBtnProps {
 	taskId: number;
 	targetDate: string | null;
+	handleIconMouseLeave?: () => void;
 }
-function StatusDoneBtn({ taskId, targetDate }: StatusDoneBtnProps) {
+function StatusDoneBtn({ taskId, targetDate, handleIconMouseLeave }: StatusDoneBtnProps) {
 	const [isPressed, setIsPressed] = useState(false);
-	const { mutate: updateStatusMutate } = useUpdateTaskStatus();
+	const { mutate: updateStatusMutate } = useUpdateTaskStatus(handleIconMouseLeave || null);
 	const handleSettingCheckClick = () => {
 		setIsPressed((prev) => !prev);
 	};

--- a/src/components/common/button/statusBtn/StatusInProgressBtn.tsx
+++ b/src/components/common/button/statusBtn/StatusInProgressBtn.tsx
@@ -41,6 +41,7 @@ function StatusInProgressBtn({ taskId, targetDate, handleIconMouseLeave }: Statu
 				isActive={false}
 				taskId={taskId}
 				targetDate={targetDate}
+				handleIconMouseLeave={handleIconMouseLeave}
 				onClick={handleSettingCheckClick}
 			/>
 		</StatusInProgressBtnLayout>

--- a/src/components/common/button/statusBtn/StatusInProgressBtn.tsx
+++ b/src/components/common/button/statusBtn/StatusInProgressBtn.tsx
@@ -8,10 +8,11 @@ import TextBtn from '@/components/common/button/textBtn/TextBtn';
 interface StatusInProgressBtnProps {
 	taskId: number;
 	targetDate: string | null;
+	handleIconMouseLeave?: () => void;
 }
-function StatusInProgressBtn({ taskId, targetDate }: StatusInProgressBtnProps) {
+function StatusInProgressBtn({ taskId, targetDate, handleIconMouseLeave }: StatusInProgressBtnProps) {
 	const [isPressed, setIsPressed] = useState(false);
-	const { mutate: updateStateMutate } = useUpdateTaskStatus();
+	const { mutate: updateStateMutate } = useUpdateTaskStatus(handleIconMouseLeave || null);
 
 	const handleSettingCheckClick = () => {
 		setIsPressed((prev) => !prev);

--- a/src/components/common/button/statusBtn/StatusTodoBtn.tsx
+++ b/src/components/common/button/statusBtn/StatusTodoBtn.tsx
@@ -6,8 +6,9 @@ import SettingCheckBtn from '@/components/common/button/settingBtn/SettingCheckB
 interface StatusTodoBtnProps {
 	taskId: number;
 	targetDate: string | null;
+	handleIconMouseLeave: () => void;
 }
-function StatusTodoBtn({ taskId, targetDate }: StatusTodoBtnProps) {
+function StatusTodoBtn({ taskId, targetDate, handleIconMouseLeave }: StatusTodoBtnProps) {
 	const [isSettingPressed, setIsSettingPressed] = useState(false);
 	const [isCheckingPressed, setIsCheckingPressed] = useState(false);
 
@@ -31,6 +32,7 @@ function StatusTodoBtn({ taskId, targetDate }: StatusTodoBtnProps) {
 					onClick={handleSettingCheckClick}
 					taskId={taskId}
 					targetDate={targetDate}
+					handleIconMouseLeave={handleIconMouseLeave}
 				/>
 			)}
 			{!isSettingPressed && (
@@ -43,6 +45,7 @@ function StatusTodoBtn({ taskId, targetDate }: StatusTodoBtnProps) {
 					onClick={handleCheckingClick}
 					taskId={taskId}
 					targetDate={targetDate}
+					handleIconMouseLeave={handleIconMouseLeave}
 				/>
 			)}
 		</StatusTodoBtnLayout>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -23,7 +23,7 @@ function Today() {
 	// Task 목록 Get
 	const { data: stagingData, isError: isStagingError } = useGetTasks({ isTotal, sortOrder });
 	const { data: targetData, isError: isTargetError } = useGetTasks({ targetDate });
-	const { mutate, queryClient } = useUpdateTaskStatus();
+	const { mutate, queryClient } = useUpdateTaskStatus(null);
 
 	/** isTotal 핸들링 함수 */
 	const handleTextBtnClick = (button: '전체' | '지연') => {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- BtnTask 에서 아이콘 호버했을 때 상태 변경하면 인벨리데이트쿼리로 쿼리키 통해 새로운 배열을 잡아와서 정렬이 되는데, 호버는 state로 관리하기 때문에 열린 상태에서 그대로 마우스를 벗어나 열린 채로 다른 위치로 이동하는 문제가 있었습니다.
- 뮤테이트 onSuccess 의 인밸리데이트쿼리 이후에 state 초기화 작업을 하도록 설정했습니다
- 대시보드쪽 플레이스홀더 지웠습니다


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 잘되는지봐주삼

## 관련 이슈

close #259 

## 스크린샷 (선택)
<img width="486" alt="image" src="https://github.com/user-attachments/assets/e1e2dac2-2032-4627-a805-59b6825ddde9">
