### PR TITLE
[FEAT] 공통 컴포넌트 아이콘버튼 퍼블리싱

### DIFF
--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -18,10 +18,10 @@ import IcnArrangeSet from '@/assets/svg/icn_arrange_set.svg?react';
 import Icn_clock from '@/assets/svg/icn_clock.svg?react';
 import IcnFile from '@/assets/svg/icn_file.svg?react';
 import Icn_hover_indicator from '@/assets/svg/icn_hover_indicator.svg?react';
-import Icn_nav_calendar from '@/assets/svg/icn_nav_calendar.svg?react';
-import Icn_nav_dashboard from '@/assets/svg/icn_nav_dashboard.svg?react';
-import Icn_nav_setting from '@/assets/svg/icn_nav_setting.svg?react';
-import Icn_nav_today from '@/assets/svg/icn_nav_today.svg?react';
+import IcnNavCalendar from '@/assets/svg/icn_nav_calendar.svg?react';
+import IcnNavDashboard from '@/assets/svg/icn_nav_dashboard.svg?react';
+import IcnNavSetting from '@/assets/svg/icn_nav_setting.svg?react';
+import IcnNavToday from '@/assets/svg/icn_nav_today.svg?react';
 import Icn_line from '@/assets/svg/line164.svg?react';
 import plus_circle from '@/assets/svg/plus-circle.svg?react';
 import PlusArrow from '@/assets/svg/PlusArrow.svg?react';
@@ -47,10 +47,10 @@ const Icons = {
 	Icn_hover_indicator,
 	IcnFile,
 	Navbar: {
-		Icn_nav_calendar,
-		Icn_nav_dashboard,
-		Icn_nav_setting,
-		Icn_nav_today,
+		IcnNavCalendar,
+		IcnNavDashboard,
+		IcnNavSetting,
+		IcnNavToday,
 	},
 	ArrangeBtn: {
 		IcnArrangeRight,

--- a/src/components/common/NavBarIcon.tsx
+++ b/src/components/common/NavBarIcon.tsx
@@ -69,10 +69,10 @@ const createStyledIcon = (IconComponent: React.FunctionComponent<React.SVGProps<
 	color: ${({ theme, $iscurrent }) => ($iscurrent ? theme.palette.Primary : theme.palette.Grey.Grey5)};
 `;
 
-const TodayIcon = createStyledIcon(Icons.Navbar.Icn_nav_today);
-const DashboardIcon = createStyledIcon(Icons.Navbar.Icn_nav_dashboard);
-const CalendarIcon = createStyledIcon(Icons.Navbar.Icn_nav_calendar);
-const SettingIcon = createStyledIcon(Icons.Navbar.Icn_nav_setting);
+const TodayIcon = createStyledIcon(Icons.Navbar.IcnNavToday);
+const DashboardIcon = createStyledIcon(Icons.Navbar.IcnNavDashboard);
+const CalendarIcon = createStyledIcon(Icons.Navbar.IcnNavCalendar);
+const SettingIcon = createStyledIcon(Icons.Navbar.IcnNavSetting);
 
 const Caption = styled.p<{ $iscurrent: boolean }>`
 	${({ theme }) => theme.fontTheme.CAPTION_02};

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -1,0 +1,102 @@
+import { css, SerializedStyles } from '@emotion/react';
+import styled from '@emotion/styled';
+import { cloneElement, ReactElement } from 'react';
+
+import color from '@/styles/color';
+import { theme } from '@/styles/theme';
+
+type SizeType = 'small' | 'big';
+type IconBtnType = 'solid' | 'normal' | 'outlined';
+type IconButtonProps = {
+	type: IconBtnType;
+	size: SizeType;
+	disabled: boolean;
+	Icon: ReactElement;
+	onClick: () => void;
+};
+
+function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
+	const buttonSizes: Record<SizeType, SerializedStyles> = {
+		big: css`
+			width: 4rem;
+			height: 4rem;
+		`,
+		small: css`
+			width: 3.2rem;
+			height: 3.2rem;
+		`,
+	};
+
+	const getIconBtnStyles = (
+		strokeColor: string,
+		defaultBG: string,
+		hoverBG: string,
+		pressedBG: string,
+		border: boolean
+	) => {
+		if (disabled) {
+			return css`
+				color: ${color.Grey.Grey4};
+				${border &&
+				css`
+					border: solid 1px ${color.Grey.Grey4};
+				`}
+			`;
+		}
+		return css`
+			background-color: ${defaultBG};
+
+			${border &&
+			css`
+				border: solid 1px ${strokeColor};
+			`}
+			:hover {
+				background-color: ${hoverBG};
+			}
+
+			:active {
+				background-color: ${pressedBG};
+			}
+		`;
+	};
+	const buttonStyles: Record<IconBtnType, SerializedStyles> = {
+		solid: getIconBtnStyles(color.Grey.White, color.Blue.Blue6, color.Blue.Blue7, color.Blue.Blue8, false),
+		normal: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, false),
+		outlined: getIconBtnStyles(color.Grey.White, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
+	};
+
+	const IconBtnContainer = styled.div`
+		display: flex;
+		${buttonSizes[size]}
+		align-items: center;
+		justify-content: center;
+
+		border-radius: 8px;
+		${buttonStyles[type]}
+	`;
+
+	const getIconColor = () => {
+		switch (type) {
+			case 'solid':
+				return theme.color.Grey.White;
+
+			case 'normal':
+			case 'outlined':
+				if (disabled) {
+					return theme.color.Grey.Grey4;
+				}
+				return theme.color.Grey.Grey5;
+
+			default:
+				return theme.color.Grey.Grey4;
+		}
+	};
+
+	return (
+		<IconBtnContainer onClick={disabled ? () => {} : onClick}>
+			{cloneElement(Icon, { color: getIconColor() })}
+		</IconBtnContainer>
+	);
+}
+
+export default IconButton;

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -1,9 +1,6 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css, SerializedStyles, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { cloneElement, ReactElement } from 'react';
-
-import color from '@/styles/color';
-import { theme } from '@/styles/theme';
 
 type SizeType = 'small' | 'big';
 type IconBtnType = 'solid' | 'normal' | 'outlined';
@@ -16,6 +13,7 @@ type IconButtonProps = {
 };
 
 function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
+	const theme = useTheme();
 	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {
 		big: css`
@@ -39,14 +37,14 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		if (disabled) {
 			if (type === 'solid')
 				return css`
-					background-color: ${color.Blue.Blue2};
+					background-color: ${theme.color.Blue.Blue2};
 				`;
 			return css`
 				${border &&
 				css`
 					box-sizing: border-box;
 
-					border: solid 1px ${color.Grey.Grey3};
+					border: solid 1px ${theme.color.Grey.Grey3};
 				`}
 			`;
 		}
@@ -70,9 +68,27 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		`;
 	};
 	const buttonStyles: Record<IconBtnType, SerializedStyles> = {
-		solid: getIconBtnStyles(color.Grey.White, color.Blue.Blue6, color.Blue.Blue7, color.Blue.Blue8, false),
-		normal: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, false),
-		outlined: getIconBtnStyles(color.Grey.Grey4, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
+		solid: getIconBtnStyles(
+			theme.color.Grey.White,
+			theme.color.Blue.Blue6,
+			theme.color.Blue.Blue7,
+			theme.color.Blue.Blue8,
+			false
+		),
+		normal: getIconBtnStyles(
+			theme.color.Grey.Grey5,
+			theme.color.Grey.White,
+			theme.color.Grey.Grey2,
+			theme.color.Grey.Grey3,
+			false
+		),
+		outlined: getIconBtnStyles(
+			theme.color.Grey.Grey4,
+			theme.color.Grey.White,
+			theme.color.Grey.Grey2,
+			theme.color.Grey.Grey3,
+			true
+		),
 	};
 
 	// 아이콘 색상 설정

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -37,11 +37,16 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		border: boolean
 	) => {
 		if (disabled) {
+			if (type === 'solid')
+				return css`
+					background-color: ${color.Blue.Blue2};
+				`;
 			return css`
-				color: ${color.Grey.Grey4};
 				${border &&
 				css`
-					border: solid 1px ${color.Grey.Grey4};
+					box-sizing: border-box;
+
+					border: solid 1px ${color.Grey.Grey3};
 				`}
 			`;
 		}
@@ -50,8 +55,11 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 
 			${border &&
 			css`
+				box-sizing: border-box;
+
 				border: solid 1px ${strokeColor};
 			`}
+
 			:hover {
 				background-color: ${hoverBG};
 			}
@@ -64,7 +72,7 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 	const buttonStyles: Record<IconBtnType, SerializedStyles> = {
 		solid: getIconBtnStyles(color.Grey.White, color.Blue.Blue6, color.Blue.Blue7, color.Blue.Blue8, false),
 		normal: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, false),
-		outlined: getIconBtnStyles(color.Grey.White, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
+		outlined: getIconBtnStyles(color.Grey.Grey4, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
 	};
 
 	// 아이콘 색상 설정

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -12,7 +12,7 @@ type IconButtonProps = {
 	onClick: () => void;
 };
 
-function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
+function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: IconButtonProps) {
 	const theme = useTheme();
 	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -1,6 +1,6 @@
 import { css, SerializedStyles, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { cloneElement, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 type SizeType = 'small' | 'big';
 type IconBtnType = 'solid' | 'normal' | 'outlined';
@@ -37,25 +37,30 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 		if (disabled) {
 			if (type === 'solid')
 				return css`
+					color: ${color.Grey.White};
+
 					background-color: ${color.Blue.Blue2};
 				`;
 			return css`
+				color: ${color.Grey.Grey4};
 				${border &&
 				css`
 					box-sizing: border-box;
 
 					border: solid 1px ${color.Grey.Grey3};
-				`}
+				`};
 			`;
 		}
 		return css`
+			color: ${strokeColor};
+
 			background-color: ${defaultBG};
 
 			${border &&
 			css`
 				box-sizing: border-box;
 
-				border: solid 1px ${strokeColor};
+				border: solid 1px ${color.Grey.Grey4};
 			`}
 
 			:hover {
@@ -70,19 +75,8 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 	const buttonStyles: Record<IconBtnType, SerializedStyles> = {
 		solid: getIconBtnStyles(color.Grey.White, color.Blue.Blue6, color.Blue.Blue7, color.Blue.Blue8, false),
 		normal: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, false),
-		outlined: getIconBtnStyles(color.Grey.Grey4, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
+		outlined: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
 	};
-
-	// 아이콘 색상 설정
-	const getIconColor = () => {
-		const iconColors = {
-			solid: color.Grey.White,
-			normal: disabled ? color.Grey.Grey4 : color.Grey.Grey5,
-			outlined: disabled ? color.Grey.Grey4 : color.Grey.Grey5,
-		};
-		return iconColors[type];
-	};
-	const ColoredIcon = cloneElement(Icon, { color: getIconColor() });
 
 	const IconBtnContainer = styled.div`
 		display: flex;
@@ -94,7 +88,7 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 		${buttonStyles[type]}
 	`;
 
-	return <IconBtnContainer onClick={disabled ? () => {} : onClick}>{ColoredIcon}</IconBtnContainer>;
+	return <IconBtnContainer onClick={disabled ? () => {} : onClick}>{Icon}</IconBtnContainer>;
 }
 
 export default IconButton;

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -13,7 +13,7 @@ type IconButtonProps = {
 };
 
 function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: IconButtonProps) {
-	const theme = useTheme();
+	const { color } = useTheme();
 	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {
 		big: css`
@@ -37,14 +37,14 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 		if (disabled) {
 			if (type === 'solid')
 				return css`
-					background-color: ${theme.color.Blue.Blue2};
+					background-color: ${color.Blue.Blue2};
 				`;
 			return css`
 				${border &&
 				css`
 					box-sizing: border-box;
 
-					border: solid 1px ${theme.color.Grey.Grey3};
+					border: solid 1px ${color.Grey.Grey3};
 				`}
 			`;
 		}
@@ -68,35 +68,17 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 		`;
 	};
 	const buttonStyles: Record<IconBtnType, SerializedStyles> = {
-		solid: getIconBtnStyles(
-			theme.color.Grey.White,
-			theme.color.Blue.Blue6,
-			theme.color.Blue.Blue7,
-			theme.color.Blue.Blue8,
-			false
-		),
-		normal: getIconBtnStyles(
-			theme.color.Grey.Grey5,
-			theme.color.Grey.White,
-			theme.color.Grey.Grey2,
-			theme.color.Grey.Grey3,
-			false
-		),
-		outlined: getIconBtnStyles(
-			theme.color.Grey.Grey4,
-			theme.color.Grey.White,
-			theme.color.Grey.Grey2,
-			theme.color.Grey.Grey3,
-			true
-		),
+		solid: getIconBtnStyles(color.Grey.White, color.Blue.Blue6, color.Blue.Blue7, color.Blue.Blue8, false),
+		normal: getIconBtnStyles(color.Grey.Grey5, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, false),
+		outlined: getIconBtnStyles(color.Grey.Grey4, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
 	};
 
 	// 아이콘 색상 설정
 	const getIconColor = () => {
 		const iconColors = {
-			solid: theme.color.Grey.White,
-			normal: disabled ? theme.color.Grey.Grey4 : theme.color.Grey.Grey5,
-			outlined: disabled ? theme.color.Grey.Grey4 : theme.color.Grey.Grey5,
+			solid: color.Grey.White,
+			normal: disabled ? color.Grey.Grey4 : color.Grey.Grey5,
+			outlined: disabled ? color.Grey.Grey4 : color.Grey.Grey5,
 		};
 		return iconColors[type];
 	};

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -16,6 +16,7 @@ type IconButtonProps = {
 };
 
 function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
+	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {
 		big: css`
 			width: 4rem;
@@ -27,6 +28,7 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		`,
 	};
 
+	// 아이콘 배경 색상 및 테두리
 	const getIconBtnStyles = (
 		strokeColor: string,
 		defaultBG: string,
@@ -65,6 +67,17 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		outlined: getIconBtnStyles(color.Grey.White, color.Grey.White, color.Grey.Grey2, color.Grey.Grey3, true),
 	};
 
+	// 아이콘 색상 설정
+	const getIconColor = () => {
+		const iconColors = {
+			solid: theme.color.Grey.White,
+			normal: disabled ? theme.color.Grey.Grey4 : theme.color.Grey.Grey5,
+			outlined: disabled ? theme.color.Grey.Grey4 : theme.color.Grey.Grey5,
+		};
+		return iconColors[type];
+	};
+	const ColoredIcon = cloneElement(Icon, { color: getIconColor() });
+
 	const IconBtnContainer = styled.div`
 		display: flex;
 		${buttonSizes[size]}
@@ -75,28 +88,7 @@ function IconButton({ type, size, disabled, Icon, onClick }: IconButtonProps) {
 		${buttonStyles[type]}
 	`;
 
-	const getIconColor = () => {
-		switch (type) {
-			case 'solid':
-				return theme.color.Grey.White;
-
-			case 'normal':
-			case 'outlined':
-				if (disabled) {
-					return theme.color.Grey.Grey4;
-				}
-				return theme.color.Grey.Grey5;
-
-			default:
-				return theme.color.Grey.Grey4;
-		}
-	};
-
-	return (
-		<IconBtnContainer onClick={disabled ? () => {} : onClick}>
-			{cloneElement(Icon, { color: getIconColor() })}
-		</IconBtnContainer>
-	);
+	return <IconBtnContainer onClick={disabled ? () => {} : onClick}>{ColoredIcon}</IconBtnContainer>;
 }
 
 export default IconButton;

--- a/src/stories/Common/Button/IconButton.stories.tsx
+++ b/src/stories/Common/Button/IconButton.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import Icons from '@/assets/svg/index';
+import IconButton from '@/components/common/v2/IconButton';
+
+const meta = {
+	title: 'Common/IconButton',
+	component: IconButton,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+	args: { onClick: fn() },
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Solid: Story = {
+	args: {
+		type: 'solid',
+		size: 'big',
+		disabled: false,
+		Icon: <Icons.Navbar.IcnNavDashboard />,
+		onClick: fn(),
+	},
+};
+export const Normal: Story = {
+	args: {
+		type: 'normal',
+		size: 'big',
+		disabled: false,
+		Icon: <Icons.Navbar.IcnNavDashboard />,
+		onClick: fn(),
+	},
+};
+export const Outlined: Story = {
+	args: {
+		type: 'outlined',
+		size: 'big',
+		disabled: false,
+		Icon: <Icons.Navbar.IcnNavDashboard />,
+		onClick: fn(),
+	},
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 공컴 아이콘 버튼 부분 제작했습니다
- 스토리북에 예시 아이콘 넣어뒀는데 icn_setting_어쩌고 이렇게 쓰여있는 형식 Screaming snake라고 린트에서 뭐라 해서... 수정하고 사용된 사이드바 부분 임포트 이름 수정했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 아이콘 stroke 색상 변경할 때 stroke 색상을 고정 색상에서 `currentColor` 로 변경하게 되면 기존에 사용하고 있던 색상을 따로 기입하지 않은 아이콘들에 문제가 생길 것 같아서.. 최대한 이부분을 변경하지 않고 styled(Icon) 처럼 받아서 변경하려고 했으나
- css 속성보다 인라인 스타일이 우선 적용되기 때문에 변경에 실패하고 currentColor 로 설정한 뒤 사용하는 방법 적용했습니다

- 또 Icon을 `ReactElement` type를 받게 만들었는데, 여기에 속성을 부여하기 위해서는 `cloneElement(Icon, { props: 'props1'});` 다음과 같이 설정해서 props 를 넘겨줄 수 있는 것을 알았습니다. 
- 기존의 요소를 복제하면서 요소에 새로운 props를 추가하거나 수정할 때 사용되고 기존 요소를 그대로 두고 props를 덮어쓰거나 병합할 수 있다고 합니다.

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 컴포넌트가 사이즈 분기, 아이콘 배경 부분, 아이콘 자체 색상 설정 부분으로 크게 세개로 나뉘어져 있습니다.
- Icon 부분에 지민언니 담당 부분인 아이콘을 넣어주어야 합니다!!  

<img width="425" alt="image" src="https://github.com/user-attachments/assets/497217c8-5a4c-406f-9b83-4dcbb35f82b7">  


- 스토리북에는 임시로 전에 사이드바 만들 때 썼던 아이콘을 넣어두었습니다.
- 아이콘 버튼에 사용되는 아이콘의 경우 stroke 쪽이 `stroke="currentColor"` 로 설정되어 있어야 stroke 색상을 바꿀 수 있을 것 같습니다.
- 이후 아이콘 추가하실 때(특히 색상을 다양하게 바꿔야 하는 아이콘인 경우) 이부분 처리 부탁드려요 !!!!!

<img width="223" alt="image" src="https://github.com/user-attachments/assets/5b953c1a-7608-4aa3-b18c-651d279b1b79">



## 관련 이슈

close #289 

## 스크린샷 (선택)


![Nov-17-2024 00-52-10](https://github.com/user-attachments/assets/3d60cf69-3452-4693-bb66-7c8569ffd6c0)

