### PR TITLE
[BUG] custom order post api 연결 문제

### DIFF
--- a/src/apis/tasks/orderTask/axios.ts
+++ b/src/apis/tasks/orderTask/axios.ts
@@ -2,11 +2,11 @@ import { OrderTaskType } from './OrderTaskType';
 
 import { privateInstance } from '@/apis/instance';
 
-// type: true=dumping area, false=todo list
+// type: false=dumping area, true=todo list
 const orderTask = async ({ type, targetDate, taskList }: OrderTaskType) => {
 	const { data } = await privateInstance.post('/api/tasks/orders', {
 		type,
-		targetDate: type === true ? null : targetDate,
+		targetDate: type === false ? null : targetDate,
 		taskList,
 	});
 	return data;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -122,7 +122,7 @@ function Today() {
 		) {
 			const newOrder = updatedStagingData.map((item) => item.id);
 			orderTasksMutate({
-				type: true,
+				type: false,
 				taskList: newOrder,
 			});
 
@@ -134,7 +134,7 @@ function Today() {
 		) {
 			const newOrder = updatedTargetData.map((item) => item.id);
 			orderTasksMutate({
-				type: false,
+				type: true,
 				targetDate,
 				taskList: newOrder,
 			});


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 순서 커스텀오더로 바꾸는 거 안되던 문제 수정
- post 에서 target 불린값 반대로 설정했던 점 + 서버에서 targetDate 파라미터 관련 필수로 지정했던 점(500에러) 등등 이 문제되어 이제야 잡았습니다..


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 잘 작동하는지 봐주세용

## 관련 이슈

close #341 

## 스크린샷 (선택)
  
근데 지원언니가 dnd 부분 갈아야 햇던 것 같은데 ...일단 api 쪽이니까 수정햇습니다