### PR TITLE
[FEAT] 구글캘린더 타임블록 정보 수정(위치이동) 막기

### DIFF
--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -109,9 +109,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 		setModalTaskId(null);
 		setModalTimeBlockId(null);
 	};
-
 	const addEventWhenDragged = (selectInfo: DateSelectArg) => {
-		if (calendarRef.current && (selectedTarget?.id === 0 || selectedTarget)) {
+		if (calendarRef.current && selectedTarget && selectedTarget.id !== -1) {
 			const calendarApi = calendarRef.current.getApi();
 
 			const existingEvents = calendarApi.getEvents();
@@ -143,29 +142,33 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 		}
 	};
 
-	const updateEvent = (info: EventDropArg | EventResizeDoneArg) => {
-		const { event } = info;
-		const { taskId, timeBlockId } = event.extendedProps;
-		const removeTimezone = (str: string) => str.replace(/:\d{2}[+-]\d{2}:\d{2}$/, '');
-
-		const startStr = removeTimezone(event.startStr);
-		const endStr = removeTimezone(event.endStr);
-
-		if (taskId && taskId !== -1) {
-			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr });
-		}
-	};
-
 	const handleSelect = (selectInfo: DateSelectArg) => {
 		if (calendarRef.current) {
 			const calendarApi = calendarRef.current.getApi();
 			calendarApi.unselect();
 		}
 
-		if (selectedTarget) {
+		if (selectedTarget && selectedTarget.id !== -1) {
 			addEventWhenDragged(selectInfo);
 		}
 	};
+
+	const updateEvent = (info: EventDropArg | EventResizeDoneArg) => {
+		const { event } = info;
+		const { taskId, timeBlockId } = event.extendedProps;
+
+		if (taskId && taskId !== -1) {
+			const removeTimezone = (str: string) => str.replace(/:\d{2}[+-]\d{2}:\d{2}$/, '');
+
+			const startStr = removeTimezone(event.startStr);
+			const endStr = removeTimezone(event.endStr);
+
+			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr });
+		} else {
+			info.revert();
+		}
+	};
+
 	const isSelectable = !!selectedTarget;
 
 	const { mutate } = useDeleteTimeBlock();


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 구글캘린더 타임블록 정보 수정(위치이동) 막기
- 위치 이동, 타임블록 늘리기 or 줄이기 등의 이벤트를 취할 순 있지만, 구글캘린더 값은 고정된 상태로 있습니다.(바로 다시 되돌아갑니다.)

## 알게된 점 :rocket:

> 기록하며 개발하기!

- fullcalendar 라이브러리의 `info.revert();` 에 대해 알았습니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 구글캘린더 변경을 막았습니다! 확인해주세요

## 관련 이슈

close #268 

## 스크린샷 (선택)
![Jul-20-2024 06-03-40](https://github.com/user-attachments/assets/a15184ee-1175-4766-85e3-08bc5a738142)

