### PR TITLE
[FEAT] Toast 컴포넌트 퍼블리싱

### DIFF
--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -14,7 +14,7 @@ const usePostTimeBlock = () => {
 			const response = await CreateTimeBlock({ taskId, startTime, endTime });
 			/** response.code가 conflict일 때 타임블록 에러 토스트 출력 */
 			if (response && response.code === 'conflict') {
-				addToast(response.message);
+				addToast(response.message, response.code);
 				throw new Error('conflict');
 			}
 			return response;

--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -12,10 +12,10 @@ const usePostTimeBlock = () => {
 	const { mutate, isError } = useMutation({
 		mutationFn: async ({ taskId, startTime, endTime }: PostTimeBlokType) => {
 			const response = await CreateTimeBlock({ taskId, startTime, endTime });
-			/** response.code가 conflict일 때 타임블록 에러 토스트 출력 */
-			if (response && response.code === 'conflict') {
+			/** response.code가 error일 때 타임블록 에러 토스트 출력 */
+			if (response && response.code === 'error') {
 				addToast(response.message, response.code);
-				throw new Error('conflict');
+				throw new Error('error');
 			}
 			return response;
 		},

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -13,7 +13,7 @@ const usePatchTimeBlock = () => {
 		mutationFn: async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime });
 			if (response && response.code === 'conflict') {
-				addToast(response.message);
+				addToast(response.message, response.code);
 				throw new Error('conflict');
 			}
 			return response;

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -12,9 +12,9 @@ const usePatchTimeBlock = () => {
 	const mutation = useMutation({
 		mutationFn: async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime });
-			if (response && response.code === 'conflict') {
+			if (response && response.code === 'error') {
 				addToast(response.message, response.code);
-				throw new Error('conflict');
+				throw new Error('error');
 			}
 			return response;
 		},

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -2,11 +2,24 @@ import styled from '@emotion/styled';
 import { useEffect } from 'react';
 
 import Icon from '@/components/common/Icon';
+import { ToastType } from '@/types/toastType';
+
+const toastIcon: Record<ToastType, { icon: JSX.Element }> = {
+	success: {
+		icon: <Icon name="IcnReturnCheck" />,
+	},
+	error: {
+		icon: <Icon name="IcnDelete" />,
+	},
+	info: {
+		icon: <Icon name="IcnAlert" />,
+	},
+};
 
 interface ToastProps {
 	message: string;
 	onClose: () => void;
-	code: string; // success, conflict, info;
+	code: ToastType;
 }
 
 function Toast({ message, onClose, code }: ToastProps) {
@@ -15,23 +28,12 @@ function Toast({ message, onClose, code }: ToastProps) {
 		return () => clearTimeout(timer);
 	}, [onClose]);
 
-	const getIcon = () => {
-		switch (code) {
-			case 'success':
-				return <Icon name="IcnReturnCheck" />;
-			case 'conflict':
-				return <Icon name="IcnDelete" />;
-			case 'info':
-				return <Icon name="IcnAlert" />;
-			default:
-				return <Icon name="IcnReturnCheck" />;
-		}
-	};
+	const { icon } = toastIcon[code];
 
 	return (
 		<ToastMessage code={code}>
 			<TextLayout>
-				{getIcon()}
+				{icon}
 				{message}
 			</TextLayout>
 			<RevertBox>
@@ -57,7 +59,7 @@ const ToastMessage = styled.div<{ code: string }>`
 		switch (code) {
 			case 'success':
 				return theme.colorToken.Primary.normal;
-			case 'conflict':
+			case 'error':
 				return theme.color.Orange.Orange5;
 			case 'info':
 				return theme.color.Grey.Grey7;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 
-import Icn from '@/assets/svg/V2';
+import Icon from '@/components/common/Icon';
 
 interface ToastProps {
 	message: string;
@@ -18,13 +18,13 @@ function Toast({ message, onClose, code }: ToastProps) {
 	const getIcon = () => {
 		switch (code) {
 			case 'success':
-				return <Icn.IcnReturnCheck />;
+				return <Icon name="IcnReturnCheck" />;
 			case 'conflict':
-				return <Icn.IcnDelete />;
+				return <Icon name="IcnDelete" />;
 			case 'info':
-				return <Icn.IcnAlert />;
+				return <Icon name="IcnAlert" />;
 			default:
-				return <Icn.IcnReturnCheck />;
+				return <Icon name="IcnReturnCheck" />;
 		}
 	};
 
@@ -36,7 +36,7 @@ function Toast({ message, onClose, code }: ToastProps) {
 			</TextLayout>
 			<RevertBox>
 				<RevertText>되돌리기</RevertText>
-				<Icn.IcnX />
+				<Icon name="IcnX" />
 			</RevertBox>
 		</ToastMessage>
 	);

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,46 +1,77 @@
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 
+import Icn from '@/assets/svg/V2';
+
 interface ToastProps {
 	message: string;
 	onClose: () => void;
+	code: string; // success, conflict, info;
 }
 
-function Toast({ message, onClose }: ToastProps) {
+function Toast({ message, onClose, code }: ToastProps) {
 	useEffect(() => {
 		const timer = setTimeout(onClose, 3000);
 		return () => clearTimeout(timer);
 	}, [onClose]);
 
-	return <ToastMessage>{message}</ToastMessage>;
+	const getIcon = () => {
+		switch (code) {
+			case 'success':
+				return <Icn.IcnReturnCheck />;
+			case 'conflict':
+				return <Icn.IcnDelete />;
+			case 'info':
+				return <Icn.IcnAlert />;
+			default:
+				return <Icn.IcnReturnCheck />;
+		}
+	};
+
+	return (
+		<ToastMessage code={code}>
+			<TextLayout>
+				{getIcon()}
+				{message}
+			</TextLayout>
+			<RevertBox>
+				<RevertText>되돌리기</RevertText>
+				<Icn.IcnX />
+			</RevertBox>
+		</ToastMessage>
+	);
 }
 
-const ToastMessage = styled.div`
+const ToastMessage = styled.div<{ code: string }>`
 	display: flex;
 	align-items: center;
-	padding: 1rem 2rem;
+	justify-content: space-between;
+	box-sizing: border-box;
+	width: 44rem;
+	height: 6.4rem;
+	padding: 1.6rem;
 
-	color: ${({ theme }) => theme.palette.Grey.Black};
-	${({ theme }) => theme.fontTheme.LABEL_02};
+	color: ${({ theme }) => theme.colorToken.Text.neutralDark};
 
-	background-color: #fff;
-	box-shadow: 0 16px 35px 0 rgb(72 87 120 / 25%);
+	background-color: ${({ theme, code }) => {
+		switch (code) {
+			case 'success':
+				return theme.colorToken.Primary.normal;
+			case 'conflict':
+				return theme.color.Orange.Orange5;
+			case 'info':
+				return theme.color.Grey.Grey7;
+			default:
+				return theme.colorToken.Primary.normal;
+		}
+	}};
 	transform: translateX(100%);
-	opacity: 0;
-	border-radius: 5px;
+	border-radius: 12px;
+	${({ theme }) => theme.font.label03};
 
 	animation:
 		slide-in 0.3s forwards,
 		fade-out 0.3s forwards 2.7s;
-
-	&::before {
-		margin-right: 1rem;
-
-		color: ${({ theme }) => theme.palette.Primary};
-		font-weight: bold;
-
-		content: '!';
-	}
 
 	@keyframes slide-in {
 		to {
@@ -55,6 +86,39 @@ const ToastMessage = styled.div`
 			opacity: 0;
 		}
 	}
+`;
+
+const TextLayout = styled.div`
+	display: flex;
+	gap: 0.8rem;
+	align-items: center;
+	width: 26.8rem;
+
+	svg {
+		width: 2.4rem;
+		height: 2.4rem;
+	}
+`;
+
+const RevertBox = styled.div`
+	display: flex;
+	align-items: center;
+
+	cursor: pointer;
+	opacity: 0.7;
+
+	svg {
+		width: 2.4rem;
+		height: 2.4rem;
+	}
+`;
+
+const RevertText = styled.p`
+	width: 5.2rem;
+	height: 1.5rem;
+	margin: 0 1.6rem;
+
+	${({ theme }) => theme.font.label04};
 `;
 
 export default Toast;

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -8,8 +8,8 @@ function ToastContainer() {
 
 	return (
 		<Container>
-			{toasts.map((toast) => (
-				<Toast key={toast.id} message={toast.message} code={toast.code} onClose={() => removeToast(toast.id)} />
+			{toasts.map(({ id, message, code }) => (
+				<Toast key={id} message={message} code={code} onClose={() => removeToast(id)} />
 			))}
 		</Container>
 	);

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -9,7 +9,7 @@ function ToastContainer() {
 	return (
 		<Container>
 			{toasts.map((toast) => (
-				<Toast key={toast.id} message={toast.message} onClose={() => removeToast(toast.id)} />
+				<Toast key={toast.id} message={toast.message} code={toast.code} onClose={() => removeToast(toast.id)} />
 			))}
 		</Container>
 	);

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -1,16 +1,17 @@
 import { createContext, useContext, useState, useMemo, ReactNode } from 'react';
 
 import ToastContainer from '@/components/toast/ToastContainer';
+import { ToastType } from '@/types/toastType';
 
 interface ToastItem {
 	id: number;
 	message: string;
-	code: string;
+	code: ToastType;
 }
 
 interface ToastContextProps {
 	toasts: ToastItem[];
-	addToast: (message: string, code: string) => void;
+	addToast: (message: string, code: ToastType) => void;
 	removeToast: (id: number) => void;
 }
 
@@ -27,7 +28,7 @@ export const useToast = () => {
 export function ToastProvider({ children }: { children: ReactNode }) {
 	const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-	const addToast = (message: string, code: string) => {
+	const addToast = (message: string, code: ToastType) => {
 		const id = new Date().getTime();
 		setToasts((prevToasts) => [...prevToasts, { id, message, code }]);
 	};

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -5,11 +5,12 @@ import ToastContainer from '@/components/toast/ToastContainer';
 interface ToastItem {
 	id: number;
 	message: string;
+	code: string;
 }
 
 interface ToastContextProps {
 	toasts: ToastItem[];
-	addToast: (message: string) => void;
+	addToast: (message: string, code: string) => void;
 	removeToast: (id: number) => void;
 }
 
@@ -26,9 +27,9 @@ export const useToast = () => {
 export function ToastProvider({ children }: { children: ReactNode }) {
 	const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-	const addToast = (message: string) => {
+	const addToast = (message: string, code: string) => {
 		const id = new Date().getTime();
-		setToasts((prevToasts) => [...prevToasts, { id, message }]);
+		setToasts((prevToasts) => [...prevToasts, { id, message, code }]);
 	};
 
 	const removeToast = (id: number) => {

--- a/src/stories/Common/toast/Toast.stories.tsx
+++ b/src/stories/Common/toast/Toast.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import Toast from '@/components/toast/Toast';
+
+const meta = {
+	title: 'Common/Toast',
+	component: Toast,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs'],
+	args: { onClose: fn() },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SuccessToast: Story = {
+	args: {
+		message: '할 일을 완료했어요',
+		onClose: fn(),
+		code: 'success',
+	},
+};
+
+export const ConflictToast: Story = {
+	args: {
+		message: '할 일을 완료했어요',
+		onClose: fn(),
+		code: 'conflict',
+	},
+};
+
+export const InfoToast: Story = {
+	args: {
+		message: '할 일을 완료했어요',
+		onClose: fn(),
+		code: 'info',
+	},
+};

--- a/src/stories/Common/toast/Toast.stories.tsx
+++ b/src/stories/Common/toast/Toast.stories.tsx
@@ -25,11 +25,11 @@ export const SuccessToast: Story = {
 	},
 };
 
-export const ConflictToast: Story = {
+export const ErrorToast: Story = {
 	args: {
 		message: '할 일을 완료했어요',
 		onClose: fn(),
-		code: 'conflict',
+		code: 'error',
 	},
 };
 

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -18,6 +18,9 @@ const color = {
 		Grey7: '#626273',
 		Grey8: '#34343C',
 	},
+	Orange: {
+		Orange5: '#FF8A65',
+	},
 };
 
 export default color;

--- a/src/types/toastType.ts
+++ b/src/types/toastType.ts
@@ -1,0 +1,1 @@
+export type ToastType = 'success' | 'error' | 'info';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- success, conflict, info 3가지 상황에 맞는 toast 컴포넌트 퍼블리싱을 하였습니다.
- 기존에 있던 toast 컴포넌트에 props로 code를 추가하여 code에 따라 아이콘과 배경색상을 변경하였습니다. 

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 기존의 theme에 orange 색상이 없어서 추가하였는데 추가하는김에 오렌지를 다 추가할까하다가 컴포넌트상에서 오렌지를 사용하는 게 orange5말고는 안보여서 디자이너 선생님들께서 다 사용하는 색상이라고 말씀해주시면 추후에 추가하고자 합니다.
- 이전까지 서버측에서 오류가 날 경우 code에 "conflict"를 담아서 보내주셔서 success, conflict, info로 코드를 정의하였습니다. 추후에 api관련 회의를 할 때 서버 측에도  success, conflict, info를 설명드리겠습니다!

## 관련 이슈

close #313

## 스크린샷 (선택)
![Dec-08-2024 16-03-29](https://github.com/user-attachments/assets/4108b2d4-2f6c-4b4f-b196-5e44f896d73a)
