### PR TITLE
[FIX] 기존 공통 컴포넌트 아이콘 수정

### DIFF
--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -1,6 +1,9 @@
 import { css, SerializedStyles, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ReactElement } from 'react';
+
+import Icon from '../Icon';
+
+import Icn from '@/assets/svg/V2';
 
 type SizeType = 'small' | 'big';
 type IconBtnType = 'solid' | 'normal' | 'outlined';
@@ -8,11 +11,11 @@ type IconButtonProps = {
 	type: IconBtnType;
 	size: SizeType;
 	disabled: boolean;
-	Icon: ReactElement;
+	iconName: keyof typeof Icn;
 	onClick: () => void;
 };
 
-function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: IconButtonProps) {
+function IconButton({ type, size = 'small', disabled = false, iconName, onClick }: IconButtonProps) {
 	const { color } = useTheme();
 	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {
@@ -88,7 +91,12 @@ function IconButton({ type, size = 'small', disabled = false, Icon, onClick }: I
 		${buttonStyles[type]}
 	`;
 
-	return <IconBtnContainer onClick={disabled ? () => {} : onClick}>{Icon}</IconBtnContainer>;
+	const iconSize = size === 'big' ? 'large' : 'medium';
+	return (
+		<IconBtnContainer onClick={disabled ? () => {} : onClick}>
+			<Icon name={iconName} size={iconSize} />
+		</IconBtnContainer>
+	);
 }
 
 export default IconButton;

--- a/src/components/common/v2/button/Button.tsx
+++ b/src/components/common/v2/button/Button.tsx
@@ -1,6 +1,9 @@
 import { css, SerializedStyles, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { ReactElement } from 'react';
+
+import Icon from '../../Icon';
+
+import Icn from '@/assets/svg/V2';
 
 // 이후 타입 여러군데에서 필요하면 빼서 export
 type SizeType = 'small' | 'medium' | 'large';
@@ -10,8 +13,8 @@ type ButtonProps = {
 	type: ButtonType;
 	size: SizeType;
 	disabled: boolean;
-	leftIcon?: ReactElement;
-	rightIcon?: ReactElement;
+	leftIcon?: keyof typeof Icn;
+	rightIcon?: keyof typeof Icn;
 	label: string;
 	additionalCss?: SerializedStyles;
 	onClick?: () => void;
@@ -119,11 +122,19 @@ function Button({
 
 		${additionalCss}
 	`;
+
+	/** Button 사이즈에 따라 아이콘 사이즈 결정 */
+	const iconSize: Record<SizeType, 'tiny' | 'small' | 'medium'> = {
+		small: 'tiny',
+		medium: 'small',
+		large: 'medium',
+	};
+
 	return (
 		<ButtonLayout onClick={disabled ? () => {} : onClick}>
-			{leftIcon && leftIcon}
+			{leftIcon && <Icon name={leftIcon} size={iconSize[size]} />}
 			{label}
-			{rightIcon && rightIcon}
+			{rightIcon && <Icon name={rightIcon} size={iconSize[size]} />}
 		</ButtonLayout>
 	);
 }

--- a/src/components/common/v2/control/CheckButton.tsx
+++ b/src/components/common/v2/control/CheckButton.tsx
@@ -1,4 +1,3 @@
-import Icon from '../../Icon';
 import Button from '../button/Button';
 
 type CheckButtonProps = {
@@ -9,13 +8,12 @@ type CheckButtonProps = {
 };
 
 function CheckButton({ label, size = 'small', checked = false, onClick }: CheckButtonProps) {
-	const iconSize = size === 'small' ? 'tiny' : 'medium';
 	const iconType = checked ? 'IcnCheck' : 'IcnSquare';
 	return (
 		<Button
 			type={checked ? 'text-primary' : 'text-assistive'}
 			size={size}
-			leftIcon={<Icon name={iconType} size={iconSize} />}
+			leftIcon={iconType}
 			disabled={false}
 			label={label}
 			onClick={onClick}

--- a/src/components/common/v2/control/CheckButton.tsx
+++ b/src/components/common/v2/control/CheckButton.tsx
@@ -1,6 +1,5 @@
+import Icon from '../../Icon';
 import Button from '../button/Button';
-
-import Icn from '@/assets/svg/V2';
 
 type CheckButtonProps = {
 	label: string;
@@ -10,12 +9,13 @@ type CheckButtonProps = {
 };
 
 function CheckButton({ label, size = 'small', checked = false, onClick }: CheckButtonProps) {
+	const iconSize = size === 'small' ? 'tiny' : 'medium';
+	const iconType = checked ? 'IcnCheck' : 'IcnSquare';
 	return (
 		<Button
 			type={checked ? 'text-primary' : 'text-assistive'}
 			size={size}
-			// TODO: 체크 아이콘으로 바꾸기
-			leftIcon={checked ? <Icn.IcnAlert /> : <Icn.IcnAlert />}
+			leftIcon={<Icon name={iconType} size={iconSize} />}
 			disabled={false}
 			label={label}
 			onClick={onClick}

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -36,6 +36,7 @@ function DropdownButton({ status }: DropdownButtonProps) {
 	};
 
 	const customStyle = css`
+		gap: 0;
 		justify-content: space-between;
 		width: 9.6rem;
 		${isOpen && shadow.FloatingAction1}

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -1,7 +1,6 @@
 import { css, useTheme } from '@emotion/react';
 import { useState } from 'react';
 
-import Icon from '../../Icon';
 import Button from '../button/Button';
 
 // 추후 type 로 빼기
@@ -49,7 +48,7 @@ function DropdownButton({ status }: DropdownButtonProps) {
 			label={status}
 			size="medium"
 			disabled={false}
-			rightIcon={<Icon name={iconType} size="small" />}
+			rightIcon={iconType}
 			additionalCss={customStyle}
 			onClick={handleOpen}
 		/>

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -1,9 +1,8 @@
 import { css, useTheme } from '@emotion/react';
 import { useState } from 'react';
 
+import Icon from '../../Icon';
 import Button from '../button/Button';
-
-import Icn from '@/assets/svg/V2';
 
 // 추후 type 로 빼기
 type TaskStatus = '미완료' | '진행중' | '완료';
@@ -42,13 +41,14 @@ function DropdownButton({ status }: DropdownButtonProps) {
 		${isOpen && shadow.FloatingAction1}
 	`;
 
+	const iconType = isOpen ? 'IcnUp' : 'IcnDown';
 	return (
 		<Button
 			type={getDropdownBtnType()}
 			label={status}
 			size="medium"
 			disabled={false}
-			rightIcon={isOpen ? <Icn.IcnAlert /> : <Icn.IcnAlert />}
+			rightIcon={<Icon name={iconType} size="small" />}
 			additionalCss={customStyle}
 			onClick={handleOpen}
 		/>

--- a/src/stories/Common/Button/Button.stories.tsx
+++ b/src/stories/Common/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
+import Icn from '@/assets/svg/V2';
 import Button from '@/components/common/v2/button/Button';
 
 const meta = {
@@ -11,6 +12,16 @@ const meta = {
 	},
 	tags: ['autodocs'],
 	args: { onClick: fn() },
+	argTypes: {
+		leftIcon: {
+			control: { type: 'select' },
+			options: Object.keys(Icn),
+		},
+		rightIcon: {
+			control: { type: 'select' },
+			options: Object.keys(Icn),
+		},
+	},
 } satisfies Meta<typeof Button>;
 
 export default meta;

--- a/src/stories/Common/Button/Button.stories.tsx
+++ b/src/stories/Common/Button/Button.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
-import Icn from '@/assets/svg/V2';
 import Button from '@/components/common/v2/button/Button';
 
 const meta = {
@@ -68,9 +67,7 @@ export const SolidWithRightIcon: Story = {
 		type: 'solid',
 		size: 'medium',
 		disabled: false,
-
-		rightIcon: <Icn.IcnModify />,
-
+		rightIcon: 'IcnCheck',
 		label: 'Label',
 		onClick: fn(),
 	},
@@ -80,7 +77,7 @@ export const SolidWithLeftIcon: Story = {
 		type: 'solid',
 		size: 'medium',
 		disabled: false,
-		leftIcon: <Icn.IcnAlert />,
+		leftIcon: 'IcnCheck',
 		label: 'Label',
 		onClick: fn(),
 	},
@@ -90,8 +87,8 @@ export const SolidWithBothIcon: Story = {
 		type: 'solid',
 		size: 'medium',
 		disabled: false,
-		leftIcon: <Icn.IcnModify />,
-		rightIcon: <Icn.IcnModify />,
+		leftIcon: 'IcnCheck',
+		rightIcon: 'IcnCheck',
 		label: 'Label',
 		onClick: fn(),
 	},

--- a/src/stories/Common/Button/IconButton.stories.tsx
+++ b/src/stories/Common/Button/IconButton.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
+import Icn from '@/assets/svg/V2';
 import IconButton from '@/components/common/v2/IconButton';
 
 const meta = {
@@ -11,6 +12,12 @@ const meta = {
 	},
 	tags: ['autodocs'],
 	args: { onClick: fn() },
+	argTypes: {
+		iconName: {
+			control: { type: 'select' },
+			options: Object.keys(Icn),
+		},
+	},
 } satisfies Meta<typeof IconButton>;
 
 export default meta;

--- a/src/stories/Common/Button/IconButton.stories.tsx
+++ b/src/stories/Common/Button/IconButton.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
-import Icn from '@/assets/svg/V2';
 import IconButton from '@/components/common/v2/IconButton';
 
 const meta = {
@@ -23,7 +22,7 @@ export const Solid: Story = {
 		type: 'solid',
 		size: 'big',
 		disabled: false,
-		Icon: <Icn.IcnAlert />,
+		iconName: 'IcnAlert',
 		onClick: fn(),
 	},
 };
@@ -32,7 +31,7 @@ export const Normal: Story = {
 		type: 'normal',
 		size: 'big',
 		disabled: false,
-		Icon: <Icn.IcnAlert />,
+		iconName: 'IcnAlert',
 		onClick: fn(),
 	},
 };
@@ -41,7 +40,7 @@ export const Outlined: Story = {
 		type: 'outlined',
 		size: 'big',
 		disabled: false,
-		Icon: <Icn.IcnAlert />,
+		iconName: 'IcnAlert',
 		onClick: fn(),
 	},
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 기존에 만들었던 공컴 드디어 아이콘 피알 머지해서 수정완 했슴니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 기존에는 아이콘을 `ReactElement` 타입으로 Button 에서 직접 받도록 설정했었는데요, 이번엔 아이콘명을 받도록 설정해봤습니다. 아이콘명 스트링 전달은 기존보다 초기 렌더링할 때 조금의 런타임 매핑 비용이 들지만(아이콘 뭔지 찾아야돼서) 리렌더링 최적화에는 더 좋다네요
- 대신 정해진 아이콘만 쓸 수 있으니가 유연성이 떨어질 수 있다는데.. 우리는 인덱스에 있는 것만 쓰니까 이게 더 명확할 것 같아요



## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 이상한점 없는지 구조 괜찮은지 봐주심 감사하겠습니다 ( _ _)

## 관련 이슈

close #304 

## 스크린샷 (선택)
![1](https://github.com/user-attachments/assets/6473ddef-de6d-4ce0-b8b8-84f7288bcb22)
![2](https://github.com/user-attachments/assets/d9318d57-56a1-401c-a34a-906d613eae47)
![3](https://github.com/user-attachments/assets/9af61412-77c5-4188-88ca-8c9e7116efd1)
![4](https://github.com/user-attachments/assets/930da80d-1ff6-4b71-8b2f-98330a24f252)
