### PR TITLE
[FIX] 대시보드 뷰 지난 날짜 버튼 클릭시 모달에 반영

### DIFF
--- a/src/components/common/datePicker/DatePickerCustom.tsx
+++ b/src/components/common/datePicker/DatePickerCustom.tsx
@@ -1,5 +1,5 @@
 import { ko } from 'date-fns/locale';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
@@ -42,6 +42,11 @@ function DatePickerCustom({
 		}
 		return false;
 	};
+
+	useEffect(() => {
+		setStartDate(initialStartDate);
+		setEndDate(initialEndDate);
+	}, [initialStartDate, initialEndDate]);
 
 	const onChange = (dates: [Date | null, Date | null]) => {
 		const [start, end] = dates;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 대시보드 뷰에서 지난 1주 전, 지난 1달 전 버튼을 클릭하면 placeholder에는 반영이 되고 아래 진행률 요약에도 반영이 되지만, datepicker 모달에 해당 날짜가 입력되지 않는 문제가 있었습니다. (미처 연동할 생각을 못함)
- 이를 데이트 피커에 반영해주었습니다~ 간단하게 useEffect를 사용해서 startDate와 endDate가 바뀔 때마다 반영되어 값이 변하게 해주었어요

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 해당 placeholder가 있는 부분을 막바지에 급하게 수정하느라 지피티에게 도움을 많이 받았었는데 지금 다시 뜯어보려니 직접 썼던 코드를 일부 밀어버리고 지피티 코드가 대부분이었기 때문에 다시 읽어보는데 시간이 꽤 걸렸다. 아무리 급해도 내 코드를 직접 짜야겠다고 생각했다....

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 괜찮은가요? 

## 관련 이슈

close #275 

## 스크린샷

`수정 전`
<img width="437" alt="수정 전 이미지" src="https://github.com/user-attachments/assets/82fdf86a-b3e3-452e-9571-36ad6964f7be">


`수정 후`
<img width="437" alt="수정 후 이미지" src="https://github.com/user-attachments/assets/241111fc-fc2b-458f-97b0-8389b9e93b9a">
