### PR TITLE
[FEAT] 타임블록 안에서 일정 옮길 때도 토스트 알림

### DIFF
--- a/src/apis/timeBlocks/updateTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/axios.ts
@@ -1,12 +1,31 @@
+import { isAxiosError } from 'axios';
+
 import { PatchTimeBlokType } from './PatchTimeBlockType';
 
 import { privateInstance } from '@/apis/instance';
+import MESSAGES from '@/apis/messages';
+import { TimeBlockResponse } from '@/apis/timeBlocks/postTimeBlock/timeblockType';
 
-const PatchTimeBlock = async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
-	await privateInstance.patch(`/api/tasks/${taskId}/time-blocks/${timeBlockId}`, {
-		startTime,
-		endTime,
-	});
+const PatchTimeBlock = async ({
+	taskId,
+	timeBlockId,
+	startTime,
+	endTime,
+}: PatchTimeBlokType): Promise<TimeBlockResponse | undefined> => {
+	try {
+		const response = await privateInstance.patch(`/api/tasks/${taskId}/time-blocks/${timeBlockId}`, {
+			startTime,
+			endTime,
+		});
+		return {
+			code: response.data.code,
+			data: response.data.data,
+			message: response.data.message,
+		};
+	} catch (error) {
+		if (isAxiosError(error)) throw error;
+		else throw new Error(MESSAGES.UNKNOWN_ERROR);
+	}
 };
 
 export default PatchTimeBlock;

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -3,12 +3,21 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import PatchTimeBlock from './axios';
 import { PatchTimeBlokType } from './PatchTimeBlockType';
 
+import { useToast } from '@/components/toast/ToastContext';
+
 const usePatchTimeBlock = () => {
 	const queryClient = useQueryClient();
+	const { addToast } = useToast();
 
 	const mutation = useMutation({
-		mutationFn: ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) =>
-			PatchTimeBlock({ taskId, timeBlockId, startTime, endTime }),
+		mutationFn: async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
+			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime });
+			if (response && response.code === 'conflict') {
+				addToast(response.message);
+				throw new Error('conflict');
+			}
+			return response;
+		},
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),
 	});
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -8,6 +8,7 @@ import BtnTaskContainer from '@/components/common/BtnTaskContainer';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TargetArea from '@/components/targetArea/TargetArea';
+import { AreaType } from '@/types/area/areaType';
 import { SortOrderType } from '@/types/sortOrderType';
 import { TaskType } from '@/types/tasks/taskType';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
@@ -19,6 +20,7 @@ function Today() {
 	const [selectedDate, setTargetDate] = useState(new Date());
 	const isTotal = activeButton === '전체';
 	const targetDate = formatDatetoLocalDate(selectedDate);
+	const [selectedArea, setSelectedArea] = useState<AreaType>(null);
 
 	// Task 목록 Get
 	const { data: stagingData, isError: isStagingError } = useGetTasks({ isTotal, sortOrder });
@@ -34,8 +36,9 @@ function Today() {
 		setSortOrder(order);
 	};
 
-	const handleSelectedTarget = (task: TaskType | null) => {
+	const handleSelectedTarget = (task: TaskType | null, area: AreaType) => {
 		setSelectedTarget(task);
+		setSelectedArea(area);
 	};
 
 	const handlePrevBtn = () => {
@@ -109,7 +112,7 @@ function Today() {
 					<BtnTaskContainer type="staging" />
 				) : (
 					<StagingArea
-						handleSelectedTarget={handleSelectedTarget}
+						handleSelectedTarget={(task) => handleSelectedTarget(task, 'staging')}
 						selectedTarget={selectedTarget}
 						tasks={stagingData.data.tasks}
 						handleSortOrder={handleSortOrder}
@@ -124,7 +127,7 @@ function Today() {
 					<BtnTaskContainer type="target" />
 				) : (
 					<TargetArea
-						handleSelectedTarget={handleSelectedTarget}
+						handleSelectedTarget={(task) => handleSelectedTarget(task, 'target')}
 						selectedTarget={selectedTarget}
 						tasks={targetData.data.tasks}
 						onClickPrevDate={handlePrevBtn}
@@ -136,7 +139,11 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} selectDate={selectedDate} />
+				<FullCalendarBox
+					size="small"
+					selectedTarget={selectedArea === 'target' ? selectedTarget : null}
+					selectDate={selectedDate}
+				/>
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/types/area/areaType.ts
+++ b/src/types/area/areaType.ts
@@ -1,0 +1,1 @@
+export type AreaType = 'target' | 'staging' | null;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 타임블록 내에서 이동할 때 이동할 수 없는 곳이라면 토스트가 나오게 하였습니다.
- target에 있을 때만 타임블록을 긁을 수 있게 처리하였습니다 (staging에 있을때는 타임블록 못긁게 하였습니다)

## 관련 이슈

close #271

## 스크린샷 (선택)
