### PR TITLE
[FEAT] 사용자 설정 정렬 리스트 생성

### DIFF
--- a/src/apis/tasks/orderTask/OrderTaskType.ts
+++ b/src/apis/tasks/orderTask/OrderTaskType.ts
@@ -1,0 +1,5 @@
+export interface OrderTaskType {
+	type: boolean;
+	targetDate?: string;
+	taskList: number[];
+}

--- a/src/apis/tasks/orderTask/axios.ts
+++ b/src/apis/tasks/orderTask/axios.ts
@@ -1,0 +1,15 @@
+import { OrderTaskType } from './OrderTaskType';
+
+import { privateInstance } from '@/apis/instance';
+
+// type: true=dumping area, false=todo list
+const orderTask = async ({ type, targetDate, taskList }: OrderTaskType) => {
+	const { data } = await privateInstance.post('/api/tasks/orders', {
+		type,
+		targetDate: type === true ? null : targetDate,
+		taskList,
+	});
+	return data;
+};
+
+export default orderTask;

--- a/src/apis/tasks/orderTask/query.ts
+++ b/src/apis/tasks/orderTask/query.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import orderTask from './axios';
+import { OrderTaskType } from './OrderTaskType';
+
+/** Task 유저 순서 지정 */
+const useOrderTask = () => {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: ({ type, targetDate, taskList }: OrderTaskType) => orderTask({ type, targetDate, taskList }),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
+	});
+
+	return { mutate: mutation.mutate };
+};
+
+export default useOrderTask;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
 import useGetTasks from '@/apis/tasks/getTask/query';
+import useOrderTask from '@/apis/tasks/orderTask/query';
 import useUpdateTaskStatus from '@/apis/tasks/updateTaskStatus/query';
 import BtnTaskContainer from '@/components/common/BtnTaskContainer';
 import FullCalendarBox from '@/components/common/fullCalendar/FullCalendarBox';
@@ -27,6 +28,7 @@ function Today() {
 	const { data: stagingData } = useGetTasks({ sortOrder });
 	const { data: targetData, isError: isTargetError } = useGetTasks({ sortOrder, targetDate });
 	const { mutate, queryClient } = useUpdateTaskStatus(null);
+	const { mutate: orderTasksMutate } = useOrderTask();
 	const handleSidebar = () => {
 		setDumpAreaOpen((prev) => !prev);
 	};
@@ -71,39 +73,70 @@ function Today() {
 		// 드래그가 끝난 위치가 없으면 리턴
 		if (!destination) return;
 
-		// sourceTasks와 destinationTasks를 배열로 변환
-		const sourceTasks = source.droppableId === 'target' ? [...targetData] : [...stagingData];
-		const destinationTasks = destination.droppableId === 'target' ? [...targetData] : [...stagingData];
+		const updatedTargetData: TaskType[] = [...targetData];
+		const updatedStagingData: TaskType[] = [...stagingData];
+		let movedTask: TaskType;
 
-		// 드래그된 항목을 sourceTasks에서 제거하고 destinationTasks에 추가
-		const [movedTask] = sourceTasks.splice(source.index, 1);
-		destinationTasks.splice(destination.index, 0, movedTask);
-
-		// 상태 업데이트
 		if (source.droppableId === 'target') {
-			queryClient.setQueryData(['tasks'], {
-				target: { ...targetData, data: { ...targetData, tasks: sourceTasks } },
-				staging: { ...stagingData, data: { ...stagingData, tasks: destinationTasks } },
-			});
+			[movedTask] = updatedTargetData.splice(source.index, 1);
+			if (destination.droppableId === 'target') {
+				updatedTargetData.splice(destination.index, 0, movedTask);
+			} else {
+				updatedStagingData.splice(destination.index, 0, movedTask);
+			}
 		} else {
-			queryClient.setQueryData(['tasks'], {
-				target: { ...targetData, data: { ...targetData, tasks: destinationTasks } },
-				staging: { ...stagingData, data: { ...stagingData, tasks: sourceTasks } },
-			});
+			[movedTask] = updatedStagingData.splice(source.index, 1);
+			if (destination.droppableId === 'staging') {
+				updatedStagingData.splice(destination.index, 0, movedTask);
+			} else {
+				updatedTargetData.splice(destination.index, 0, movedTask);
+			}
 		}
 
+		queryClient.setQueryData(['tasks'], {
+			target: { ...targetData, tasks: updatedTargetData },
+			staging: { ...stagingData, tasks: updatedStagingData },
+		});
+
 		// API 호출
-		if (destination.droppableId === 'target') {
+		// staging -> target area: 해당 날짜로 설정, 미완료 상태 지정
+		if (destination.droppableId === 'target' && source.droppableId === 'staging') {
 			mutate({
 				taskId: movedTask.id,
 				targetDate,
 				status: '미완료',
 			});
-		} else if (destination.droppableId === 'staging') {
+			// target -> staging area: 상태 초기화
+		} else if (destination.droppableId === 'staging' && source.droppableId === 'target') {
 			mutate({
 				taskId: movedTask.id,
 				targetDate: null,
 				status: null,
+			});
+		}
+		// staging -> staging: custom order post api 호출
+		else if (
+			destination.droppableId === 'staging' &&
+			source.droppableId === 'staging' &&
+			sortOrder === 'CUSTOM_ORDER'
+		) {
+			const newOrder = updatedStagingData.map((item) => item.id);
+			orderTasksMutate({
+				type: true,
+				taskList: newOrder,
+			});
+
+			// target -> target: custom order post api 호출
+		} else if (
+			destination.droppableId === 'target' &&
+			source.droppableId === 'target' &&
+			sortOrder === 'CUSTOM_ORDER'
+		) {
+			const newOrder = updatedTargetData.map((item) => item.id);
+			orderTasksMutate({
+				type: false,
+				targetDate,
+				taskList: newOrder,
 			});
 		}
 	};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 태스크 사용자 순서대로 오더링 하는거 api 연결했습니다.
- 기존에는 `staging -> target`, `target->staging` 처리하는 부분만 있었는데, 더 조건을 달아서 `staging-> staging` 인 경우, `target-> target` 인 경우도 추가하고 api 적용하도록 설정했습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 근데 order api 보내도 바로 다시 오는 api 에 태스크 순서가 바뀌어있지는 않네요...
- 낼 더 보고 문제있음 서버 문의해보겠습니다 ...



## 관련 이슈

close #339

## 스크린샷 (선택)

<img width="747" alt="Screenshot 2025-01-13 at 12 28 56 AM" src="https://github.com/user-attachments/assets/e3e1c9a9-3fa1-4647-bc50-5d4b3d475f17" />
<img width="797" alt="Screenshot 2025-01-13 at 12 29 02 AM" src="https://github.com/user-attachments/assets/cd8251c1-f439-4d21-a63e-209e142188a7" />
<img width="711" alt="Screenshot 2025-01-13 at 12 29 26 AM" src="https://github.com/user-attachments/assets/68db4faa-5119-420c-b273-889e344e35ea" />  


984(기존) -> 948(요청) -> 984(기존)