### PR TITLE
[FEAT] datepicker 모달 디자인 수정

### DIFF
--- a/src/components/common/BtnDate/BtnDate.tsx
+++ b/src/components/common/BtnDate/BtnDate.tsx
@@ -19,7 +19,6 @@ interface BtnDateProps {
 	isDelayed?: boolean;
 	isDisabled?: boolean;
 	handleDate?: (newDate: string) => void;
-	handleTime?: (newTime: string) => void;
 }
 // date, time 각각 Date|null, String|null 로 관리
 // 값이 없으면 '마감 기한' 등 텍스트 설정,
@@ -33,7 +32,6 @@ function BtnDate(props: BtnDateProps) {
 		isDelayed = false,
 		isDisabled = false,
 		handleDate,
-		handleTime,
 	} = props;
 	const [isPressed, setIsPressed] = useState(false);
 	const [isClicked, setIsClicked] = useState(false);
@@ -88,10 +86,8 @@ function BtnDate(props: BtnDateProps) {
 							size.type !== 'long' ? MODAL.DATE_CORRECTION.SET_DEADLINE.left : MODAL.DATE_CORRECTION.TASK_MODAL.left
 						}
 						date={date}
-						time={time}
 						onClick={handleMouseUp}
 						handleCurrentDate={(newDate: Date) => handleDate?.(parseDate(newDate.toString()))}
-						handleCurrentTime={handleTime}
 					/>
 					<ModalBackdrop onClick={handleMouseUp} />
 				</>

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -11,6 +11,7 @@ interface CustomHeaderProps {
 	prevMonthButtonDisabled: boolean;
 	nextMonthButtonDisabled: boolean;
 	onChange: (date: Date | null) => void;
+	onClose: () => void;
 }
 
 function CorrectionCustomHeader({
@@ -20,12 +21,13 @@ function CorrectionCustomHeader({
 	prevMonthButtonDisabled,
 	nextMonthButtonDisabled,
 	onChange,
+	onClose,
 }: CustomHeaderProps) {
 	const selectedDate = selected || new Date();
 	const today = new Date();
 	return (
 		<HeaderLayout className="react-datepicker__header-custom">
-			<IconButton iconName="IcnX" size="small" type="normal" disabled={false} onClick={() => {}} />
+			<IconButton iconName="IcnX" size="small" type="normal" disabled={false} onClick={onClose} />
 			<DateWrapper>
 				<MainDate
 					month={selectedDate.getUTCMonth() + 1}

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -1,3 +1,4 @@
+import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Button from '../v2/button/Button';
@@ -25,14 +26,27 @@ function CorrectionCustomHeader({
 }: CustomHeaderProps) {
 	const selectedDate = selected || new Date();
 	const today = new Date();
+	const { colorToken, color } = useTheme();
+	const ButtonColorCss = css`
+		color: ${color.Grey.Grey5};
+
+		border: solid 1px ${colorToken.Outline.neutralNormal};
+	`;
+	const IconButtonColorCss = css`
+		color: ${color.Grey.Grey4};
+	`;
 	return (
 		<HeaderLayout className="react-datepicker__header-custom">
-			<IconButton iconName="IcnX" size="small" type="normal" disabled={false} onClick={onClose} />
+			<IconButton
+				iconName="IcnX"
+				size="small"
+				type="normal"
+				disabled={false}
+				onClick={onClose}
+				additionalCss={IconButtonColorCss}
+			/>
 			<DateWrapper>
-				<MainDate
-					month={selectedDate.getUTCMonth() + 1}
-					year={selectedDate.getUTCFullYear()}
-				/>
+				<MainDate month={selectedDate.getUTCMonth() + 1} year={selectedDate.getUTCFullYear()} />
 			</DateWrapper>
 			<div className="react-datepicker__navigation-wrapper">
 				<BtnWrapper className="react-datepicker__navigation-container">
@@ -43,6 +57,7 @@ function CorrectionCustomHeader({
 						size="medium"
 						type="outlined-assistive"
 						onClick={() => onChange(today)}
+						additionalCss={ButtonColorCss}
 					/>
 					<IconButton
 						iconName="IcnLeft"
@@ -67,6 +82,7 @@ function CorrectionCustomHeader({
 		</HeaderLayout>
 	);
 }
+
 const HeaderLayout = styled.div`
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -31,7 +31,6 @@ function CorrectionCustomHeader({
 			<DateWrapper>
 				<MainDate
 					month={selectedDate.getUTCMonth() + 1}
-					day={selectedDate.getUTCDate()}
 					year={selectedDate.getUTCFullYear()}
 				/>
 			</DateWrapper>

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
 
-import ArrangeBtn from '../arrangeBtn/ArrangeBtn';
-import TextboxInput from '../textbox/TextboxInput';
-
-import formatDatetoString from '@/utils/formatDatetoString';
+import Button from '../v2/button/Button';
+import IconButton from '../v2/IconButton';
+import MainDate from '../v2/TextBox/MainDate';
 
 interface CustomHeaderProps {
-	prevDate: Date | null;
+	selected: Date | null;
 	decreaseMonth: () => void;
 	increaseMonth: () => void;
 	prevMonthButtonDisabled: boolean;
@@ -16,7 +15,7 @@ interface CustomHeaderProps {
 }
 
 function CorrectionCustomHeader({
-	prevDate,
+	selected,
 	decreaseMonth,
 	increaseMonth,
 	prevMonthButtonDisabled,
@@ -24,52 +23,65 @@ function CorrectionCustomHeader({
 	onChange,
 	dateTextRef,
 }: CustomHeaderProps) {
+	const selectedDate = selected || new Date();
+	const today = new Date();
 	return (
-		<div className="react-datepicker__header-custom">
-			<InfoBox>
-				<TextboxInput
-					variant="date"
-					placeholder={formatDatetoString(prevDate)}
-					onDateChange={onChange}
-					dateTextRef={dateTextRef}
+		<HeaderLayout className="react-datepicker__header-custom">
+			<IconButton iconName="IcnX" size="small" type="normal" disabled={false} onClick={() => {}} />
+			<DateWrapper>
+				<MainDate
+					month={selectedDate.getUTCMonth() + 1}
+					day={selectedDate.getUTCDate()}
+					year={selectedDate.getUTCFullYear()}
 				/>
-				<div className="react-datepicker__navigation-wrapper">
-					<BtnWrapper className="react-datepicker__navigation-container">
-						<ArrangeBtn
-							color="WHITE"
-							mode="DEFAULT"
-							size="small"
-							type="left"
-							className="react-datepicker__navigation react-datepicker__navigation--previous"
-							onClick={decreaseMonth}
-							disabled={prevMonthButtonDisabled}
-							aria-label="Previous Month"
-						/>
-						<ArrangeBtn
-							color="WHITE"
-							mode="DEFAULT"
-							size="small"
-							type="right"
-							className="react-datepicker__navigation react-datepicker__navigation--next"
-							onClick={increaseMonth}
-							disabled={nextMonthButtonDisabled}
-							aria-label="Next Month"
-						/>
-					</BtnWrapper>
-				</div>
-			</InfoBox>
-		</div>
+			</DateWrapper>
+			<div className="react-datepicker__navigation-wrapper">
+				<BtnWrapper className="react-datepicker__navigation-container">
+					<Button
+						leftIcon="IcnCalendar"
+						disabled={false}
+						label="오늘"
+						size="medium"
+						type="outlined-assistive"
+						onClick={() => onChange(today)}
+					/>
+					<IconButton
+						iconName="IcnLeft"
+						size="small"
+						type="outlined"
+						onClick={decreaseMonth}
+						disabled={prevMonthButtonDisabled}
+						aria-label="Previous Month"
+						// className="react-datepicker__navigation react-datepicker__navigation--previous"
+					/>
+					<IconButton
+						iconName="IcnRight"
+						size="small"
+						type="outlined"
+						onClick={increaseMonth}
+						disabled={nextMonthButtonDisabled}
+						aria-label="Next Month"
+						// className="react-datepicker__navigation react-datepicker__navigation--next"
+					/>
+				</BtnWrapper>
+			</div>
+		</HeaderLayout>
 	);
 }
+const HeaderLayout = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	width: 100%;
+`;
+const DateWrapper = styled.div`
+	align-self: flex-start;
+	padding: 1.6rem 0 0.8rem;
+`;
 const BtnWrapper = styled.div`
 	display: flex;
+	gap: 0.8rem;
 	justify-content: flex-end;
 `;
-const InfoBox = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	width: 20.4rem;
-	padding-bottom: 0.6rem;
-`;
+
 export default CorrectionCustomHeader;

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -6,7 +6,7 @@ import IconButton from '../v2/IconButton';
 import MainDate from '../v2/TextBox/MainDate';
 
 interface CustomHeaderProps {
-	selected: Date | null;
+	date: Date;
 	decreaseMonth: () => void;
 	increaseMonth: () => void;
 	prevMonthButtonDisabled: boolean;
@@ -16,7 +16,7 @@ interface CustomHeaderProps {
 }
 
 function CorrectionCustomHeader({
-	selected,
+	date,
 	decreaseMonth,
 	increaseMonth,
 	prevMonthButtonDisabled,
@@ -24,7 +24,6 @@ function CorrectionCustomHeader({
 	onChange,
 	onClose,
 }: CustomHeaderProps) {
-	const selectedDate = selected || new Date();
 	const today = new Date();
 	const { colorToken, color } = useTheme();
 	const ButtonColorCss = css`
@@ -46,7 +45,7 @@ function CorrectionCustomHeader({
 				additionalCss={IconButtonColorCss}
 			/>
 			<DateWrapper>
-				<MainDate month={selectedDate.getUTCMonth() + 1} year={selectedDate.getUTCFullYear()} />
+				<MainDate month={date.getUTCMonth() + 1} year={date.getUTCFullYear()} />
 			</DateWrapper>
 			<div className="react-datepicker__navigation-wrapper">
 				<BtnWrapper className="react-datepicker__navigation-container">

--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -11,7 +11,6 @@ interface CustomHeaderProps {
 	prevMonthButtonDisabled: boolean;
 	nextMonthButtonDisabled: boolean;
 	onChange: (date: Date | null) => void;
-	dateTextRef: React.RefObject<HTMLInputElement>;
 }
 
 function CorrectionCustomHeader({
@@ -21,7 +20,6 @@ function CorrectionCustomHeader({
 	prevMonthButtonDisabled,
 	nextMonthButtonDisabled,
 	onChange,
-	dateTextRef,
 }: CustomHeaderProps) {
 	const selectedDate = selected || new Date();
 	const today = new Date();

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -33,9 +33,13 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 			blurRef(dateTextRef);
 		}
 	};
-	/** 모달 확인, 닫기버튼 */
+	/** 모달 확인버튼 */
 	const onSave = () => {
 		if (handleCurrentDate && currentDate) handleCurrentDate(currentDate);
+		onClick();
+	};
+	/** 모달 닫기 */
+	const onClose = () => {
 		onClick();
 	};
 	return (
@@ -46,7 +50,9 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 				onChange={onChange}
 				inline
 				calendarContainer={CalendarStyle}
-				renderCustomHeader={(props) => <CorrectionCustomHeader {...props} selected={currentDate} onChange={onChange} />}
+				renderCustomHeader={(props) => (
+					<CorrectionCustomHeader {...props} selected={currentDate} onChange={onChange} onClose={onClose} />
+				)}
 			>
 				<BottomBtnWrapper>
 					<Button label="확인" disabled={false} size="medium" type="solid" onClick={onSave} />

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -46,9 +46,7 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 				onChange={onChange}
 				inline
 				calendarContainer={CalendarStyle}
-				renderCustomHeader={(props) => (
-					<CorrectionCustomHeader {...props} selected={currentDate} dateTextRef={dateTextRef} onChange={onChange} />
-				)}
+				renderCustomHeader={(props) => <CorrectionCustomHeader {...props} selected={currentDate} onChange={onChange} />}
 			>
 				<BottomBtnWrapper>
 					<Button label="확인" disabled={false} size="medium" type="solid" onClick={onSave} />

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -4,8 +4,7 @@ import { useRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
-import TextBtn from '../button/textBtn/TextBtn';
-import TextboxInput from '../textbox/TextboxInput';
+import Button from '../v2/button/Button';
 
 import CorrectionCustomHeader from './CorrectionCustomHeader';
 import CalendarStyle from './DatePickerStyle';
@@ -14,31 +13,17 @@ import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef } from '@/utils/refStatus';
 
 interface DateCorrectionModalProps {
-	isDateOnly?: boolean;
 	top?: number;
 	left?: number;
 	date: string | null;
-	time: string | null;
 	onClick: () => void;
 	handleCurrentDate?: (newDate: Date) => void;
-	handleCurrentTime?: (newTime: string) => void;
 }
 
-function DateCorrectionModal({
-	isDateOnly = false,
-	top = 0,
-	left = 0,
-	date,
-	time,
-	onClick,
-	handleCurrentDate,
-	handleCurrentTime,
-}: DateCorrectionModalProps) {
+function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDate }: DateCorrectionModalProps) {
 	const prevDate = date ? new Date(date) : null;
 	const [currentDate, setCurrentDate] = useState<Date | null>(prevDate);
-	const [currentTime, setCurrentTime] = useState<string | null>(time);
 	const dateTextRef = useRef<HTMLInputElement>(null);
-	const timeTextRef = useRef<HTMLInputElement>(null);
 
 	const onChange = (newDate: Date | null) => {
 		setCurrentDate(newDate);
@@ -48,13 +33,9 @@ function DateCorrectionModal({
 			blurRef(dateTextRef);
 		}
 	};
-	const onTimeChange = (newTime: string | null) => {
-		setCurrentTime(newTime);
-	};
 	/** 모달 확인, 닫기버튼 */
 	const onSave = () => {
 		if (handleCurrentDate && currentDate) handleCurrentDate(currentDate);
-		if (handleCurrentTime && currentTime) handleCurrentTime(currentTime);
 		onClick();
 	};
 	return (
@@ -66,19 +47,11 @@ function DateCorrectionModal({
 				inline
 				calendarContainer={CalendarStyle}
 				renderCustomHeader={(props) => (
-					<CorrectionCustomHeader {...props} prevDate={prevDate} dateTextRef={dateTextRef} onChange={onChange} />
+					<CorrectionCustomHeader {...props} selected={currentDate} dateTextRef={dateTextRef} onChange={onChange} />
 				)}
 			>
 				<BottomBtnWrapper>
-					{!isDateOnly && (
-						<TextboxInput
-							variant="time"
-							dateTextRef={timeTextRef}
-							onTimeChange={onTimeChange}
-							currentTime={currentTime}
-						/>
-					)}
-					<TextBtn text="확인" color="BLACK" size="small" mode="DEFAULT" isHover isPressed onClick={onSave} />
+					<Button label="확인" disabled={false} size="medium" type="solid" onClick={onSave} />
 				</BottomBtnWrapper>
 			</DatePicker>
 		</DateCorrectionModalLayout>
@@ -93,9 +66,6 @@ const DateCorrectionModalLayout = styled.div<{ top: number; left: number }>`
 `;
 
 const BottomBtnWrapper = styled.div`
-	display: flex;
-	gap: 0.5rem;
-	justify-content: flex-end;
-	width: 100%;
+	padding-top: 3.2rem;
 `;
 export default DateCorrectionModal;

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -50,9 +50,7 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 				onChange={onChange}
 				inline
 				calendarContainer={CalendarStyle}
-				renderCustomHeader={(props) => (
-					<CorrectionCustomHeader {...props} selected={currentDate} onChange={onChange} onClose={onClose} />
-				)}
+				renderCustomHeader={(props) => <CorrectionCustomHeader {...props} onChange={onChange} onClose={onClose} />}
 			>
 				<BottomBtnWrapper>
 					<Button label="확인" disabled={false} size="medium" type="solid" onClick={onSave} />

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -60,6 +60,7 @@ const CalendarStyle = styled.div`
 		width: 5.2rem;
 		height: 4rem;
 		margin: 0;
+		margin-bottom: 0.8rem;
 
 		color: ${({ theme }) => theme.palette.Grey.Grey5};
 		${({ theme }) => theme.font.label03};

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -89,8 +89,12 @@ const CalendarStyle = styled.div`
 		height: 4rem;
 		margin: 0;
 
-		border-radius: 0;
+		border-radius: 6px;
+
 		${({ theme }) => theme.font.label03};
+		:hover {
+			background-color: ${({ theme }) => theme.colorToken.Primary.strongVariant};
+		}
 	}
 
 	.react-datepicker__day--keyboard-selected {
@@ -108,6 +112,10 @@ const CalendarStyle = styled.div`
 
 		background-color: ${({ theme }) => theme.colorToken.Primary.normal};
 		border-radius: 6px;
+
+		:hover {
+			background-color: ${({ theme }) => theme.colorToken.Primary.strong};
+		}
 	}
 
 	.react-datepicker__day--in-selecting-range {

--- a/src/components/common/datePicker/DatePickerStyle.tsx
+++ b/src/components/common/datePicker/DatePickerStyle.tsx
@@ -6,12 +6,13 @@ const CalendarStyle = styled.div`
 	flex-direction: column;
 	flex-shrink: 0;
 	align-items: center;
-	width: 22.8rem;
-	height: 27rem;
-	padding: 1.6rem 0;
+	box-sizing: border-box;
+	width: 41.2rem;
+	height: fit-content;
+	padding: 2.4rem 2.4rem 3.2rem;
 	overflow: auto;
 
-	box-shadow: 0 3px 7px 0 rgb(0 0 0 / 38%);
+	${({ theme }) => theme.shadow.FloatingAction1};
 	border: 0;
 	border-radius: 12px;
 	/* stylelint-disable selector-class-pattern */
@@ -38,6 +39,7 @@ const CalendarStyle = styled.div`
 	}
 
 	.react-datepicker__header {
+		width: 100%;
 		padding: 0;
 
 		background-color: transparent;
@@ -45,22 +47,37 @@ const CalendarStyle = styled.div`
 	}
 
 	.react-datepicker__day-names {
-		margin-bottom: 0.7rem;
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+		padding-top: 1.6rem;
 	}
 
 	.react-datepicker__day-name {
-		width: 2.8rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 5.2rem;
+		height: 4rem;
 		margin: 0;
 
 		color: ${({ theme }) => theme.palette.Grey.Grey5};
-		${({ theme }) => theme.fontTheme.CAPTION_04};
+		${({ theme }) => theme.font.label03};
+
+		:first-of-type {
+			color: ${({ theme }) => theme.palette.Orange.Orange6};
+		}
+
+		:last-of-type {
+			color: ${({ theme }) => theme.colorToken.Text.primary};
+		}
 	}
 
 	/** 주 날짜 */
 	.react-datepicker__week {
 		display: flex;
-		justify-content: center;
-		width: 22rem;
+		justify-content: space-between;
+		width: 100%;
 	}
 
 	/* 선택된 날짜 */
@@ -68,19 +85,28 @@ const CalendarStyle = styled.div`
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 2.8rem;
-		height: 2.8rem;
+		width: 5.2rem;
+		height: 4rem;
 		margin: 0;
 
 		border-radius: 0;
+		${({ theme }) => theme.font.label03};
 	}
 
 	.react-datepicker__day--keyboard-selected {
 		background-color: transparent;
 	}
 
+	.react-datepicker__day--today {
+		color: ${({ theme }) => theme.colorToken.Primary.normal};
+		text-decoration: underline;
+	}
+
 	.react-datepicker__day--selected {
-		background-color: ${({ theme }) => theme.palette.Primary};
+		color: ${({ theme }) => theme.color.Grey.White};
+		text-decoration: none;
+
+		background-color: ${({ theme }) => theme.colorToken.Primary.normal};
 		border-radius: 6px;
 	}
 
@@ -107,13 +133,13 @@ const CalendarStyle = styled.div`
 
 	/* 이번 월에 포함되지 않는 날짜 */
 	.react-datepicker__day--outside-month {
-		color: ${({ theme }) => theme.palette.Grey.Grey4};
+		color: ${({ theme }) => theme.colorToken.Text.disable};
 	}
 
 	.react-datepicker__children-container {
 		display: flex;
 		justify-content: end;
-		width: 20.4rem;
+		width: 100%;
 		margin: 0;
 		padding: 0;
 	}

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -62,10 +62,6 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, locat
 		setDeadLineDate(newDate);
 	};
 
-	const handleTaskTimeChange = (newTime: string) => {
-		setDeadLineTime(newTime);
-	};
-
 	const [startTime, setStartTime] = useState('');
 	const [endTime, setEndTime] = useState('');
 
@@ -130,12 +126,7 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, locat
 		<ModalBackdrop onClick={onClose}>
 			<ModalLayout type={sizeType.type} top={top} left={left} onClick={(e) => e.stopPropagation()}>
 				<ModalHeader>
-					<BtnDate
-						date={deadLineDate}
-						time={deadLineTime}
-						handleDate={handleTaskDateChange}
-						handleTime={handleTaskTimeChange}
-					/>
+					<BtnDate date={deadLineDate} time={deadLineTime} handleDate={handleTaskDateChange} />
 					<ModalHeaderBtn type={sizeType.type} onDelete={handleDelete} taskId={taskId} targetDate={targetDate} />
 				</ModalHeader>
 				<ModalBody>

--- a/src/components/common/textbox/TextInputStaging.tsx
+++ b/src/components/common/textbox/TextInputStaging.tsx
@@ -23,10 +23,6 @@ function TextInputStaging() {
 		setDate(new Date(newDate));
 	};
 
-	const handleTime = (newTime: string) => {
-		setTime(newTime);
-	};
-
 	const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		setTaskName(e.target.value);
 	};
@@ -72,13 +68,7 @@ function TextInputStaging() {
 			<BtnWrapper>
 				<SetDeadLineContainer>
 					{time || date ? (
-						<BtnDate
-							date={formatDatetoString(date)}
-							time={time}
-							handleDate={handleDate}
-							handleTime={handleTime}
-							size={{ type: 'default' }}
-						/>
+						<BtnDate date={formatDatetoString(date)} time={time} handleDate={handleDate} size={{ type: 'default' }} />
 					) : (
 						<BtnStagingDate onClick={handleArrangeBtnClick} />
 					)}

--- a/src/components/common/v2/IconButton.tsx
+++ b/src/components/common/v2/IconButton.tsx
@@ -13,10 +13,11 @@ type IconButtonProps = {
 	disabled: boolean;
 	iconName: keyof typeof Icn;
 	onClick: () => void;
+	additionalCss?: SerializedStyles;
 };
 
-function IconButton({ type, size = 'small', disabled = false, iconName, onClick }: IconButtonProps) {
-	const { color } = useTheme();
+function IconButton({ type, size = 'small', disabled = false, iconName, onClick, additionalCss }: IconButtonProps) {
+	const { color, colorToken } = useTheme();
 	// 사이즈별 분기
 	const buttonSizes: Record<SizeType, SerializedStyles> = {
 		big: css`
@@ -63,7 +64,7 @@ function IconButton({ type, size = 'small', disabled = false, iconName, onClick 
 			css`
 				box-sizing: border-box;
 
-				border: solid 1px ${color.Grey.Grey4};
+				border: solid 1px ${colorToken.Outline.neutralNormal};
 			`}
 
 			:hover {
@@ -89,6 +90,8 @@ function IconButton({ type, size = 'small', disabled = false, iconName, onClick 
 
 		border-radius: 8px;
 		${buttonStyles[type]}
+
+		${additionalCss}
 	`;
 
 	const iconSize = size === 'big' ? 'large' : 'medium';

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -41,9 +41,7 @@ function TargetControlSection({
 							top={MODAL.DATE_CORRECTION.TARGET.top}
 							left={MODAL.DATE_CORRECTION.TARGET.left}
 							date={formatDatetoString(targetDate)}
-							time={null}
 							onClick={handleCloseModal}
-							isDateOnly
 							handleCurrentDate={onClickDatePicker}
 						/>
 					)}

--- a/src/stories/Common/DateCorrectionModal.stories.tsx
+++ b/src/stories/Common/DateCorrectionModal.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
+
+const meta: Meta<typeof DateCorrectionModal> = {
+	title: 'Common/DateCorrectionModal',
+	component: DateCorrectionModal,
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		top: { control: { type: 'number', min: 0, max: 20, step: 1 } },
+		left: { control: { type: 'number', min: 0, max: 20, step: 1 } },
+		date: { control: 'date' },
+	},
+	args: {
+		top: 5,
+		left: 5,
+		date: null,
+		onClick: fn(),
+		handleCurrentDate: fn(),
+	},
+} satisfies Meta<typeof DateCorrectionModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {},
+};
+
+export const Date: Story = {
+	args: {
+		date: '2024-12-18',
+	},
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 데이트피커 모달을 만들었습니다


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 안에 인풋창이 없어져서 ref 제거했고
- 기존에 시간도 한 모달에서 관리했었는데 이부분이 사라져서 + 모달로만 날짜 설정할 수 있게 되어서 많은 상태를 제거했습니다.
- 수정해서 기존에 사용하던 곳에서 빌드 터지지 않게 수정했는데 기능 연결, 작동에 문제가 있을 것 같아요. 나중에 페이지+기능 연결할 때 잘 수정해야 할 것 같습니다
- 주간 글자쪽 테마가 피그마에 미지정되어있어 댓글로 문의한 상태입니다.
- 오늘 버튼 선택시 피그마 요구사항에 오늘이 포함된 날을 보이도록 하라고 되어 있었는데, 오늘 날짜를 선택하지 않고서는 해당 기능 구현이 어려워 현재 오늘 날짜가 선택되도록 한 후 피그마에 문의 댓글 남겨놓은 상태입니다.

## 관련 이슈

close #318 

## 스크린샷 (선택)

<img width="392" alt="image" src="https://github.com/user-attachments/assets/bf1f1fc1-08e2-4fab-97a3-43d812670040" />


데이트피커 커스텀..햄드네요..