### PR TITLE
[FEAT] DueDate모달 연결

### DIFF
--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -10,7 +10,8 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 100%;
-	height: 54rem;
+	height: 100%;
+	max-height: 82rem;
 	padding-left: 0.8rem;
 	overflow: auto;
 	overflow-y: scroll;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -101,7 +101,7 @@ const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 44.8rem;
-	height: 100%;
+	height: 108rem;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
@@ -130,6 +130,6 @@ const BottomContainer = styled.div`
 	flex-direction: column;
 	align-items: flex-start;
 	width: 100%;
-	height: 100%;
+	height: 88rem;
 	padding-bottom: 2.8rem;
 `;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -3,7 +3,6 @@ import { Draggable } from 'react-beautiful-dnd';
 
 import BtnTaskContainer from '../BtnTaskContainer';
 import EmptyContainer from '../EmptyContainer';
-import ScrollGradient from '../ScrollGradient';
 import Todo from '../v2/taskBox/Todo';
 
 import { StatusType, TaskType } from '@/types/tasks/taskType';
@@ -52,7 +51,7 @@ function StagingAreaTaskContainer({
 									)}
 								</Draggable>
 							))}
-						<ScrollGradient />
+						{/* <ScrollGradient /> */}
 					</TaskWrapper>
 				)}
 			</BtnTaskContainer>
@@ -73,4 +72,5 @@ const StagingAreaTaskContainerLayout = styled.div`
 	align-items: flex-start;
 	align-self: stretch;
 	width: 100%;
+	height: 100%;
 `;

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -121,6 +121,7 @@ function DumpingAreaBtn() {
 export default DumpingAreaBtn;
 
 const DumpingAreaContainer = styled.div`
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 8px;

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -10,14 +10,30 @@ import { CreateTaskType } from '@/apis/tasks/createTask/CreateTaskType';
 import useCreateTask from '@/apis/tasks/createTask/query';
 import useInputHandler from '@/hooks/useInputHandler';
 import { INPUT_STATE, InputState } from '@/types/inputStateType';
+import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 function DumpingAreaBtn() {
 	const { state, handleFocus, handleBlur, handleChange, handleMouseEnter, handleMouseLeave } = useInputHandler();
 	const [todoTitle, setTodoTitle] = useState('');
 	const [settingModalOpen, setSettingModalOpen] = useState(false);
+	// 날짜를 별도로 설정하지 않을 경우,
+	//   마감기간/시간은 접속 날짜 기준
+	//   14일 후의 동일 시간으로 자동 지정.
+	const defaultDate = new Date();
+	const dateAfter14Days = defaultDate;
+	dateAfter14Days.setDate(defaultDate.getDate() + 14);
+
+	const [todoDate, setTodoDate] = useState(dateAfter14Days);
+	const [todoTime, setTodoTime] = useState('');
 	const { mutate: createTaskMutate } = useCreateTask();
 	const createTask = (taskData: CreateTaskType) => {
 		createTaskMutate(taskData);
+	};
+	const handleTodoDate = (selectedTodoDate: Date) => {
+		setTodoDate(selectedTodoDate);
+	};
+	const handleTodoTime = (selectedTodoTime: string) => {
+		setTodoTime(selectedTodoTime);
 	};
 	const onChange = (e: React.FocusEvent<HTMLInputElement>) => {
 		handleChange(e);
@@ -39,8 +55,8 @@ function DumpingAreaBtn() {
 		createTask({
 			name: todoTitle,
 			deadLine: {
-				date: null,
-				time: null,
+				date: formatDatetoLocalDate(todoDate) || null,
+				time: todoTime || null,
 			},
 		});
 		setTodoTitle('');
@@ -74,7 +90,14 @@ function DumpingAreaBtn() {
 					onClick={handleSettingModal}
 				/>
 			)}
-			{settingModalOpen && <DueDateModal />}
+			{settingModalOpen && (
+				<DueDateModal
+					handleTodoTime={handleTodoTime}
+					handleTodoDate={handleTodoDate}
+					todoDate={todoDate}
+					todoTime={todoTime}
+				/>
+			)}
 			{settingModalOpen && <ModalBackdrop onClick={handleSettingModal} />}
 		</DumpingAreaContainer>
 	);

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -57,7 +57,13 @@ function DumpingAreaBtn() {
 				time: todoTime || null,
 			},
 		});
+		resetInputs();
+	};
+
+	const resetInputs = () => {
 		setTodoTitle('');
+		setTodoTime('');
+		setTodoDate(undefined);
 	};
 
 	const timeDateChipLabel = () => {
@@ -94,7 +100,7 @@ function DumpingAreaBtn() {
 					size="small"
 					disabled={false}
 					label={timeDateChipLabel()}
-					leftIcon="IcnPlus"
+					leftIcon={!todoDate && todoTime ? 'IcnPlus' : 'IcnModify'}
 					onClick={handleSettingModal}
 				/>
 			)}

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -11,6 +11,7 @@ import useCreateTask from '@/apis/tasks/createTask/query';
 import useInputHandler from '@/hooks/useInputHandler';
 import { INPUT_STATE, InputState } from '@/types/inputStateType';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
+import formatDateWithDay from '@/utils/formatDateWithDay';
 
 function DumpingAreaBtn() {
 	const { state, handleFocus, handleBlur, handleChange, handleMouseEnter, handleMouseLeave } = useInputHandler();
@@ -19,11 +20,8 @@ function DumpingAreaBtn() {
 	// 날짜를 별도로 설정하지 않을 경우,
 	//   마감기간/시간은 접속 날짜 기준
 	//   14일 후의 동일 시간으로 자동 지정.
-	const defaultDate = new Date();
-	const dateAfter14Days = defaultDate;
-	dateAfter14Days.setDate(defaultDate.getDate() + 14);
 
-	const [todoDate, setTodoDate] = useState(dateAfter14Days);
+	const [todoDate, setTodoDate] = useState<Date>();
 	const [todoTime, setTodoTime] = useState('');
 	const { mutate: createTaskMutate } = useCreateTask();
 	const createTask = (taskData: CreateTaskType) => {
@@ -55,11 +53,21 @@ function DumpingAreaBtn() {
 		createTask({
 			name: todoTitle,
 			deadLine: {
-				date: formatDatetoLocalDate(todoDate) || null,
+				date: todoDate ? formatDatetoLocalDate(todoDate) : null,
 				time: todoTime || null,
 			},
 		});
 		setTodoTitle('');
+	};
+
+	const timeDateChipLabel = () => {
+		if (todoDate && todoTime) {
+			return `${formatDateWithDay(todoDate)} ${todoTime} 까지`;
+		}
+		if (todoDate) {
+			return `${formatDateWithDay(todoDate)} 까지`;
+		}
+		return '마감 기간/시간';
 	};
 
 	return (
@@ -85,7 +93,7 @@ function DumpingAreaBtn() {
 					type="outlined-primary"
 					size="small"
 					disabled={false}
-					label="마감 기간/시간"
+					label={timeDateChipLabel()}
 					leftIcon="IcnPlus"
 					onClick={handleSettingModal}
 				/>
@@ -96,6 +104,7 @@ function DumpingAreaBtn() {
 					handleTodoDate={handleTodoDate}
 					todoDate={todoDate}
 					todoTime={todoTime}
+					handleSettingModal={handleSettingModal}
 				/>
 			)}
 			{settingModalOpen && <ModalBackdrop onClick={handleSettingModal} />}

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -2,7 +2,9 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 
 import Icon from '../../Icon';
+import ModalBackdrop from '../../modal/ModalBackdrop';
 import Button from '../button/Button';
+import DueDateModal from '../modal/DueDateModal';
 
 import { CreateTaskType } from '@/apis/tasks/createTask/CreateTaskType';
 import useCreateTask from '@/apis/tasks/createTask/query';
@@ -72,8 +74,8 @@ function DumpingAreaBtn() {
 					onClick={handleSettingModal}
 				/>
 			)}
-			{/* 세팅 모달 들어갈 자리 */}
-			{settingModalOpen && <div />}
+			{settingModalOpen && <DueDateModal />}
+			{settingModalOpen && <ModalBackdrop onClick={handleSettingModal} />}
 		</DumpingAreaContainer>
 	);
 }

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -32,8 +32,8 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 	/** hh:mm a.m, hh:mm p.m 형식 */
 	const getDisplayCurrTime = () => {
 		const { hours, formattedHours, formattedMinutes } = getCurrTime();
-		const period = hours >= 12 ? 'p.m' : 'a.m';
-		return `${formattedHours}:${formattedMinutes} ${period}`;
+		const period = hours >= 12 ? 'pm' : 'am';
+		return `${formattedHours}:${formattedMinutes}${period}`;
 	};
 
 	/** hh:mm 형식 */

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -15,16 +15,28 @@ interface DueDateModalType {
 function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
 	// 모달 안 임시 state들, Button 누를시 상위 컴포넌트 state로 들어감
 	const defaultDate = new Date();
+
 	const dateAfter14Days = defaultDate;
 	dateAfter14Days.setDate(defaultDate.getDate() + 14);
+	/** 현재 시각 */
+	const getCurrTime = () => {
+		let hours = defaultDate.getHours();
+		const minutes = defaultDate.getMinutes();
+		const period = hours >= 12 ? 'p.m' : 'a.m';
+		hours = hours % 12 || 12;
+		const formattedHours = hours.toString().padStart(2, '0');
+		const formattedMinutes = minutes.toString().padStart(2, '0');
 
-	const [dueDateTime, setDueDateTime] = useState(todoTime);
+		return `${formattedHours}:${formattedMinutes} ${period}`;
+	};
+
+	const [dueDateTime, setDueDateTime] = useState(todoTime || getCurrTime());
 	const [dueDateDate, setDueDateDate] = useState(todoDate || dateAfter14Days);
 
 	const onDueDateSubmit = () => {
 		handleTodoDate(dueDateDate);
 		handleTodoTime(dueDateTime);
-		// console.log(dueDateDate, dueDateTime);
+		console.log(dueDateDate, dueDateTime);
 		handleSettingModal();
 	};
 
@@ -46,10 +58,9 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 			</DueDateModalHeadLayout>
 
 			<DueDateModalBodyLayout>
-				{/* TODO: endTime 형식 맞춰서 넣기 */}
 				<DeadlineBox
 					date={dueDateDate}
-					endTime="06:00pm"
+					endTime={dueDateTime}
 					label="마감 기간"
 					isDueDate
 					handleDueDateModalTime={handleDueDateModalTime}

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -1,10 +1,26 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import Button from '@/components/common/v2/button/Button';
 import IconButton from '@/components/common/v2/IconButton';
 import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
 
-function DueDateModal() {
+interface DueDateModalType {
+	todoTime: string;
+	todoDate: Date;
+	handleTodoTime: (selectedTodoTime: string) => void;
+	handleTodoDate: (selectedTodoDate: Date) => void;
+}
+function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime }: DueDateModalType) {
+	// 모달 안 임시 state들, Button 누를시 상위 컴포넌트 state로 들어감
+	const [dueDateTime, setDueDateTime] = useState(todoTime);
+	const [dueDateDate, setDueDateDate] = useState(todoDate);
+
+	const onDueDateSubmit = () => {
+		handleTodoDate(dueDateDate);
+		handleTodoTime(dueDateTime);
+	};
+
 	return (
 		<DueDateModalLayout>
 			<DueDateModalHeadLayout>
@@ -16,11 +32,12 @@ function DueDateModal() {
 			</DueDateModalHeadLayout>
 
 			<DueDateModalBodyLayout>
-				<DeadlineBox date={new Date()} endTime="06:00pm" label="마감 기간" isDueDate />
+				{/* TODO: endTime 형식 맞춰서 넣기 */}
+				<DeadlineBox date={dueDateDate} endTime="06:00pm" label="마감 기간" isDueDate />
 			</DueDateModalBodyLayout>
 
 			<DueDateModalButtonLayout>
-				<Button type="solid" size="medium" label="확인" />
+				<Button type="solid" size="medium" label="확인" onClick={onDueDateSubmit} />
 			</DueDateModalButtonLayout>
 		</DueDateModalLayout>
 	);

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/v2/button/Button';
+import IconButton from '@/components/common/v2/IconButton';
+import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
+
+function DueDateModal() {
+	return (
+		<DueDateModalLayout>
+			<DueDateModalHeadLayout>
+				<ModalTopButtonBox>
+					<ButtonBox>
+						<IconButton iconName="IcnX" type="normal" size="small" disabled />
+					</ButtonBox>
+				</ModalTopButtonBox>
+			</DueDateModalHeadLayout>
+
+			<DueDateModalBodyLayout>
+				<DeadlineBox date={new Date()} endTime="06:00pm" label="마감 기간" isDueDate />
+			</DueDateModalBodyLayout>
+
+			<DueDateModalButtonLayout>
+				<Button type="solid" size="medium" label="확인" />
+			</DueDateModalButtonLayout>
+		</DueDateModalLayout>
+	);
+}
+
+const DueDateModalLayout = styled.article`
+	z-index: 5;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	width: 41.6rem;
+	height: auto;
+	padding: 2.4rem 2.4rem 3.2rem;
+
+	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
+	box-shadow:
+		4px 4px 40px 20px #717e9833,
+		-4px -4px 40px 0 #717e9833;
+	border-radius: 20px;
+`;
+
+const DueDateModalHeadLayout = styled.section`
+	display: flex;
+	flex-direction: column;
+	gap: 3.2rem;
+	width: 100%;
+`;
+
+const DueDateModalBodyLayout = styled.section`
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+`;
+
+const ModalTopButtonBox = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const ButtonBox = styled.div`
+	display: flex;
+	gap: 0.8rem;
+	justify-content: flex-end;
+	width: 100%;
+`;
+
+const DueDateModalButtonLayout = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	width: 100%;
+	height: 3.2rem;
+`;
+
+export default DueDateModal;

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Button from '@/components/common/v2/button/Button';
 import IconButton from '@/components/common/v2/IconButton';
 import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
+import { getDisplayCurrTime, getFormattedCurrTime } from '@/utils/time';
 
 interface DueDateModalType {
 	todoTime: string;
@@ -18,31 +19,8 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 
 	const dateAfter14Days = defaultDate;
 	dateAfter14Days.setDate(defaultDate.getDate() + 14);
-	/** 현재 시각 */
-	const getCurrTime = () => {
-		let hours = defaultDate.getHours();
-		const minutes = defaultDate.getMinutes();
 
-		hours = hours % 12 || 12;
-		const formattedHours = hours.toString().padStart(2, '0');
-		const formattedMinutes = minutes.toString().padStart(2, '0');
-		return { hours, formattedHours, formattedMinutes };
-	};
-
-	/** hh:mm a.m, hh:mm p.m 형식 */
-	const getDisplayCurrTime = () => {
-		const { hours, formattedHours, formattedMinutes } = getCurrTime();
-		const period = hours >= 12 ? 'pm' : 'am';
-		return `${formattedHours}:${formattedMinutes}${period}`;
-	};
-
-	/** hh:mm 형식 */
-	const getFormattedCurrTime = () => {
-		const { formattedHours, formattedMinutes } = getCurrTime();
-		return `${formattedHours}:${formattedMinutes}`;
-	};
-
-	const [dueDateTime, setDueDateTime] = useState(todoTime || getFormattedCurrTime());
+	const [dueDateTime, setDueDateTime] = useState(todoTime || getFormattedCurrTime(defaultDate));
 	const [dueDateDate, setDueDateDate] = useState(todoDate || dateAfter14Days);
 
 	const onDueDateSubmit = () => {
@@ -71,7 +49,7 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 			<DueDateModalBodyLayout>
 				<DeadlineBox
 					date={dueDateDate}
-					endTime={getDisplayCurrTime()}
+					endTime={getDisplayCurrTime(defaultDate)}
 					label="마감 기간"
 					isDueDate
 					handleDueDateModalTime={handleDueDateModalTime}

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -22,21 +22,32 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 	const getCurrTime = () => {
 		let hours = defaultDate.getHours();
 		const minutes = defaultDate.getMinutes();
-		const period = hours >= 12 ? 'p.m' : 'a.m';
+
 		hours = hours % 12 || 12;
 		const formattedHours = hours.toString().padStart(2, '0');
 		const formattedMinutes = minutes.toString().padStart(2, '0');
+		return { hours, formattedHours, formattedMinutes };
+	};
 
+	/** hh:mm a.m, hh:mm p.m 형식 */
+	const getDisplayCurrTime = () => {
+		const { hours, formattedHours, formattedMinutes } = getCurrTime();
+		const period = hours >= 12 ? 'p.m' : 'a.m';
 		return `${formattedHours}:${formattedMinutes} ${period}`;
 	};
 
-	const [dueDateTime, setDueDateTime] = useState(todoTime || getCurrTime());
+	/** hh:mm 형식 */
+	const getFormattedCurrTime = () => {
+		const { formattedHours, formattedMinutes } = getCurrTime();
+		return `${formattedHours}:${formattedMinutes}`;
+	};
+
+	const [dueDateTime, setDueDateTime] = useState(todoTime || getFormattedCurrTime());
 	const [dueDateDate, setDueDateDate] = useState(todoDate || dateAfter14Days);
 
 	const onDueDateSubmit = () => {
 		handleTodoDate(dueDateDate);
 		handleTodoTime(dueDateTime);
-		console.log(dueDateDate, dueDateTime);
 		handleSettingModal();
 	};
 
@@ -60,7 +71,7 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 			<DueDateModalBodyLayout>
 				<DeadlineBox
 					date={dueDateDate}
-					endTime={dueDateTime}
+					endTime={getDisplayCurrTime()}
 					label="마감 기간"
 					isDueDate
 					handleDueDateModalTime={handleDueDateModalTime}

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -7,18 +7,32 @@ import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
 
 interface DueDateModalType {
 	todoTime: string;
-	todoDate: Date;
+	todoDate?: Date;
 	handleTodoTime: (selectedTodoTime: string) => void;
 	handleTodoDate: (selectedTodoDate: Date) => void;
+	handleSettingModal: () => void;
 }
-function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime }: DueDateModalType) {
+function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
 	// 모달 안 임시 state들, Button 누를시 상위 컴포넌트 state로 들어감
+	const defaultDate = new Date();
+	const dateAfter14Days = defaultDate;
+	dateAfter14Days.setDate(defaultDate.getDate() + 14);
+
 	const [dueDateTime, setDueDateTime] = useState(todoTime);
-	const [dueDateDate, setDueDateDate] = useState(todoDate);
+	const [dueDateDate, setDueDateDate] = useState(todoDate || dateAfter14Days);
 
 	const onDueDateSubmit = () => {
 		handleTodoDate(dueDateDate);
 		handleTodoTime(dueDateTime);
+		// console.log(dueDateDate, dueDateTime);
+		handleSettingModal();
+	};
+
+	const handleDueDateModalTime = (time: string) => {
+		setDueDateTime(time);
+	};
+	const handleDueDateModalDate = (date: Date) => {
+		setDueDateDate(date);
 	};
 
 	return (
@@ -33,7 +47,14 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime }: Du
 
 			<DueDateModalBodyLayout>
 				{/* TODO: endTime 형식 맞춰서 넣기 */}
-				<DeadlineBox date={dueDateDate} endTime="06:00pm" label="마감 기간" isDueDate />
+				<DeadlineBox
+					date={dueDateDate}
+					endTime="06:00pm"
+					label="마감 기간"
+					isDueDate
+					handleDueDateModalTime={handleDueDateModalTime}
+					handleDueDateModalDate={handleDueDateModalDate}
+				/>
 			</DueDateModalBodyLayout>
 
 			<DueDateModalButtonLayout>

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -14,7 +14,7 @@ interface DueDateModalType {
 	handleSettingModal: () => void;
 }
 function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
-	// 모달 안 임시 state들, Button 누를시 상위 컴포넌트 state로 들어감
+	// 모달 내부 state들, Button 누를시 상위 컴포넌트 state로 들어감
 	const defaultDate = new Date();
 
 	const dateAfter14Days = defaultDate;
@@ -65,6 +65,9 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 }
 
 const DueDateModalLayout = styled.article`
+	position: absolute;
+	top: 8.8rem;
+	left: 0.8rem;
 	z-index: 5;
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -11,6 +11,7 @@ interface DateTimeBtnProps {
 	isSetDate: boolean;
 	isAllday?: boolean;
 	onClick: () => void;
+	handleDueDateModalDate?: (date: Date) => void;
 }
 
 function DateTimeBtn({
@@ -20,6 +21,7 @@ function DateTimeBtn({
 	isSetDate,
 	isAllday = false,
 	onClick,
+	handleDueDateModalDate = () => {},
 }: DateTimeBtnProps) {
 	const [startTime, setStartTime] = useState(initStartTime);
 	const [endTime, setEndTime] = useState(initEndTime);
@@ -35,6 +37,7 @@ function DateTimeBtn({
 
 	const updateDate = (newDate: Date) => {
 		setDate(newDate);
+		handleDueDateModalDate(newDate);
 	};
 
 	return isSetDate ? (

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -12,6 +12,7 @@ interface DateTimeBtnProps {
 	isAllday?: boolean;
 	onClick: () => void;
 	handleDueDateModalDate?: (date: Date) => void;
+	handleDueDateModalTime?: (time: string) => void;
 }
 
 function DateTimeBtn({
@@ -22,10 +23,13 @@ function DateTimeBtn({
 	isAllday = false,
 	onClick,
 	handleDueDateModalDate = () => {},
+	handleDueDateModalTime = () => {},
 }: DateTimeBtnProps) {
+	// ~~여기에 상태 있어야하는지 의문~~
 	const [startTime, setStartTime] = useState(initStartTime);
 	const [endTime, setEndTime] = useState(initEndTime);
 	const [date, setDate] = useState(initDate);
+	// ~~~~
 
 	const updateStartTime = (newTime: string) => {
 		setStartTime(newTime);
@@ -33,6 +37,7 @@ function DateTimeBtn({
 
 	const updateEndTime = (newTime: string) => {
 		setEndTime(newTime);
+		handleDueDateModalTime(newTime.slice(0, 5));
 	};
 
 	const updateDate = (newDate: Date) => {

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -10,11 +10,12 @@ interface DeadlineBoxProps {
 	startTime?: string;
 	endTime: string;
 	label: string;
+	isDueDate?: boolean;
 }
 
-function DeadlineBox({ date, startTime, endTime, label }: DeadlineBoxProps) {
+function DeadlineBox({ date, startTime, endTime, label, isDueDate = false }: DeadlineBoxProps) {
 	const [isSettingActive, setIsSettingActive] = useState(false);
-	const [isClicked, setIsClicked] = useState(false);
+	const [isClicked, setIsClicked] = useState(isDueDate);
 	const [isAllday, setIsAllday] = useState(false);
 
 	const containerRef = useRef(null);
@@ -56,31 +57,39 @@ function DeadlineBox({ date, startTime, endTime, label }: DeadlineBoxProps) {
 	}, []);
 
 	return (
-		<DeadlineBoxContainer ref={containerRef}>
-			<DeadlineBtnLayout>
-				<CategoryTitleStyle>{label}</CategoryTitleStyle>
-				{isClicked ? (
-					<Icon name="IcnX" size="tiny" color="strong" onClick={handleXBtnClick} isCursor />
-				) : (
-					<Icon name="IcnPlus" size="tiny" color="strong" onClick={handlePlusBtnClick} isCursor />
-				)}
-			</DeadlineBtnLayout>
-			{isClicked && (
-				<>
-					<DateTimeBtn
-						date={date}
-						startTime={startTime}
-						endTime={endTime}
-						isSetDate={isSettingActive}
-						isAllday={isAllday}
-						onClick={handleClickModify}
-					/>
-					{!isSettingActive && (
-						<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />
+		<>
+			{!isDueDate && <Divder />}
+			<DeadlineBoxContainer ref={containerRef}>
+				<DeadlineBtnLayout>
+					<CategoryTitleStyle>{label}</CategoryTitleStyle>
+					{!isDueDate && (
+						<div>
+							{isClicked ? (
+								<Icon name="IcnX" size="tiny" color="strong" onClick={handleXBtnClick} isCursor />
+							) : (
+								<Icon name="IcnPlus" size="tiny" color="strong" onClick={handlePlusBtnClick} isCursor />
+							)}
+						</div>
 					)}
-				</>
-			)}
-		</DeadlineBoxContainer>
+				</DeadlineBtnLayout>
+				{isClicked && (
+					<>
+						<DateTimeBtn
+							date={date}
+							startTime={startTime}
+							endTime={endTime}
+							isSetDate={isSettingActive}
+							isAllday={isAllday}
+							onClick={handleClickModify}
+						/>
+						{!isSettingActive && (
+							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />
+						)}
+					</>
+				)}
+			</DeadlineBoxContainer>
+			{!isDueDate && <Divder />}
+		</>
 	);
 }
 
@@ -95,11 +104,13 @@ const DeadlineBoxContainer = styled.div`
 	padding: 1.6rem 0;
 
 	color: ${({ theme }) => theme.colorToken.Text.assistive};
-
-	border-top: 1px solid ${({ theme }) => theme.color.Grey.Grey3};
-	border-bottom: 1px solid ${({ theme }) => theme.color.Grey.Grey3};
 `;
+const Divder = styled.div`
+	width: 100%;
+	height: 0.1rem;
 
+	background-color: ${({ theme }) => theme.color.Grey.Grey3};
+`;
 const DeadlineBtnLayout = styled.div`
 	display: flex;
 	gap: 0.8rem;

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -97,6 +97,7 @@ function DeadlineBox({
 							isAllday={isAllday}
 							onClick={handleClickModify}
 							handleDueDateModalDate={handleDueDateModalDate}
+							handleDueDateModalTime={handleDueDateModalTime}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -11,9 +11,19 @@ interface DeadlineBoxProps {
 	endTime: string;
 	label: string;
 	isDueDate?: boolean;
+	handleDueDateModalTime?: (time: string) => void;
+	handleDueDateModalDate?: (date: Date) => void;
 }
 
-function DeadlineBox({ date, startTime, endTime, label, isDueDate = false }: DeadlineBoxProps) {
+function DeadlineBox({
+	date,
+	startTime,
+	endTime,
+	label,
+	isDueDate = false,
+	handleDueDateModalTime = () => {},
+	handleDueDateModalDate = () => {},
+}: DeadlineBoxProps) {
 	const [isSettingActive, setIsSettingActive] = useState(false);
 	const [isClicked, setIsClicked] = useState(isDueDate);
 	const [isAllday, setIsAllday] = useState(false);
@@ -24,9 +34,14 @@ function DeadlineBox({ date, startTime, endTime, label, isDueDate = false }: Dea
 		setIsClicked((prev) => !prev);
 		setIsSettingActive(false);
 	};
-
+	const removeTime = () => {
+		handleDueDateModalTime('');
+	};
 	const handleCheckBtnClick = () => {
 		setIsAllday((prev) => !prev);
+
+		// 하루종일 선택시 기존 time 제거
+		removeTime();
 	};
 
 	const handleXBtnClick = () => {
@@ -81,6 +96,7 @@ function DeadlineBox({ date, startTime, endTime, label, isDueDate = false }: Dea
 							isSetDate={isSettingActive}
 							isAllday={isAllday}
 							onClick={handleClickModify}
+							handleDueDateModalDate={handleDueDateModalDate}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -187,7 +187,8 @@ export default Today;
 
 const TodayLayout = styled.div`
 	display: flex;
-	height: 100%;
+	height: 108rem;
+	overflow: hidden;
 `;
 
 const CalendarWrapper = styled.div`

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,23 @@
+/** 현재 시각: hours, hh, mm return */
+export const getCurrTime = (date: Date) => {
+	const hours24format = date.getHours();
+	const minutes = date.getMinutes();
+
+	const hours12format = hours24format % 12 || 12;
+	const formattedHours = hours12format.toString().padStart(2, '0');
+	const formattedMinutes = minutes.toString().padStart(2, '0');
+	return { hours24format, formattedHours, formattedMinutes };
+};
+
+/** hh:mm a.m, hh:mm p.m 형식 */
+export const getDisplayCurrTime = (date: Date) => {
+	const { hours24format, formattedHours, formattedMinutes } = getCurrTime(date);
+	const period = hours24format >= 12 ? 'pm' : 'am';
+	return `${formattedHours}:${formattedMinutes}${period}`;
+};
+
+/** hh:mm 형식 */
+export const getFormattedCurrTime = (date: Date) => {
+	const { formattedHours, formattedMinutes } = getCurrTime(date);
+	return `${formattedHours}:${formattedMinutes}`;
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

진행사항 노티겸 피알 한번 씁니다 (성히언니 보삼)  

- DueDate 모달이 없어서 새로 만들었습니다
- 기존 큰 모달을 재활용하려고 했는데, 조건부 렌더링 부분이 너무 많아져서 너무 복잡해 따로 파는 게 나을 것 같아서 따로 빼서 제작했습니다
- create 하는 데에 필요한 state 들 만들고 연결했습니다
- 현시각 반영, 현재일로부터 14일 이후 등 반영했습니다

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- Date 쪽 처리를 일단 시간이 없어 props 뚫어 가져갔는데 구조가 더러워서 조금 고민 중입니다.
- 말단 컴포넌트들 state 는 이제 필요없을 것 같아 차차 살펴보고 제거하고 싶습니다
- 구조가 컴포넌트에서 시간.날짜 상태 한번, 모달에서 시간,날짜 상태 한번, 전체 mutation 일어나는 곳에서 한번이라 상당히 복잡한데 , 모달 -> 전체에서는 모달에서 임시 상태를 가지고 있다가 표시해주고 또 취소하는 유즈케이스 대응하기 위해 필요합니다. 컴포넌트단은 한번 다시 봐야할 듯합니다

## 관련 이슈

close #342 

## 스크린샷 (선택)
