### PR TITLE
[FEAT] DueDate모달 2차 연결

### DIFF
--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -11,6 +11,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
+	max-height: 82rem;
 	padding-left: 0.8rem;
 	overflow: auto;
 	overflow-y: scroll;

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -10,7 +10,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 100%;
-	height: 88rem;
+	height: 100%;
 	padding-left: 0.8rem;
 	overflow: auto;
 	overflow-y: scroll;

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -10,7 +10,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 100%;
-	height: 54rem;
+	height: 88rem;
 	padding-left: 0.8rem;
 	overflow: auto;
 	overflow-y: scroll;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -101,7 +101,7 @@ const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 44.8rem;
-	height: 100%;
+	height: 108rem;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
@@ -130,6 +130,6 @@ const BottomContainer = styled.div`
 	flex-direction: column;
 	align-items: flex-start;
 	width: 100%;
-	height: 100%;
+	height: 88rem;
 	padding-bottom: 2.8rem;
 `;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -72,4 +72,5 @@ const StagingAreaTaskContainerLayout = styled.div`
 	align-items: flex-start;
 	align-self: stretch;
 	width: 100%;
+	height: 100%;
 `;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -3,7 +3,6 @@ import { Draggable } from 'react-beautiful-dnd';
 
 import BtnTaskContainer from '../BtnTaskContainer';
 import EmptyContainer from '../EmptyContainer';
-import ScrollGradient from '../ScrollGradient';
 import Todo from '../v2/taskBox/Todo';
 
 import { StatusType, TaskType } from '@/types/tasks/taskType';
@@ -52,7 +51,7 @@ function StagingAreaTaskContainer({
 									)}
 								</Draggable>
 							))}
-						<ScrollGradient />
+						{/* <ScrollGradient /> */}
 					</TaskWrapper>
 				)}
 			</BtnTaskContainer>

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -121,6 +121,7 @@ function DumpingAreaBtn() {
 export default DumpingAreaBtn;
 
 const DumpingAreaContainer = styled.div`
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 8px;

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -14,7 +14,7 @@ interface DueDateModalType {
 	handleSettingModal: () => void;
 }
 function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
-	// 모달 안 임시 state들, Button 누를시 상위 컴포넌트 state로 들어감
+	// 모달 내부 state들, Button 누를시 상위 컴포넌트 state로 들어감
 	const defaultDate = new Date();
 
 	const dateAfter14Days = defaultDate;

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -65,6 +65,9 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 }
 
 const DueDateModalLayout = styled.article`
+	position: absolute;
+	top: 8.8rem;
+	left: 0.8rem;
 	z-index: 5;
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -12,6 +12,7 @@ interface DateTimeBtnProps {
 	isAllday?: boolean;
 	onClick: () => void;
 	handleDueDateModalDate?: (date: Date) => void;
+	handleDueDateModalTime?: (time: string) => void;
 }
 
 function DateTimeBtn({
@@ -22,10 +23,13 @@ function DateTimeBtn({
 	isAllday = false,
 	onClick,
 	handleDueDateModalDate = () => {},
+	handleDueDateModalTime = () => {},
 }: DateTimeBtnProps) {
+	// ~~여기에 상태 있어야하는지 의문~~
 	const [startTime, setStartTime] = useState(initStartTime);
 	const [endTime, setEndTime] = useState(initEndTime);
 	const [date, setDate] = useState(initDate);
+	// ~~~~
 
 	const updateStartTime = (newTime: string) => {
 		setStartTime(newTime);
@@ -33,6 +37,7 @@ function DateTimeBtn({
 
 	const updateEndTime = (newTime: string) => {
 		setEndTime(newTime);
+		handleDueDateModalTime(newTime.slice(0, 5));
 	};
 
 	const updateDate = (newDate: Date) => {

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -97,6 +97,7 @@ function DeadlineBox({
 							isAllday={isAllday}
 							onClick={handleClickModify}
 							handleDueDateModalDate={handleDueDateModalDate}
+							handleDueDateModalTime={handleDueDateModalTime}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -187,7 +187,8 @@ export default Today;
 
 const TodayLayout = styled.div`
 	display: flex;
-	height: 100%;
+	height: 108rem;
+	overflow: hidden;
 `;
 
 const CalendarWrapper = styled.div`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 전에 DueDate 모달 설정하던 브랜치 기준으로 브랜치를 팠습니다
- dumpingArea 특히 Todo 홀딩하는 부분 스타일링이 좀 이상해서 화면에 맞게 해두었는데 디자인 화면이랑 1000% 일치 하지는 않을 것 같습니다 추후 세세하게 수정해 볼게요 ...
- 드롭다운에서 시간 선택해서 연결하는 부분 구현해뒀습니다. 


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 기존 드롭다운에서는 `hh:mm am` 같은 형식으로 상태에 저장이 되어 있어서 뒤 am pm 부분만 잘라서 api 에 꽂았으니 이후에 이부분 건드리면 터질 수 있으니 주의해주세요
- 이 표시하는 부분들이랑 모달에서 표기하는 방법, state 로 관리하는 시간 형식이 다 string이다보니 제각각이라서.. 어디는 hh:mm am 이런 식으로 붙어있기도 하고 어디는 hh:mm 으로 되어있어서 이거 통일하고 변환하는 유틸 함수 만들기 + 출력값 형식 맞추기 함 해야 할 것 같아요 피알 올려두고 리뷰어푸까지 시간 걸릴테니 그때 해보겠습다

## 관련 이슈

close #345 

## 스크린샷 (선택)
<img width="317" alt="image" src="https://github.com/user-attachments/assets/58c3b4e0-634d-4b73-82aa-7363fd4efb41" />
<img width="185" alt="image" src="https://github.com/user-attachments/assets/6c20df32-519b-48d6-85f3-03f849508231" />
