### PR TITLE
[FEAT] MainDate, SubDate 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/common/v2/TextBox/MainDate.tsx
+++ b/src/components/common/v2/TextBox/MainDate.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+
+import { theme } from '@/styles/theme';
+import getToday from '@/utils/getToday';
+
+type MainDateProps = {
+	year?: number;
+	month: number;
+	day?: number;
+};
+
+const TextContainer = styled.div`
+	display: flex;
+	gap: 1px;
+	align-items: flex-end;
+
+	.value-text {
+		${theme.font.title01};
+		color: ${theme.color.Grey.Grey8};
+		font-weight: 500;
+	}
+
+	.text {
+		${theme.font.label03};
+		padding-bottom: 0.3rem;
+
+		color: ${theme.color.Grey.Grey6};
+		font-weight: 600;
+	}
+`;
+
+function Date({ value, text }: { value?: number; text: string }) {
+	return value ? (
+		<TextContainer>
+			<span className="value-text">{value}</span>
+			<span className="text">{text}</span>
+		</TextContainer>
+	) : null;
+}
+
+const { year: TodayYear, month: TodayMonth, date: TodayDay } = getToday();
+
+function MainDate({ year, month, day }: MainDateProps) {
+	const [isToday, setIsToday] = useState(false);
+
+	// console.log('todayDate', TodayYear, TodayMonth, TodayDay);
+	// console.log('inputDate', year, month, day);
+
+	useEffect(() => {
+		if ((year === undefined || TodayYear === year) && TodayMonth === month && TodayDay === day) {
+			setIsToday(true);
+		} else {
+			setIsToday(false);
+		}
+	}, [year, month, day]);
+
+	return (
+		<MainDateContainer>
+			<div style={{ display: 'flex', flexDirection: 'row', gap: '0.4rem' }}>
+				<Date value={year} text="년" />
+				<Date value={month} text="월" />
+				<Date value={day} text="일" />
+			</div>
+			{isToday && (
+				<button className="btn" type="button">
+					오늘
+				</button>
+			)}
+		</MainDateContainer>
+	);
+}
+
+export default MainDate;
+
+const MainDateContainer = styled.div`
+	display: flex;
+	gap: 0.8rem;
+	align-items: flex-end;
+
+	background-color: ${theme.color.Grey.White};
+
+	& .btn {
+		display: flex;
+		flex-shrink: 0;
+		align-items: center;
+		justify-content: center;
+		padding: 1px 8px;
+
+		${theme.font.body03}
+
+		color: ${theme.color.Grey.White};
+		font-weight: 600;
+		text-align: center;
+
+		background: ${theme.color.Blue.Blue6};
+		border-radius: 4px;
+	}
+`;
+
+// 년/월/일 -> 오늘 on/off
+// 년/월 -> 오늘 off
+// 월/일 -> (항상 올해라고 가정하고) 오늘 on/off
+// 년/일 -> 이런 거 없음 (?)
+
+// 최종
+// 년은 입력 없으면 디폴트로 올해라고 가정.
+// 일 안들어오면 '오늘' off
+// 월은 무조건 들어와야함.
+// 월, 일 들어오면 비교

--- a/src/components/common/v2/TextBox/MainDate.tsx
+++ b/src/components/common/v2/TextBox/MainDate.tsx
@@ -10,32 +10,12 @@ type MainDateProps = {
 	day?: number;
 };
 
-const TextContainer = styled.div`
-	display: flex;
-	gap: 1px;
-	align-items: flex-end;
-
-	.value-text {
-		${theme.font.title01};
-		color: ${theme.color.Grey.Grey8};
-		font-weight: 500;
-	}
-
-	.text {
-		${theme.font.label03};
-		padding-bottom: 0.3rem;
-
-		color: ${theme.color.Grey.Grey6};
-		font-weight: 600;
-	}
-`;
-
 function Date({ value, text }: { value?: number; text: string }) {
 	return value ? (
-		<TextContainer>
+		<DateContainer>
 			<span className="value-text">{value}</span>
 			<span className="text">{text}</span>
-		</TextContainer>
+		</DateContainer>
 	) : null;
 }
 
@@ -70,6 +50,24 @@ function MainDate({ year, month, day }: MainDateProps) {
 
 export default MainDate;
 
+const DateContainer = styled.div`
+	display: flex;
+	gap: 1px;
+	align-items: flex-end;
+
+	.value-text {
+		${theme.font.title01};
+		color: ${theme.color.Grey.Grey8};
+	}
+
+	.text {
+		${theme.font.label03};
+		padding-bottom: 0.3rem;
+
+		color: ${theme.color.Grey.Grey6};
+	}
+`;
+
 const MainDateContainer = styled.div`
 	display: flex;
 	gap: 0.8rem;
@@ -87,7 +85,6 @@ const MainDateContainer = styled.div`
 		${theme.font.body03}
 
 		color: ${theme.color.Grey.White};
-		font-weight: 600;
 		text-align: center;
 
 		background: ${theme.color.Blue.Blue6};

--- a/src/components/common/v2/TextBox/MainDate.tsx
+++ b/src/components/common/v2/TextBox/MainDate.tsx
@@ -44,9 +44,6 @@ const { year: TodayYear, month: TodayMonth, date: TodayDay } = getToday();
 function MainDate({ year, month, day }: MainDateProps) {
 	const [isToday, setIsToday] = useState(false);
 
-	// console.log('todayDate', TodayYear, TodayMonth, TodayDay);
-	// console.log('inputDate', year, month, day);
-
 	useEffect(() => {
 		if ((year === undefined || TodayYear === year) && TodayMonth === month && TodayDay === day) {
 			setIsToday(true);
@@ -97,14 +94,3 @@ const MainDateContainer = styled.div`
 		border-radius: 4px;
 	}
 `;
-
-// 년/월/일 -> 오늘 on/off
-// 년/월 -> 오늘 off
-// 월/일 -> (항상 올해라고 가정하고) 오늘 on/off
-// 년/일 -> 이런 거 없음 (?)
-
-// 최종
-// 년은 입력 없으면 디폴트로 올해라고 가정.
-// 일 안들어오면 '오늘' off
-// 월은 무조건 들어와야함.
-// 월, 일 들어오면 비교

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+import { theme } from '@/styles/theme';
+
+type SubDateProps = {
+	day: number;
+	weekDay: string;
+};
+
+// Teritary, Secondary, Primary
+//  Default, Hover, Pressed
+
+const dateStyle = {
+	style: {},
+	Teritary: {
+		Default: {},
+		Hover: {},
+		Pressed: {},
+	},
+	Secondary: {
+		Default: {},
+		Hover: {},
+		Pressed: {},
+	},
+	Primary: {
+		Default: {},
+		Hover: {},
+		Pressed: {},
+	},
+};
+
+function SubDate({ day, weekDay }: SubDateProps) {
+	return (
+		<SubDateContainer>
+			<span className="day">{day}</span>
+			<span className="week-day">{weekDay}</span>
+		</SubDateContainer>
+	);
+}
+
+export default SubDate;
+
+const SubDateContainer = styled.div`
+	display: inline-flex;
+	gap: 4px;
+	align-items: center;
+	justify-content: center;
+	padding: 0 3px;
+
+	.day {
+		${theme.font.body01};
+	}
+
+	.week-day {
+		${theme.font.body04};
+	}
+`;

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -1,18 +1,45 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import { theme } from '@/styles/theme';
+
+const TYPE = {
+	TERITARY: 'Teritary',
+	SECONDARY: 'Secondary',
+	PRIMARY: 'Primary',
+} as const;
+
+const STATE = {
+	DEFAULT: 'Default',
+	HOVER: 'Hover',
+	PRESSED: 'Pressed',
+} as const;
+
+type StateType = (typeof STATE)[keyof typeof STATE];
 
 interface SubDateProps {
 	day: string;
 	weekDay: string;
-	type: 'Teritary' | 'Secondary' | 'Primary';
-	state: 'Default' | 'Hover' | 'Pressed';
+	type: (typeof TYPE)[keyof typeof TYPE];
 }
 
-function SubDate({ day, weekDay, type, state }: SubDateProps) {
+function SubDate({ day, weekDay, type }: SubDateProps) {
+	const [state, setState] = useState<StateType>(STATE.DEFAULT);
+
+	const handleStateChange = (newState: StateType) => () => {
+		setState(newState);
+	};
+
 	return (
-		<SubDateContainer type={type} state={state}>
+		<SubDateContainer
+			type={type}
+			state={state}
+			onMouseEnter={handleStateChange(STATE.HOVER)}
+			onMouseLeave={handleStateChange(STATE.DEFAULT)}
+			onMouseDown={handleStateChange(STATE.PRESSED)}
+			onMouseUp={handleStateChange(STATE.DEFAULT)}
+		>
 			<span className="day">{day}</span>
 			<span className="week-day">{weekDay}</span>
 		</SubDateContainer>

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -1,37 +1,18 @@
-import styled from 'styled-components';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 
 import { theme } from '@/styles/theme';
 
-type SubDateProps = {
-	day: number;
+interface SubDateProps {
+	day: string;
 	weekDay: string;
-};
+	type: 'Teritary' | 'Secondary' | 'Primary';
+	state: 'Default' | 'Hover' | 'Pressed';
+}
 
-// Teritary, Secondary, Primary
-//  Default, Hover, Pressed
-
-const dateStyle = {
-	style: {},
-	Teritary: {
-		Default: {},
-		Hover: {},
-		Pressed: {},
-	},
-	Secondary: {
-		Default: {},
-		Hover: {},
-		Pressed: {},
-	},
-	Primary: {
-		Default: {},
-		Hover: {},
-		Pressed: {},
-	},
-};
-
-function SubDate({ day, weekDay }: SubDateProps) {
+function SubDate({ day, weekDay, type, state }: SubDateProps) {
 	return (
-		<SubDateContainer>
+		<SubDateContainer type={type} state={state}>
 			<span className="day">{day}</span>
 			<span className="week-day">{weekDay}</span>
 		</SubDateContainer>
@@ -40,18 +21,62 @@ function SubDate({ day, weekDay }: SubDateProps) {
 
 export default SubDate;
 
-const SubDateContainer = styled.div`
+const backgroundStyles = {
+	Teritary: {
+		Default: 'transparent',
+		Hover: theme.colorToken.Primary.strongVariant,
+		Pressed: theme.colorToken.Primary.heavyVariant,
+	},
+	Secondary: {
+		Default: 'transparent',
+		Hover: theme.colorToken.Primary.strongVariant,
+		Pressed: theme.colorToken.Component.heavy,
+	},
+	Primary: {
+		Default: theme.colorToken.Primary.normal,
+		Hover: theme.colorToken.Primary.strong,
+		Pressed: theme.colorToken.Primary.heavy,
+	},
+};
+
+const textStyles = {
+	Teritary: {
+		day: theme.colorToken.Text.assistive,
+		weekDay: theme.colorToken.Text.assistiveLight,
+	},
+	Secondary: {
+		day: theme.colorToken.Text.primary,
+		weekDay: theme.colorToken.Text.primary,
+	},
+	Primary: {
+		day: theme.colorToken.Text.neutralDark,
+		weekDay: theme.colorToken.Text.neutralDark,
+	},
+};
+
+const SubDateContainer = styled.div<{
+	type: keyof typeof backgroundStyles;
+	state: keyof (typeof backgroundStyles)['Teritary'];
+}>`
 	display: inline-flex;
 	gap: 4px;
 	align-items: center;
 	justify-content: center;
 	padding: 0 3px;
 
-	.day {
-		${theme.font.body01};
-	}
+	border-radius: 4px;
 
-	.week-day {
-		${theme.font.body04};
-	}
+	${({ type, state }) => css`
+		background-color: ${backgroundStyles[type][state]};
+
+		.day {
+			color: ${textStyles[type].day};
+			${theme.font.body01};
+		}
+
+		.week-day {
+			color: ${textStyles[type].weekDay};
+			${theme.font.body04};
+		}
+	`}
 `;

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -105,5 +105,27 @@ const SubDateContainer = styled.div<{
 			color: ${textStyles[type].weekDay};
 			${theme.font.body04};
 		}
+
+		${type === TYPE.SECONDARY &&
+		css`
+			${underlineStyle}
+		`}
 	`}
+`;
+
+const underlineStyle = css`
+	position: relative;
+
+	&::after {
+		position: absolute;
+		bottom: 2px;
+		left: 50%;
+		width: 3.2rem;
+		height: 0.1rem;
+
+		background-color: ${theme.colorToken.Text.primary};
+		transform: translateX(-50%);
+
+		content: '';
+	}
 `;

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -106,10 +106,7 @@ const SubDateContainer = styled.div<{
 			${theme.font.body04};
 		}
 
-		${type === TYPE.SECONDARY &&
-		css`
-			${underlineStyle}
-		`}
+		${type === TYPE.SECONDARY && underlineStyle}
 	`}
 `;
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,8 +2,6 @@ import styled from '@emotion/styled';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 
 import Images from '@/assets/images';
-import MainDate from '@/components/common/v2/TextBox/MainDate';
-import SubDate from '@/components/common/v2/TextBox/SubDate';
 import GoogleLoginBtn from '@/components/loginPage/GoogleLoginBtn';
 
 function Login() {
@@ -13,20 +11,6 @@ function Login() {
 		<GoogleOAuthProvider clientId={LOGIN_CLIENT_ID}>
 			<LoginLayout>
 				<LeftSection>
-					<MainDate year={2024} month={11} day={27} />
-
-					{/* <SubDate day="23" weekDay="화" type="Teritary" state="Default" />
-					<SubDate day="23" weekDay="화" type="Teritary" state="Hover" />
-					<SubDate day="23" weekDay="화" type="Teritary" state="Pressed" />
-
-					<SubDate day="23" weekDay="화" type="Secondary" state="Default" />
-					<SubDate day="23" weekDay="화" type="Secondary" state="Hover" />
-					<SubDate day="23" weekDay="화" type="Secondary" state="Pressed" /> */}
-
-					<SubDate day="23" weekDay="화" type="Primary" state="Default" />
-					<SubDate day="23" weekDay="화" type="Primary" state="Hover" />
-					<SubDate day="23" weekDay="화" type="Primary" state="Pressed" />
-
 					<LogoTitleImg src={Images.titleIcon} />
 					<LoginBtn>
 						<GoogleLoginBtn />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google';
 
 import Images from '@/assets/images';
 import MainDate from '@/components/common/v2/TextBox/MainDate';
+import SubDate from '@/components/common/v2/TextBox/SubDate';
 import GoogleLoginBtn from '@/components/loginPage/GoogleLoginBtn';
 
 function Login() {
@@ -13,6 +14,18 @@ function Login() {
 			<LoginLayout>
 				<LeftSection>
 					<MainDate year={2024} month={11} day={27} />
+
+					{/* <SubDate day="23" weekDay="화" type="Teritary" state="Default" />
+					<SubDate day="23" weekDay="화" type="Teritary" state="Hover" />
+					<SubDate day="23" weekDay="화" type="Teritary" state="Pressed" />
+
+					<SubDate day="23" weekDay="화" type="Secondary" state="Default" />
+					<SubDate day="23" weekDay="화" type="Secondary" state="Hover" />
+					<SubDate day="23" weekDay="화" type="Secondary" state="Pressed" /> */}
+
+					<SubDate day="23" weekDay="화" type="Primary" state="Default" />
+					<SubDate day="23" weekDay="화" type="Primary" state="Hover" />
+					<SubDate day="23" weekDay="화" type="Primary" state="Pressed" />
 
 					<LogoTitleImg src={Images.titleIcon} />
 					<LoginBtn>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 
 import Images from '@/assets/images';
+import MainDate from '@/components/common/v2/TextBox/MainDate';
 import GoogleLoginBtn from '@/components/loginPage/GoogleLoginBtn';
 
 function Login() {
@@ -11,6 +12,8 @@ function Login() {
 		<GoogleOAuthProvider clientId={LOGIN_CLIENT_ID}>
 			<LoginLayout>
 				<LeftSection>
+					<MainDate year={2024} month={11} day={27} />
+
 					<LogoTitleImg src={Images.titleIcon} />
 					<LoginBtn>
 						<GoogleLoginBtn />

--- a/src/stories/Common/Button/MainDate.stories.tsx
+++ b/src/stories/Common/Button/MainDate.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MainDate from '@/components/common/v2/TextBox/MainDate';
+
+const meta = {
+	title: 'Common/TextBox/MainDate',
+	component: MainDate,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+	argTypes: {
+		year: { control: { type: 'number' }, description: '년도 (선택)' },
+		month: { control: { type: 'number', min: 1, max: 12 }, description: '월 (필수)' },
+		day: { control: { type: 'number', min: 1, max: 31 }, description: '일 (선택)' },
+	},
+} satisfies Meta<typeof MainDate>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		month: 11,
+		day: 30,
+	},
+};
+
+export const DateWithYear: Story = {
+	args: {
+		year: new Date().getFullYear(),
+		month: new Date().getMonth() + 1,
+		day: new Date().getDate(),
+	},
+};
+
+export const DateWithNonDay: Story = {
+	args: {
+		year: 2023,
+		month: 11,
+	},
+};

--- a/src/stories/Common/Button/SubDate.stories.tsx
+++ b/src/stories/Common/Button/SubDate.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SubDate from '@/components/common/v2/TextBox/SubDate';
+
+const meta = {
+	title: 'Common/TextBox/SubDate',
+	component: SubDate,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+	argTypes: {
+		type: {
+			control: { type: 'radio' },
+			options: ['Teritary', 'Secondary', 'Primary'],
+		},
+		day: {
+			control: { type: 'text' },
+			description: '날짜(일)',
+		},
+		weekDay: {
+			control: { type: 'text' },
+			description: '날짜(요일). ex) 화',
+		},
+	},
+} satisfies Meta<typeof SubDate>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		type: 'Teritary',
+		day: '23',
+		weekDay: '화',
+	},
+};

--- a/src/styles/colorToken.ts
+++ b/src/styles/colorToken.ts
@@ -20,6 +20,7 @@ const colorToken = {
 		neutralDark: color.Grey.White,
 		neutralLight: color.Grey.Grey8,
 		assistive: color.Grey.Grey6,
+		assistiveLight: color.Grey.Grey5,
 		disable: color.Grey.Grey4,
 	},
 	Outline: {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- MainDate, SubDate 컴포넌트 퍼블리싱입니다.
  - MainDate는 오늘 날짜일때만 `오늘` 버튼이 나타납니다. 
  - SubDate는 props로 넘기는 type에 따라 색이 변합니다.
- storybook 추가했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- **after 라는 것을 통해 쉽게 css만으로 밑줄 설정이 가능하다**는 것을 알게되었습니다. 
기능이 전혀 없는 보여주기용 밑줄이라 코드 적게 쓰고싶어서 찾아본건데.. 굉장히 유용한거같아요.
https://developer.mozilla.org/ko/docs/Web/CSS/::after
https://sookkiong.tistory.com/20 <- 참고링크

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- SubDate는 각 행위(`default`, `hover`, `pressed`)에 따라 상태 바뀌는 핸들러를 하나로 합쳤습니다. **역할에 따라 그냥 하나하나 분리하는 게 좋을 지 봐주세요**
- 지금 제작중인 **TextBox부분 컴포넌트들에 들어가는 상태가 여러가지 있는데, 상수파일로 빼는 게 나을까요?** 은근 겹치는 게 없어서.. 일단은 각 파일마다 해당하는 상태 상수화 해놨습니다.
- 두 컴포넌트 모두 사용자가 입력하는 부분은 없어서 **날짜유효성검사는 따로 진행하지 않았습니다.** 

## 관련 이슈

close #298 

## 스크린샷 (선택)
**MainDate**
![Dec-01-2024 00-22-53](https://github.com/user-attachments/assets/31124ab3-7a23-46eb-8c32-721a11c94a3b)

**SubDate**
![Dec-01-2024 00-21-59](https://github.com/user-attachments/assets/4c3978a7-d3b3-441e-b22f-5eebbd0508c5)
