### PR TITLE
[FEAT] dropdown 퍼블리싱

### DIFF
--- a/src/components/common/v2/button/Button.tsx
+++ b/src/components/common/v2/button/Button.tsx
@@ -12,7 +12,7 @@ type ButtonType = 'solid' | 'outlined-primary' | 'outlined-assistive' | 'text-pr
 type ButtonProps = {
 	type: ButtonType;
 	size: SizeType;
-	disabled: boolean;
+	disabled?: boolean;
 	leftIcon?: keyof typeof Icn;
 	rightIcon?: keyof typeof Icn;
 	label: string;

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -1,18 +1,35 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import CheckButton from '@/components/common/v2/control/CheckButton';
+import { STATUS_OPTIONS } from '@/constants/statuses';
 
 function CalendarSettingDropdown() {
+	const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
+
+	const handleStatusChange = (status: string) => {
+		setSelectedStatus(status === selectedStatus ? null : status);
+	};
+
 	return (
 		<CalendarSettingDropdownContainer>
-			<CheckButton label="미완료 일정" onClick={() => {}} size="large" checked={false} />
-			<CheckButton label="진행중 일정" onClick={() => {}} size="large" checked={false} />
-			<CheckButton label="완료 일정" onClick={() => {}} size="large" checked={false} />
+			{STATUS_OPTIONS.map((option) => (
+				<CheckButton
+					key={option.value}
+					label={option.label}
+					onClick={() => handleStatusChange(option.value)}
+					size="large"
+					checked={selectedStatus === option.value}
+				/>
+			))}
 		</CalendarSettingDropdownContainer>
 	);
 }
 
 const CalendarSettingDropdownContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
 	box-sizing: border-box;
 	width: 16.8rem;
 	height: 16rem;

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+import CheckButton from '@/components/common/v2/control/CheckButton';
+
+function CalendarSettingDropdown() {
+	return (
+		<CalendarSettingDropdownContainer>
+			<CheckButton label="미완료 일정" onClick={() => {}} size="large" checked={false} />
+			<CheckButton label="진행중 일정" onClick={() => {}} size="large" checked={false} />
+			<CheckButton label="완료 일정" onClick={() => {}} size="large" checked={false} />
+		</CalendarSettingDropdownContainer>
+	);
+}
+
+const CalendarSettingDropdownContainer = styled.div`
+	box-sizing: border-box;
+	width: 16.8rem;
+	height: 16rem;
+	padding: 1.6rem 0.8rem;
+
+	border-radius: 12px;
+	${({ theme }) => theme.shadow.FloatingAction3};
+`;
+
+export default CalendarSettingDropdown;

--- a/src/components/common/v2/dropdown/SortingDropdown.tsx
+++ b/src/components/common/v2/dropdown/SortingDropdown.tsx
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled';
 
 import Button from '@/components/common/v2/button/Button';
+import SORT_BY from '@/constants/sortType';
 
 function SortingDropdown() {
 	return (
 		<SortingDropdownContainer>
-			<Button label="사용자 설정순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
-			<Divider />
-			<Button label="최신 등록순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
-			<Button label="오래된 등록순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
-			<Divider />
-			<Button label="가까운 마감기한순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
-			<Button label="먼 마감기한순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			{Object.values(SORT_BY).map((label, index) => (
+				<div key={label}>
+					<Button label={label} onClick={() => {}} size="large" type="text-assistive" />
+					{(index === 0 || index === 2) && <Divider />}
+				</div>
+			))}
 		</SortingDropdownContainer>
 	);
 }

--- a/src/components/common/v2/dropdown/SortingDropdown.tsx
+++ b/src/components/common/v2/dropdown/SortingDropdown.tsx
@@ -33,7 +33,7 @@ const Divider = styled.div`
 	height: 0;
 	margin: 1.6rem 0;
 
-	border: 1px solid ${({ theme }) => theme.colorToken.Divider.neutral};
+	border: 1px solid ${({ theme }) => theme.colorToken.Neutral.strong};
 `;
 
 export default SortingDropdown;

--- a/src/components/common/v2/dropdown/SortingDropdown.tsx
+++ b/src/components/common/v2/dropdown/SortingDropdown.tsx
@@ -7,10 +7,10 @@ function SortingDropdown() {
 	return (
 		<SortingDropdownContainer>
 			{Object.values(SORT_BY).map((label, index) => (
-				<div key={label}>
+				<ButtonLayout key={label}>
 					<Button label={label} onClick={() => {}} size="large" type="text-assistive" />
 					{(index === 0 || index === 2) && <Divider />}
-				</div>
+				</ButtonLayout>
 			))}
 		</SortingDropdownContainer>
 	);
@@ -19,6 +19,7 @@ function SortingDropdown() {
 const SortingDropdownContainer = styled.div`
 	display: flex;
 	flex-direction: column;
+	box-sizing: border-box;
 	width: 16.8rem;
 	height: 28.8rem;
 	padding: 0.8rem;
@@ -27,11 +28,15 @@ const SortingDropdownContainer = styled.div`
 	${({ theme }) => theme.shadow.FloatingAction3};
 `;
 
+const ButtonLayout = styled.div`
+	width: 100%;
+`;
+
 const Divider = styled.div`
 	align-self: center;
 	width: 13.6rem;
 	height: 0;
-	margin: 1.6rem 0;
+	margin: 1.6rem 0.8rem;
 
 	border: 1px solid ${({ theme }) => theme.colorToken.Neutral.strong};
 `;

--- a/src/components/common/v2/dropdown/SortingDropdown.tsx
+++ b/src/components/common/v2/dropdown/SortingDropdown.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/v2/button/Button';
+
+function SortingDropdown() {
+	return (
+		<SortingDropdownContainer>
+			<Button label="사용자 설정순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			<Divider />
+			<Button label="최신 등록순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			<Button label="오래된 등록순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			<Divider />
+			<Button label="가까운 마감기한순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			<Button label="먼 마감기한순" onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+		</SortingDropdownContainer>
+	);
+}
+
+const SortingDropdownContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 16.8rem;
+	height: 28.8rem;
+	padding: 0.8rem;
+
+	border-radius: 12px;
+	${({ theme }) => theme.shadow.FloatingAction3};
+`;
+
+const Divider = styled.div`
+	align-self: center;
+	width: 13.6rem;
+	height: 0;
+	margin: 1.6rem 0;
+
+	border: 1px solid ${({ theme }) => theme.colorToken.Divider.neutral};
+`;
+
+export default SortingDropdown;

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/v2/button/Button';
+
+const STATUSES = {
+	INCOMPLETE: '미완료',
+	IN_PROGRESS: '진행중',
+	COMPLETED: '완료',
+};
+
+interface StatusDropdownProps {
+	currentStatus: string;
+}
+
+function StatusDropdown({ currentStatus }: StatusDropdownProps) {
+	// 현재 상태를 제외한 나머지 상태 필터링
+	const visibleStatuses = Object.values(STATUSES).filter((status) => status !== currentStatus);
+
+	return (
+		<StatusDropdownContainer>
+			{visibleStatuses.map((status) => (
+				<Button
+					key={status}
+					label={status}
+					onClick={() => {}}
+					size="large"
+					type={status === STATUSES.COMPLETED ? 'text-primary' : 'text-assistive'}
+					disabled={false}
+				/>
+			))}
+		</StatusDropdownContainer>
+	);
+}
+
+const StatusDropdownContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+	box-sizing: border-box;
+	width: 10.4rem;
+	height: 11rem;
+	padding: 0.8rem;
+
+	border-radius: 12px;
+	${({ theme }) => theme.shadow.FloatingAction3};
+`;
+
+export default StatusDropdown;

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -22,7 +22,6 @@ function StatusDropdown({ currentStatus }: StatusDropdownProps) {
 					onClick={() => {}}
 					size="large"
 					type={status === STATUSES.COMPLETED ? 'text-primary' : 'text-assistive'}
-					disabled={false}
 				/>
 			))}
 		</StatusDropdownContainer>

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 import Button from '@/components/common/v2/button/Button';
 import { STATUSES } from '@/constants/statuses';
 
+type Status = (typeof STATUSES)[keyof typeof STATUSES];
+
 interface StatusDropdownProps {
-	currentStatus: string;
+	currentStatus: Status;
 }
 
 function StatusDropdown({ currentStatus }: StatusDropdownProps) {

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled';
 
 import Button from '@/components/common/v2/button/Button';
-
-const STATUSES = {
-	INCOMPLETE: '미완료',
-	IN_PROGRESS: '진행중',
-	COMPLETED: '완료',
-};
+import { STATUSES } from '@/constants/statuses';
 
 interface StatusDropdownProps {
 	currentStatus: string;

--- a/src/components/common/v2/dropdown/TimeDropdown.tsx
+++ b/src/components/common/v2/dropdown/TimeDropdown.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/v2/button/Button';
+import quarterTimes from '@/utils/generateQuarterTimes';
+
+function TimeDropdown() {
+	return (
+		<TimeDropdownContainer>
+			{quarterTimes.map((time) => (
+				<Button key={time} label={time} onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+			))}
+		</TimeDropdownContainer>
+	);
+}
+
+const TimeDropdownContainer = styled.div`
+	width: 16.8rem;
+	height: 30rem;
+	padding: 0.8rem;
+	overflow-y: auto;
+
+	border-radius: 12px;
+
+	${({ theme }) => theme.shadow.FloatingAction3};
+
+	/* 스크롤바 전체 */
+	::-webkit-scrollbar {
+		width: 1.6rem;
+	}
+
+	/* 스크롤 바의 막대 */
+	::-webkit-scrollbar-thumb {
+		height: 40%;
+
+		background-color: ${({ theme }) => theme.colorToken.Neutral.strong};
+		background-clip: padding-box;
+		border: 4px solid transparent;
+		border-radius: 10px;
+	}
+`;
+
+export default TimeDropdown;

--- a/src/components/common/v2/dropdown/TimeDropdown.tsx
+++ b/src/components/common/v2/dropdown/TimeDropdown.tsx
@@ -7,7 +7,7 @@ function TimeDropdown() {
 	return (
 		<TimeDropdownContainer>
 			{quarterTimes.map((time) => (
-				<Button key={time} label={time} onClick={() => {}} size="large" type="text-assistive" disabled={false} />
+				<Button key={time} label={time} onClick={() => {}} size="large" type="text-assistive" />
 			))}
 		</TimeDropdownContainer>
 	);

--- a/src/components/common/v2/dropdown/TimeDropdown.tsx
+++ b/src/components/common/v2/dropdown/TimeDropdown.tsx
@@ -30,7 +30,7 @@ const TimeDropdownContainer = styled.div`
 
 	/* 스크롤 바의 막대 */
 	::-webkit-scrollbar-thumb {
-		height: 40%;
+		height: 45%;
 
 		background-color: ${({ theme }) => theme.colorToken.Neutral.strong};
 		background-clip: padding-box;

--- a/src/constants/sortType.ts
+++ b/src/constants/sortType.ts
@@ -1,4 +1,5 @@
 const SORT_BY = {
+	CUSTOM_ORDER: '사용자 설정순',
 	NEWEST: '최신 등록순',
 	OLDEST: '오래된 등록순',
 	CLOSEST: '가까운 마감기한순',

--- a/src/constants/statuses.ts
+++ b/src/constants/statuses.ts
@@ -2,7 +2,7 @@ export const STATUSES = {
 	INCOMPLETE: '미완료',
 	IN_PROGRESS: '진행중',
 	COMPLETED: '완료',
-};
+} as const;
 
 export const STATUS_OPTIONS = [
 	{ label: STATUSES.INCOMPLETE, value: 'INCOMPLETE' },

--- a/src/constants/statuses.ts
+++ b/src/constants/statuses.ts
@@ -1,0 +1,11 @@
+export const STATUSES = {
+	INCOMPLETE: '미완료',
+	IN_PROGRESS: '진행중',
+	COMPLETED: '완료',
+};
+
+export const STATUS_OPTIONS = [
+	{ label: STATUSES.INCOMPLETE, value: 'INCOMPLETE' },
+	{ label: STATUSES.IN_PROGRESS, value: 'IN_PROGRESS' },
+	{ label: STATUSES.COMPLETED, value: 'COMPLETED' },
+];

--- a/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
+++ b/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CalendarSettingDropdown from '@/components/common/v2/dropdown/CalendarSettingDropdown';
+
+const meta = {
+	title: 'Common/dropdown/CalendarSettingDropdown',
+	component: CalendarSettingDropdown,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+} satisfies Meta<typeof CalendarSettingDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/Common/dropdown/SortingDropdown.stories.ts
+++ b/src/stories/Common/dropdown/SortingDropdown.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SortingDropdown from '@/components/common/v2/dropdown/SortingDropdown';
+
+const meta = {
+	title: 'Common/dropdown/SortingDropdown',
+	component: SortingDropdown,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+} satisfies Meta<typeof SortingDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/Common/dropdown/StatusDropdown.stories.ts
+++ b/src/stories/Common/dropdown/StatusDropdown.stories.ts
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import StatusDropdown from '@/components/common/v2/dropdown/StatusDropdown';
+
+const meta = {
+	title: 'Common/dropdown/StatusDropdown',
+	component: StatusDropdown,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+} satisfies Meta<typeof StatusDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Incomplete: Story = {
+	args: {
+		currentStatus: '미완료',
+	},
+};
+
+export const InProgress: Story = {
+	args: {
+		currentStatus: '진행중',
+	},
+};
+
+export const Completed: Story = {
+	args: {
+		currentStatus: '완료',
+	},
+};

--- a/src/stories/Common/dropdown/TimeDropdown.stories.ts
+++ b/src/stories/Common/dropdown/TimeDropdown.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TimeDropdown from '@/components/common/v2/dropdown/TimeDropdown';
+
+const meta = {
+	title: 'Common/dropdown/TimeDropdown',
+	component: TimeDropdown,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+} satisfies Meta<typeof TimeDropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/styles/shadow.ts
+++ b/src/styles/shadow.ts
@@ -13,6 +13,12 @@ const shadow = {
 			0 2px 4px 0 rgb(23 59 134 / 5%),
 			0 4px 12px 0 rgb(23 59 134 / 60%);
 	`,
+	FloatingAction3: css`
+		box-shadow:
+			0 0 8px 0 #00000014,
+			0 8px 16px 0 #00000014,
+			0 16px 20px 0 #0000001f;
+	`,
 };
 
 export default shadow;

--- a/src/utils/generateQuarterTimes.ts
+++ b/src/utils/generateQuarterTimes.ts
@@ -1,0 +1,17 @@
+/**  15분 간격으로 시간을 생성하는 함수 */
+const generateQuarterTimes = () => {
+	const times = [];
+	for (let hour = 0; hour < 24; hour += 1) {
+		for (let minute = 0; minute < 60; minute += 15) {
+			const period = hour < 12 ? 'am' : 'pm';
+			const formattedHour = (hour % 12 === 0 ? 12 : hour % 12).toString().padStart(2, '0');
+			const formattedMinute = minute.toString().padStart(2, '0');
+			times.push(`${formattedHour}:${formattedMinute} ${period}`);
+		}
+	}
+	return times;
+};
+
+const quarterTimes = generateQuarterTimes();
+
+export default quarterTimes;

--- a/src/utils/generateQuarterTimes.ts
+++ b/src/utils/generateQuarterTimes.ts
@@ -4,7 +4,7 @@ const generateQuarterTimes = () => {
 	for (let hour = 0; hour < 24; hour += 1) {
 		for (let minute = 0; minute < 60; minute += 15) {
 			const period = hour < 12 ? 'am' : 'pm';
-			const formattedHour = (hour % 12 === 0 ? 12 : hour % 12).toString().padStart(2, '0');
+			const formattedHour = hour.toString().padStart(2, '0');
 			const formattedMinute = minute.toString().padStart(2, '0');
 			times.push(`${formattedHour}:${formattedMinute} ${period}`);
 		}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 시간선택 드랍다운 컴포넌트 구현
- 할 일 상태 드랍다운 컴포넌트 구현
- 정렬 드랍다운 컴포넌트 구현
- 캘린서 설정 드랍다운 컴포넌트 구현

## 알게된 점 :rocket:

> 기록하며 개발하기!

- scrollbar의 커스텀을 진행하면서 `::-webkit-scrollbar`는 스크롤바 전체를 의미하고, `::-webkit-scrollbar-thumb`는 스크롤 바의 막대를 의미함을 알게되었습니다.
- `::-webkit-scrollbar-thumb`의 경우 padding이나 margin을 줄 수 없어서 `background-clip: padding-box; border: 4px solid transparent;`를 통해서 border를 투명한 색으로 주어 thumb과 track의 공간을 주었습니다. 
- `::-webkit-scrollbar-thumb`의 height는 직접 지정할 수 없고 스크롤되는 크기에 따라서 동적으로 적용되며 최소 길이 이상으로 줄일 수 없음을 알게되었습니다. => 스크롤할 내용이 많을 수록 스크롤바의 높이가 작아지고 스크롤할 내용이 적을수록 스크롤바의 높이가 길어진다!


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 피그마 상으로는 시간선택 드랍다운 컴포넌트가 divider가 있는 버전과 없는 버전으로 2가지인데 디자이너분께 해당 2가지 버전의 쓰임을 여쭤보니 다른 것 먼저 작업하라는 답변을 받아서 일단 divider가 없는 버전의 시간 선택 드랍다운만 만들었습니다.
- theme의 컬러코드가 피그마상과 차이가 있는 부분이 몇군데 있어서 (다 grey4인데 컴포넌트별로 색상차이가 있음) 해당 부분 12월 4일에 있는 회의에서 말씀드리려고 합니다.
## 관련 이슈

close #311 

## 스크린샷 (선택)
<img width="405" alt="image" src="https://github.com/user-attachments/assets/eb19d688-d199-48cb-b548-b59be0e69a1b">
<img width="398" alt="image" src="https://github.com/user-attachments/assets/a65ba246-bc16-4f64-8f95-ac0b4546acc2">
<img width="394" alt="image" src="https://github.com/user-attachments/assets/af5240be-8403-4dbe-8dec-ea38c2aedbc4">
<img width="397" alt="image" src="https://github.com/user-attachments/assets/2ccf037c-6b00-42e1-bb47-acffa89af574">
