### PR TITLE
[FEAT] todo 목록 구현

### DIFF
--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -7,8 +7,11 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
+	align-items: center;
+	box-sizing: border-box;
 	width: 100%;
-	height: ${({ type }) => (type === 'staging' ? '56rem' : '61rem')};
+	height: 54rem;
+	padding-left: 0.8rem;
 	overflow: auto;
 	overflow-y: scroll;
 
@@ -17,12 +20,14 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	}
 
 	::-webkit-scrollbar-thumb {
-		background-color: ${theme.palette.Grey.Grey6};
+		height: 45%;
+
 		visibility: hidden;
-		border-radius: 3px;
+		border-radius: 6px;
 	}
 
 	&:hover::-webkit-scrollbar-thumb {
+		background-color: ${theme.colorToken.Neutral.accent};
 		visibility: visible;
 	}
 `;

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -7,7 +7,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
-	width: 31.8rem;
+	width: 100%;
 	height: ${({ type }) => (type === 'staging' ? '56rem' : '61rem')};
 	overflow: auto;
 	overflow-y: scroll;

--- a/src/components/common/v2/TextBox/MainDate.tsx
+++ b/src/components/common/v2/TextBox/MainDate.tsx
@@ -64,7 +64,7 @@ const DateContainer = styled.div`
 		${theme.font.label03};
 		padding-bottom: 0.3rem;
 
-		color: ${theme.color.Grey.Grey6};
+		color: ${theme.color.Grey.Grey5};
 	}
 `;
 

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -1,15 +1,19 @@
 import { css, useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
 import React, { useState } from 'react';
 
 import Button from '../button/Button';
+
+import StatusDropdown from '@/components/common/v2/dropdown/StatusDropdown';
 
 // 추후 type 로 빼기
 type TaskStatus = '미완료' | '진행중' | '완료';
 type DropdownButtonProps = {
 	status: TaskStatus;
+	handleStatusChange: (newStatus: TaskStatus) => void;
 };
 
-function DropdownButton({ status }: DropdownButtonProps) {
+function DropdownButton({ status, handleStatusChange }: DropdownButtonProps) {
 	const { shadow } = useTheme();
 
 	/** 임시 state */
@@ -25,6 +29,11 @@ function DropdownButton({ status }: DropdownButtonProps) {
 		setOpen((prev) => !prev);
 	};
 	/** 임시 state */
+
+	const handleStatus = (newStatus: TaskStatus) => {
+		handleStatusChange(newStatus);
+		setOpen(false);
+	};
 
 	/** status에 따른 버튼 스타일 타입 설정 */
 	const getDropdownBtnType = () => {
@@ -50,18 +59,26 @@ function DropdownButton({ status }: DropdownButtonProps) {
 
 	const iconType = isOpen ? 'IcnUp' : 'IcnDown';
 	return (
-		<button type="button" onMouseDown={handleMouseDown}>
-			<Button
-				type={getDropdownBtnType()}
-				label={status}
-				size="medium"
-				disabled={false}
-				rightIcon={iconType}
-				additionalCss={customStyle}
-				onClick={handleOpen}
-			/>
-		</button>
+		<DropdownWrapper>
+			<button type="button" onMouseDown={handleMouseDown}>
+				<Button
+					type={getDropdownBtnType()}
+					label={status}
+					size="medium"
+					disabled={false}
+					rightIcon={iconType}
+					additionalCss={customStyle}
+					onClick={handleOpen}
+				/>
+				{isOpen && <StatusDropdown currentStatus={status} handleStatusChange={handleStatus} />}
+			</button>
+		</DropdownWrapper>
 	);
 }
+
+const DropdownWrapper = styled.div`
+	position: relative;
+	display: inline-block;
+`;
 
 export default DropdownButton;

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -7,9 +7,10 @@ type Status = (typeof STATUSES)[keyof typeof STATUSES];
 
 interface StatusDropdownProps {
 	currentStatus: Status;
+	handleStatusChange: (newStatus: Status) => void;
 }
 
-function StatusDropdown({ currentStatus }: StatusDropdownProps) {
+function StatusDropdown({ currentStatus, handleStatusChange }: StatusDropdownProps) {
 	// 현재 상태를 제외한 나머지 상태 필터링
 	const visibleStatuses = Object.values(STATUSES).filter((status) => status !== currentStatus);
 
@@ -19,7 +20,7 @@ function StatusDropdown({ currentStatus }: StatusDropdownProps) {
 				<Button
 					key={status}
 					label={status}
-					onClick={() => {}}
+					onClick={() => handleStatusChange(status)}
 					size="large"
 					type={status === STATUSES.COMPLETED ? 'text-primary' : 'text-assistive'}
 				/>
@@ -29,6 +30,10 @@ function StatusDropdown({ currentStatus }: StatusDropdownProps) {
 }
 
 const StatusDropdownContainer = styled.div`
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	z-index: 2;
 	display: flex;
 	flex-direction: column;
 	gap: 0.6rem;
@@ -37,6 +42,7 @@ const StatusDropdownContainer = styled.div`
 	height: 11rem;
 	padding: 0.8rem;
 
+	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
 	border-radius: 12px;
 	${({ theme }) => theme.shadow.FloatingAction3};
 `;

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import DropdownButton from '../control/DropdownButton';
 
 import useTodoEventHandler from '@/hooks/useTodoEventHandler';
+import { STATUS } from '@/types/tasks/taskType';
 
 const TODO_EVENT_STATE = {
 	DEFAULT: 'default',
@@ -14,12 +15,6 @@ const TODO_EVENT_STATE = {
 } as const;
 
 type TodoEventState = (typeof TODO_EVENT_STATE)[keyof typeof TODO_EVENT_STATE];
-
-const STATUS = {
-	NOT_DONE: '미완료',
-	IN_PROGRESS: '진행중',
-	COMPLETE: '완료',
-} as const;
 
 type StatusType = (typeof STATUS)[keyof typeof STATUS];
 

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -1,5 +1,6 @@
 import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import DropdownButton from '../control/DropdownButton';
 
@@ -24,16 +25,22 @@ type StatusType = (typeof STATUS)[keyof typeof STATUS];
 
 type TodoProps = {
 	title: string;
-	deadline?: string;
+	deadlineDate?: string;
+	deadlineTime?: string;
 	status: StatusType;
 	isStatusVisible?: boolean;
 };
 
-function Todo({ title, deadline, status, isStatusVisible = true }: TodoProps) {
+function Todo({ title, deadlineDate, status: initStatus, isStatusVisible = true, deadlineTime }: TodoProps) {
 	const { state, handleMouseEnter, handleMouseLeave, handleMouseDown, handleMouseUp, handleDragStart, handleDragEnd } =
 		useTodoEventHandler();
 
+	const [status, setStatus] = useState<StatusType>(initStatus);
 	const isCompleted = status === STATUS.COMPLETE;
+
+	const handleStatusChange = (newStatus: StatusType) => {
+		setStatus(newStatus);
+	};
 
 	return (
 		<TodoContainer
@@ -49,11 +56,15 @@ function Todo({ title, deadline, status, isStatusVisible = true }: TodoProps) {
 		>
 			<TodoWrapper>
 				<span className="todo-title">{title}</span>
-				{deadline && <span className="todo-deadline">{deadline}</span>}
+				{deadlineDate && (
+					<span className="todo-deadline">
+						{deadlineDate} / {deadlineTime}
+					</span>
+				)}
 			</TodoWrapper>
 			{isStatusVisible && (
 				<DropdownWrapper>
-					<DropdownButton status={status} />
+					<DropdownButton status={status} handleStatusChange={handleStatusChange} />
 				</DropdownWrapper>
 			)}
 		</TodoContainer>
@@ -68,8 +79,7 @@ const baseStyles = ({ theme }: { theme: Theme }) => css`
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: auto;
-	min-width: 43.2rem;
-	max-width: 47.2rem;
+	width: 45.6rem;
 
 	background-color: ${theme.colorToken.Component.normal};
 	border-radius: 12px;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -62,13 +62,13 @@ const TargetAreaLayout = styled.section`
 	flex-direction: column;
 	flex-shrink: 0;
 	align-items: flex-start;
-	width: 31.8rem;
-	height: 74.8rem;
-	margin: 1rem;
+	width: 47.2rem;
+	margin: 0.8;
 	padding: 0 0.1rem 0 0.7rem;
 
+	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
-	border-radius: 12px;
+	border-radius: 20px;
 `;
 
 // 변화 가능성 있어 우선 wrapper로 컴포넌트에 간접적으로 간격 조정함

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { Droppable } from 'react-beautiful-dnd';
 
-import TargetAreaDate from './TargetAreaDate';
 import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
 
+import MainDate from '@/components/common/v2/TextBox/MainDate';
 import { TaskType } from '@/types/tasks/taskType';
 import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
@@ -25,11 +25,14 @@ function TargetArea({
 	onClickDatePicker,
 	targetDate,
 }: TargetAreaProps) {
+	const dateTypeDate = new Date(targetDate);
+	const month = dateTypeDate.getMonth() + 1;
+	const day = dateTypeDate.getDate();
 	return (
 		<TargetAreaLayout>
 			{/* 날짜 */}
 			<DateWrapper>
-				<TargetAreaDate targetDate={targetDate} />
+				<MainDate month={month} day={day} />
 			</DateWrapper>
 
 			{/* 버튼 */}

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -49,7 +49,7 @@ function TargetArea({
 			{/* 태스크 목록 */}
 			<Droppable droppableId="target">
 				{(provided) => (
-					<div ref={provided.innerRef} {...provided.droppableProps}>
+					<DroppableWrapper ref={provided.innerRef} {...provided.droppableProps}>
 						<TargetTaskSection
 							handleSelectedTarget={handleSelectedTarget}
 							selectedTarget={selectedTarget}
@@ -57,7 +57,7 @@ function TargetArea({
 							targetDate={formatDatetoLocalDate(targetDate)}
 						/>
 						{provided.placeholder}
-					</div>
+					</DroppableWrapper>
 				)}
 			</Droppable>
 		</TargetAreaLayout>
@@ -82,4 +82,7 @@ const DateWrapper = styled.div`
 	padding: 5.6rem 0 1.6rem 2.4rem;
 `;
 
+const DroppableWrapper = styled.div`
+	width: 100%;
+`;
 export default TargetArea;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -5,6 +5,7 @@ import TargetControlSection from './TargetControlSection';
 import TargetTaskSection from './TargetTaskSection';
 
 import MainDate from '@/components/common/v2/TextBox/MainDate';
+import TargetFilterSection from '@/components/targetArea/TargetFilterSection';
 import { TaskType } from '@/types/tasks/taskType';
 import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
@@ -43,6 +44,8 @@ function TargetArea({
 				onClickDatePicker={onClickDatePicker}
 				targetDate={targetDate}
 			/>
+			{/* 정렬 버튼 */}
+			<TargetFilterSection />
 			{/* 태스크 목록 */}
 			<Droppable droppableId="target">
 				{(provided) => (
@@ -68,7 +71,6 @@ const TargetAreaLayout = styled.section`
 	box-sizing: border-box;
 	width: 47.2rem;
 	margin: 0.8rem;
-	padding: 0 0.8rem;
 
 	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
@@ -77,7 +79,7 @@ const TargetAreaLayout = styled.section`
 
 // 변화 가능성 있어 우선 wrapper로 컴포넌트에 간접적으로 간격 조정함
 const DateWrapper = styled.div`
-	padding: 5.6rem 0 1.6rem 1.6rem;
+	padding: 5.6rem 0 1.6rem 2.4rem;
 `;
 
 export default TargetArea;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -62,9 +62,10 @@ const TargetAreaLayout = styled.section`
 	flex-direction: column;
 	flex-shrink: 0;
 	align-items: flex-start;
+	box-sizing: border-box;
 	width: 47.2rem;
-	margin: 0.8;
-	padding: 0 0.1rem 0 0.7rem;
+	margin: 0.8rem;
+	padding: 0 0.8rem;
 
 	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
@@ -73,7 +74,7 @@ const TargetAreaLayout = styled.section`
 
 // 변화 가능성 있어 우선 wrapper로 컴포넌트에 간접적으로 간격 조정함
 const DateWrapper = styled.div`
-	padding: 1.8rem 0 2rem;
+	padding: 5.6rem 0 1.6rem 1.6rem;
 `;
 
 export default TargetArea;

--- a/src/components/targetArea/TargetAreaDate.tsx
+++ b/src/components/targetArea/TargetAreaDate.tsx
@@ -1,21 +1,41 @@
 import styled from '@emotion/styled';
 
-import formatDatetoStrinKor from '@/utils/formatDatetoStringKor';
-
-/** nnnn년 nn월 nn일 */
+/** nn월 nn일 */
 interface TargetAreaDateProps {
 	targetDate: string;
 }
 
 function TargetAreaDate({ targetDate }: TargetAreaDateProps) {
 	const dateTypeDate = new Date(targetDate);
-	const formatDate = formatDatetoStrinKor(dateTypeDate);
-	return <DateText>{formatDate}</DateText>;
+	const month = '0'.concat((dateTypeDate.getMonth() + 1).toString()).slice(-2);
+	const day = '0'.concat(dateTypeDate.getDate().toString()).slice(-2);
+	return (
+		<TargetAreaDateBox>
+			<DateNumText>{month}</DateNumText>
+			<DateText>월</DateText>
+			<DateNumText>{day}</DateNumText>
+			<DateText>일</DateText>
+		</TargetAreaDateBox>
+	);
 }
 
-const DateText = styled.h2`
-	${({ theme }) => theme.fontTheme.HEADLINE_02};
-	padding: 0.7rem 0.2rem 0.7rem 1rem;
+const TargetAreaDateBox = styled.div`
+	display: flex;
+	align-items: baseline;
+`;
+
+const DateNumText = styled.h1`
+	margin-right: 0.1rem;
+
+	color: ${({ theme }) => theme.colorToken.Text.neutralLight};
+	${({ theme }) => theme.font.title01};
+`;
+
+const DateText = styled.h3`
+	margin-right: 0.6rem;
+
+	color: ${({ theme }) => theme.color.Grey.Grey5};
+	${({ theme }) => theme.font.label03};
 `;
 
 export default TargetAreaDate;

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
-import ArrangeBtn from '@/components/common/arrangeBtn/ArrangeBtn';
-import TextBtn from '@/components/common/button/textBtn/TextBtn';
 import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
+import Icon from '@/components/common/Icon';
 import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
+import Button from '@/components/common/v2/button/Button';
 import MODAL from '@/constants/modalLocation';
 import { TargetControlSectionProps } from '@/types/today/TargetControlSectionProps';
 import formatDatetoString from '@/utils/formatDatetoString';
@@ -29,13 +29,8 @@ function TargetControlSection({
 	return (
 		<>
 			<TargetControlSectionLayout>
-				<BtnWrapper>
-					<TextBtn text="오늘" size="small" color="BLACK" mode="DEFAULT" isHover isPressed onClick={onClickTodayDate} />
-					<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="left" onClick={onClickPrevDate} />
-					<ArrangeBtn color="BLACK" mode="DEFAULT" size="small" type="right" onClick={onClickNextDate} />
-				</BtnWrapper>
 				<ModalLayout>
-					<ArrangeBtn color="WHITE" mode="DEFAULT" size="small" type="calendar" onClick={handleArrangeBtnClick} />
+					<Icon name="IcnCalendar" color="nomal" onClick={handleArrangeBtnClick} isCusor />
 					{isModalOpen && (
 						<DateCorrectionModal
 							top={MODAL.DATE_CORRECTION.TARGET.top}
@@ -48,6 +43,15 @@ function TargetControlSection({
 						/>
 					)}
 				</ModalLayout>
+				<BtnWrapper>
+					<Button type="outlined-assistive" label="오늘" size="medium" onClick={onClickTodayDate} />
+					<IconLayout>
+						<Icon name="IcnLeft" color="nomal" onClick={onClickPrevDate} isCusor />
+					</IconLayout>
+					<IconLayout>
+						<Icon name="IcnRight" color="nomal" onClick={onClickNextDate} isCusor />
+					</IconLayout>
+				</BtnWrapper>
 			</TargetControlSectionLayout>
 			{isModalOpen && <ModalBackdrop onClick={handleCloseModal} />}
 		</>
@@ -60,16 +64,37 @@ const ModalLayout = styled.div`
 
 const TargetControlSectionLayout = styled.div`
 	display: flex;
+	align-items: center;
 	justify-content: space-between;
 	box-sizing: border-box;
 	width: 100%;
-	margin-bottom: 1.3rem;
-	padding: 0 0.4rem;
+	height: 4.8rem;
+	padding: 0 1.6rem 0 2.8rem;
 `;
 const BtnWrapper = styled.div`
 	display: flex;
-	gap: 0.4rem;
+	gap: 0.8rem;
 	width: fit-content;
+`;
+
+const IconLayout = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 3.2rem;
+	height: 3.2rem;
+
+	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
+	border: 1px solid ${({ theme }) => theme.color.Grey.Grey6};
+	border-radius: 8px;
+
+	:hover {
+		background-color: ${({ theme }) => theme.color.Grey.Grey2};
+	}
+
+	:active {
+		background-color: ${({ theme }) => theme.color.Grey.Grey3};
+	}
 `;
 
 export default TargetControlSection;

--- a/src/components/targetArea/TargetFilterSection.tsx
+++ b/src/components/targetArea/TargetFilterSection.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+import Icon from '@/components/common/Icon';
+
+function TargetFilterSection() {
+	return (
+		<TargetFilterSectionLayout>
+			<Icon name="IcnFilter" color="nomal" size="medium" />
+		</TargetFilterSectionLayout>
+	);
+}
+
+const TargetFilterSectionLayout = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	box-sizing: border-box;
+	width: 100%;
+	height: 4.8rem;
+	padding: 0 2rem;
+
+	border-top: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralNormal};
+`;
+
+export default TargetFilterSection;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 import { Draggable } from 'react-beautiful-dnd';
 
-import BtnTask from '../common/BtnTask/BtnTask';
 import BtnTaskContainer from '../common/BtnTaskContainer';
 import EmptyContainer from '../common/EmptyContainer';
 
+import Todo from '@/components/common/v2/taskBox/Todo';
 import { TaskType } from '@/types/tasks/taskType';
+import formatDatetoStringKor from '@/utils/formatDatetoStringKor';
 
 interface TargetTaskSectionProps {
 	handleSelectedTarget: (task: TaskType | null) => void;
@@ -13,9 +14,9 @@ interface TargetTaskSectionProps {
 	tasks: TaskType[];
 	targetDate: string;
 }
-function TargetTaskSection(props: TargetTaskSectionProps) {
-	const { handleSelectedTarget, selectedTarget, tasks, targetDate } = props;
-
+function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, targetDate }: TargetTaskSectionProps) {
+	// TODO: 추후에 해당 로직을 연결해야 합니다.
+	console.log(handleSelectedTarget, selectedTarget, targetDate);
 	return (
 		<BtnTaskContainer type="target">
 			{tasks.length === 0 ? (
@@ -26,28 +27,26 @@ function TargetTaskSection(props: TargetTaskSectionProps) {
 				<>
 					{tasks.map((task: TaskType, index: number) => (
 						<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
-							{(provided, snapshot) => (
+							{(provided) => (
 								<div
 									ref={provided.innerRef}
 									{...provided.draggableProps}
 									{...provided.dragHandleProps}
-									style={{ userSelect: 'none', ...provided.draggableProps.style }}
+									style={provided.draggableProps.style}
 								>
-									<BtnTask
-										location="target"
+									<Todo
+										// location="target"
 										key={task.id}
-										hasDescription={task.hasDescription}
-										name={task.name}
-										deadLine={task.deadLine}
-										btnStatus={task.status}
+										title={task.name}
+										deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
+										deadlineTime={task.deadLine?.time || undefined}
 										status={task.status}
-										id={task.id}
-										handleSelectedTarget={handleSelectedTarget}
-										selectedTarget={selectedTarget}
-										isDragging={snapshot.isDragging}
-										targetDate={targetDate}
-										dashBoardInprogress={false}
-										modalSize={{ type: 'long' }}
+										// id={task.id}
+										// handleSelectedTarget={handleSelectedTarget}
+										// selectedTarget={selectedTarget}
+										// isDragging={snapshot.isDragging}
+										// targetDate={targetDate}
+										// dashBoardInprogress={false}
 									/>
 								</div>
 							)}
@@ -66,5 +65,4 @@ const EmptyLayout = styled.div`
 	align-items: center;
 	justify-content: center;
 	width: 100%;
-	height: 90%;
 `;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -13,11 +13,11 @@ function MainLayout() {
 }
 const MainLayOutContainer = styled.div`
 	position: relative;
-	width: 136.6rem;
-	height: 76.8rem;
+	width: 100vw;
+	height: 100vh;
 	padding-left: 7.2rem;
 
-	background-color: ${({ theme }) => theme.palette.Grey.White};
+	background-color: ${({ theme }) => theme.colorToken.Component.strong};
 	border-radius: 8px;
 `;
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -153,6 +153,7 @@ export default Today;
 
 const TodayLayout = styled.div`
 	display: flex;
+	height: 100%;
 `;
 
 const CalendarWrapper = styled.div`

--- a/src/types/tasks/taskType.ts
+++ b/src/types/tasks/taskType.ts
@@ -1,3 +1,10 @@
+export const STATUS = {
+	NOT_DONE: '미완료',
+	IN_PROGRESS: '진행중',
+	COMPLETE: '완료',
+} as const;
+
+export type StatusType = (typeof STATUS)[keyof typeof STATUS];
 export interface TaskType {
 	id: number;
 	name: string;
@@ -6,5 +13,5 @@ export interface TaskType {
 		time?: string | null;
 	};
 	hasDescription: boolean;
-	status: '진행중' | '미완료' | '완료' | '지연';
+	status: StatusType;
 }

--- a/src/utils/formatDatetoStringKor.ts
+++ b/src/utils/formatDatetoStringKor.ts
@@ -1,11 +1,12 @@
 /** Date 형식을 0000년 00월 00일 형식 string 으로 반환합니다
  * undefined, null 의 경우 '시간' 텍스트를 반환합니다
  */
-const formatDatetoStringKor = (date: Date | undefined | null) => {
+const formatDatetoStringKor = (date: Date | undefined | null | string) => {
 	if (date) {
-		const year = date.getFullYear();
-		const month = '0'.concat((date.getMonth() + 1).toString()).slice(-2);
-		const day = '0'.concat(date.getDate().toString()).slice(-2);
+		const dateTypeDate = new Date(date);
+		const year = dateTypeDate.getFullYear();
+		const month = '0'.concat((dateTypeDate.getMonth() + 1).toString()).slice(-2);
+		const day = '0'.concat(dateTypeDate.getDate().toString()).slice(-2);
 		return `${year}년 ${month}월 ${day}일`;
 	}
 	return '';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- todo 목록 리디자인을 진행하였습니다.
- 기존의 코드에서 필요한 부분만 변경하면서 진행하였습니다. 
- 일단 피그마 처럼 "보이게"만 만들었습니다. 추가적인 로직은 추가가 필요한 상황입니다.
- 아직 상태 변경이나 필터 기능은 추가하지 않았습니다.



## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- TargetTaskSection 컴포넌트에서 기존의 로직을 유지하고자 일단 사용하지 않는 로직을 console.log로 해놧슴다
- 리자인된 화면이 맥북 에어 13인지 기준으로 커서 해당 부분에 대해서 디자이너 분들과 이야기 해봐야 할 것 같습니다.
- Todo 컴포넌트의 호버시에 발생하는 border로 인해서 크기가 약간씩 커져 기존의 컴포넌트가 밀리는 현상이 발생해서 border을 안으로 생기게 하던가 기존 스타일에 border을 투명으로 추가하여 hover시에서 크기차이가 발생하지 않도록 해야할 듯 합니다. 이것도 디자이너 분들과 함께 이야기 해보면 좋을 것 같습니다.
- 아이콘 버튼 공컴 잇나요?? 못찾아서 개별적으로 스타일링 하긴 했는데 있다면 변경하도록 하겠습니다. 아래 사진 첨부
 - <img width="116" alt="image" src="https://github.com/user-attachments/assets/42631171-2dde-4307-a108-f3eea7c294b3" />  
- 현재 버튼 공통 컴포넌트의 outlined-assistive 타입의 색상이 약간 다른 거 같아서 수정이 필요할 것 같습니다!



## 관련 이슈

close #323

## 스크린샷 (선택)
<img width="320" alt="image" src="https://github.com/user-attachments/assets/2a1fa624-2ffc-4450-a9d7-2cd955308916" />

https://github.com/user-attachments/assets/6b107ce2-974b-4b3d-96d4-65a40d321b88
