### PR TITLE
[CHORE] maze 스크립트 추가

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -47,6 +47,7 @@ jobs:
             echo "VITE_BASE_URL=${{ secrets.VITE_BASE_URL }}" >> .env
             echo "VITE_GOOGLE_LOGIN_CLIENT_ID=${{ secrets.VITE_GOOGLE_LOGIN_CLIENT_ID }}" >> .env
             echo "VITE_GOOGLE_CALENDAR_CLIENT_ID=${{ secrets.VITE_GOOGLE_CALENDAR_CLIENT_ID }}" >> .env
+            echo "VITE_MAZE_CODE=${{ secrets.VITE_MAZE_CODE }}" >> .env
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/index.html
+++ b/index.html
@@ -1,6 +1,27 @@
 <!doctype html>
 <html lang="ko">
 	<head>
+		<script>
+			(function (m, a, z, e) {
+				var s, t;
+				try {
+					t = m.sessionStorage.getItem('maze-us');
+				} catch (err) {}
+
+				if (!t) {
+					t = new Date().getTime();
+					try {
+						m.sessionStorage.setItem('maze-us', t);
+					} catch (err) {}
+				}
+
+				s = a.createElement('script');
+				s.src = z + '?apiKey=' + e;
+				s.async = true;
+				a.getElementsByTagName('head')[0].appendChild(s);
+				m.mazeUniversalSnippetApiKey = e;
+			})(window, document, 'https://snippet.maze.co/maze-universal-loader.js', '%VITE_MAZE_CODE%');
+		</script>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/svg+xml" href="/src/assets/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- maze 스크립트를 추가했습니다.
- 깃헙 시크릿에 키 넣어두고 야믈파일 cd단계에 env 추가해뒀습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- html 에서 env 가져와야 할 때 `%{env}%` 형태로 쓸 수 있습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 가이드에는 env처리에 대한 내용이 없는데 일단 키값이니까 처리해 두었습니다

## 관련 이슈

close #280 

## 스크린샷 (선택)
