### PR TITLE
[FEAT] timeblock 생성 기능+api 연결

### DIFF
--- a/src/apis/timeBlocks/getTimeBlock/GetTimeBlockType.ts
+++ b/src/apis/timeBlocks/getTimeBlock/GetTimeBlockType.ts
@@ -1,5 +1,8 @@
 export interface GetTimeBlokType {
 	startDate: string;
 	range: number;
-	categories?: string[];
+	/**
+	 * TODO: 구글 캘린더 추후 다시 추가 예정
+	 */
+	// categories?: string[];
 }

--- a/src/apis/timeBlocks/getTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/getTimeBlock/axios.ts
@@ -2,12 +2,14 @@ import { GetTimeBlokType } from './GetTimeBlockType';
 
 import { privateInstance } from '@/apis/instance';
 
-const getTimeBlock = async ({ startDate, range, categories }: GetTimeBlokType) => {
+/**
+ * TODO: 구글 캘린더 추후 다시 추가 예정
+ */
+const getTimeBlock = async ({ startDate, range }: GetTimeBlokType) => {
 	const response = await privateInstance.get(`/api/tasks/time-blocks`, {
 		params: {
 			startDate,
 			range,
-			categories,
 		},
 	});
 	return response;

--- a/src/apis/timeBlocks/getTimeBlock/query.ts
+++ b/src/apis/timeBlocks/getTimeBlock/query.ts
@@ -4,10 +4,10 @@ import getTimeBlock from './axios';
 import { GetTimeBlokType } from './GetTimeBlockType';
 
 /** TimeBlock 리스트 조회 */
-const useGetTimeBlock = ({ startDate, range, categories }: GetTimeBlokType) =>
+const useGetTimeBlock = ({ startDate, range }: GetTimeBlokType) =>
 	useQuery({
-		queryKey: ['timeblock', startDate, range, categories],
-		queryFn: () => getTimeBlock({ startDate, range, categories }),
+		queryKey: ['timeblock', startDate, range],
+		queryFn: () => getTimeBlock({ startDate, range }),
 	});
 
 export default useGetTimeBlock;

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable as FullCalendarDraggable } from 'fullcalendar/index.js';
+import { useEffect } from 'react';
+import { Draggable as BeautifulDnDDraggable } from 'react-beautiful-dnd';
 
 import BtnTaskContainer from '../BtnTaskContainer';
 import EmptyContainer from '../EmptyContainer';
@@ -17,21 +19,47 @@ interface StagingAreaTaskContainerProps {
 }
 
 function StagingAreaTaskContainer({
-	// handleSelectedTarget,
-	// selectedTarget,
+	handleSelectedTarget,
+	selectedTarget,
 	tasks,
 	// targetDate,
 }: StagingAreaTaskContainerProps) {
+	useEffect(() => {
+		const container = document.getElementById('dumping-task-container');
+
+		if (container) {
+			const draggable = new FullCalendarDraggable(container, {
+				itemSelector: '.todo-item', // 드래그 가능한 요소
+				eventData: () => {
+					if (selectedTarget) {
+						return {
+							id: selectedTarget.id.toString(),
+							title: selectedTarget.name,
+						};
+					}
+					return null;
+				},
+			});
+
+			// 컴포넌트 언마운트 시 FullCalendarDraggable 정리
+			return () => {
+				draggable.destroy?.();
+			};
+		}
+
+		return undefined;
+	}, [selectedTarget]);
+
 	return (
 		<StagingAreaTaskContainerLayout>
-			<BtnTaskContainer type="staging">
+			<BtnTaskContainer id="dumping-task-container" type="staging">
 				{tasks?.length === 0 || !tasks ? (
 					<EmptyContainer />
 				) : (
 					<TaskWrapper>
 						{tasks &&
 							tasks.map((task: TaskType, index: number) => (
-								<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
+								<BeautifulDnDDraggable key={task.id} draggableId={task.id.toString()} index={index}>
 									{(provided) => (
 										<div
 											ref={provided.innerRef}
@@ -39,18 +67,23 @@ function StagingAreaTaskContainer({
 											{...provided.dragHandleProps}
 											style={{ userSelect: 'none', ...provided.draggableProps.style }}
 										>
-											<Todo
-												key={task.id}
-												status={task.status as StatusType}
-												title={task.name}
-												// 이후 날짜, 시간 표시 형식에 맞게 입력 / 조정
-												deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
-												deadlineTime={task.deadLine?.time || undefined}
-												isStatusVisible={false}
-											/>
+											<div
+												className="todo-item" // FullCalendarDraggable 대상
+											>
+												<Todo
+													key={task.id}
+													status={task.status as StatusType}
+													title={task.name}
+													// 이후 날짜, 시간 표시 형식에 맞게 입력 / 조정
+													deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
+													deadlineTime={task.deadLine?.time || undefined}
+													isStatusVisible={false}
+													onClick={() => handleSelectedTarget(task)}
+												/>
+											</div>
 										</div>
 									)}
-								</Draggable>
+								</BeautifulDnDDraggable>
 							))}
 						<ScrollGradient />
 					</TaskWrapper>

--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -15,12 +15,13 @@ import { blurRef } from '@/utils/refStatus';
 interface DateCorrectionModalProps {
 	top?: number;
 	left?: number;
+	right?: number;
 	date: string | null;
 	onClick: () => void;
 	handleCurrentDate?: (newDate: Date) => void;
 }
 
-function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDate }: DateCorrectionModalProps) {
+function DateCorrectionModal({ top = 0, left, right, date, onClick, handleCurrentDate }: DateCorrectionModalProps) {
 	const prevDate = date ? new Date(date) : null;
 	const [currentDate, setCurrentDate] = useState<Date | null>(prevDate);
 	const dateTextRef = useRef<HTMLInputElement>(null);
@@ -43,7 +44,7 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 		onClick();
 	};
 	return (
-		<DateCorrectionModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
+		<DateCorrectionModalLayout top={top} left={left} right={right} onClick={(e) => e.stopPropagation()}>
 			<DatePicker
 				locale={ko}
 				selected={currentDate}
@@ -60,11 +61,20 @@ function DateCorrectionModal({ top = 0, left = 0, date, onClick, handleCurrentDa
 	);
 }
 
-const DateCorrectionModalLayout = styled.div<{ top: number; left: number }>`
+const DateCorrectionModalLayout = styled.div<{ top: number; left?: number; right?: number }>`
 	position: absolute;
 	top: ${({ top }) => top}rem;
-	left: ${({ left }) => left}rem;
 	z-index: 4;
+
+	${({ left, right }) => {
+		if (left !== undefined) {
+			return `left: ${left}rem;`;
+		}
+		if (right !== undefined) {
+			return `right: ${right}rem;`;
+		}
+		return `left: 0;`;
+	}}
 `;
 
 const BottomBtnWrapper = styled.div`

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -1,19 +1,45 @@
+import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import IconButton from '../v2/IconButton';
 import MainDate from '../v2/TextBox/MainDate';
 
-type Props = {
+type CalendarHeaderProps = {
 	size: 'small' | 'big';
 	date: { year: number; month: number };
+	isActive: boolean;
+	handleCalendarPopup: () => void;
 };
 
-function CalendarHeader({ size, date }: Props) {
+function CalendarHeader({ size, date, isActive, handleCalendarPopup }: CalendarHeaderProps) {
+	const { color } = useTheme();
+
+	const activeButtonStyle = css`
+		color: ${color.Grey.Grey5};
+
+		background-color: ${color.Grey.Grey3};
+
+		${isActive &&
+		css`
+			:hover {
+				color: ${color.Grey.Grey5};
+
+				background-color: ${color.Grey.Grey3};
+			}
+		`}
+	`;
+
 	return (
 		<CalendarHeaderContainer size={size}>
 			<MainDate year={date.year} month={date.month} />
 			<CalendarHeaderWrapper>
-				<IconButton type="normal" size="small" iconName="IcnCalendar" />
+				<IconButton
+					type="normal"
+					size="small"
+					iconName="IcnCalendar"
+					onClick={handleCalendarPopup}
+					additionalCss={isActive ? activeButtonStyle : undefined}
+				/>
 				<IconButton type="normal" size="small" iconName="IcnFilter" />
 			</CalendarHeaderWrapper>
 		</CalendarHeaderContainer>

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -25,6 +25,7 @@ export default CalendarHeader;
 const CalendarHeaderContainer = styled.div<{ size: string }>`
 	position: absolute;
 	top: 56px;
+	z-index: 1;
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -9,9 +9,10 @@ type CalendarHeaderProps = {
 	date: { year: number; month: number };
 	isActive: boolean;
 	handleCalendarPopup: () => void;
+	handleFilterPopup: () => void;
 };
 
-function CalendarHeader({ size, date, isActive, handleCalendarPopup }: CalendarHeaderProps) {
+function CalendarHeader({ size, date, isActive, handleCalendarPopup, handleFilterPopup }: CalendarHeaderProps) {
 	const { color } = useTheme();
 
 	const activeButtonStyle = css`
@@ -40,7 +41,13 @@ function CalendarHeader({ size, date, isActive, handleCalendarPopup }: CalendarH
 					onClick={handleCalendarPopup}
 					additionalCss={isActive ? activeButtonStyle : undefined}
 				/>
-				<IconButton type="normal" size="small" iconName="IcnFilter" />
+				<IconButton
+					type="normal"
+					size="small"
+					iconName="IcnFilter"
+					onClick={handleFilterPopup}
+					additionalCss={isActive ? activeButtonStyle : undefined}
+				/>
 			</CalendarHeaderWrapper>
 		</CalendarHeaderContainer>
 	);

--- a/src/components/common/fullCalendar/CustomDayCellContent.tsx
+++ b/src/components/common/fullCalendar/CustomDayCellContent.tsx
@@ -30,7 +30,8 @@ interface CustomDayCellContentProps {
 function CustomDayCellContent({ arg, today, selectDate }: CustomDayCellContentProps) {
 	const date = new Date(arg.date);
 	const day = arg.dayNumberText.replace('일', '');
-	const isSelectedDate = date.toDateString() === selectDate;
+	const isSelectedDate = selectDate ? new Date(selectDate).toDateString() === new Date(arg.date).toDateString() : false;
+
 	const isToday = date.toDateString() === today;
 	const [state, setState] = useState<StateType>(STATE.DEFAULT);
 
@@ -116,7 +117,7 @@ const underlineStyle = css`
 		position: absolute;
 		bottom: 2px;
 		left: 50%;
-		width: 3.2rem;
+		width: 2rem;
 		height: 0.1rem;
 
 		background-color: ${theme.colorToken.Text.primary};

--- a/src/components/common/fullCalendar/DayHeaderContent.tsx
+++ b/src/components/common/fullCalendar/DayHeaderContent.tsx
@@ -9,22 +9,14 @@ interface DayHeaderContentProps {
 	currentView: string;
 	today: string;
 	selectDate?: string;
-	size: string;
 }
 
-function DayHeaderContent({ arg, currentView, today, selectDate, size }: DayHeaderContentProps) {
-	let adjustDay = size === 'big' ? 3 : 2;
-	if (currentView === 'dayGridMonth') {
-		adjustDay = 0;
-	}
-	const adjustedDate = new Date(arg.date);
-	adjustedDate.setDate(adjustedDate.getDate() - adjustDay);
+function DayHeaderContent({ arg, currentView, today, selectDate }: DayHeaderContentProps) {
+	const day = new Intl.DateTimeFormat('ko', { weekday: 'short' }).format(arg.date);
+	const date = arg.date.getDate();
 
-	const isTimeGridDay = currentView === 'timeGridDay';
-	const day = new Intl.DateTimeFormat('ko', { weekday: isTimeGridDay ? 'long' : 'short' }).format(adjustedDate);
-	const date = adjustedDate.getDate();
-	const isSelectedDate = adjustedDate.toDateString() === selectDate;
-	const isToday = adjustedDate.toDateString() === today;
+	const isSelectedDate = arg.date.toDateString() === selectDate;
+	const isToday = arg.date.toDateString() === today;
 	const isSatday = day === '토';
 	const isSunday = day === '일';
 

--- a/src/components/common/fullCalendar/DayHeaderContent.tsx
+++ b/src/components/common/fullCalendar/DayHeaderContent.tsx
@@ -9,13 +9,14 @@ interface DayHeaderContentProps {
 	currentView: string;
 	today: string;
 	selectDate?: string;
+	handleChangeDate: (target: Date) => void;
 }
 
-function DayHeaderContent({ arg, currentView, today, selectDate }: DayHeaderContentProps) {
+function DayHeaderContent({ arg, currentView, today, selectDate, handleChangeDate }: DayHeaderContentProps) {
 	const day = new Intl.DateTimeFormat('ko', { weekday: 'short' }).format(arg.date);
 	const date = arg.date.getDate();
 
-	const isSelectedDate = arg.date.toDateString() === selectDate;
+	const isSelectedDate = selectDate ? new Date(selectDate).toDateString() === new Date(arg.date).toDateString() : false;
 	const isToday = arg.date.toDateString() === today;
 	const isSatday = day === '토';
 	const isSunday = day === '일';
@@ -31,6 +32,7 @@ function DayHeaderContent({ arg, currentView, today, selectDate }: DayHeaderCont
 					day={date.toString()}
 					weekDay={day.toString()}
 					type={isToday ? 'Primary' : isSelectedDate ? 'Secondary' : 'Teritary'}
+					handleChangeDate={() => handleChangeDate(arg.date)}
 				/>
 			)}
 		</div>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -50,6 +50,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 	const { data: timeBlockData } = useGetTimeBlock({ startDate, range });
 	const { mutate: createMutate } = usePostTimeBlock();
 	const { mutate: updateMutate } = useUpdateTimeBlock();
+	const { mutate: deleteMutate } = useDeleteTimeBlock();
 
 	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data) : [];
 
@@ -186,13 +187,11 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 
 	const isSelectable = !!selectedTarget;
 
-	const { mutate } = useDeleteTimeBlock();
-
 	const handleDelete = () => {
 		console.log('taskId, timeBlockId', modalTaskId, modalTimeBlockId);
 
 		if (modalTaskId && modalTimeBlockId) {
-			mutate({ taskId: modalTaskId, timeBlockId: modalTimeBlockId });
+			deleteMutate({ taskId: modalTaskId, timeBlockId: modalTimeBlockId });
 		} else {
 			console.error('taskId 또는 timeBlockId가 존재하지 않습니다.');
 		}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -1,4 +1,4 @@
-import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg } from '@fullcalendar/core';
+import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg, MoreLinkContentArg } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { EventReceiveArg } from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
@@ -297,6 +297,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				dayCellContent={(arg) => (
 					<CustomDayCellContent arg={arg} today={today.toDateString()} selectDate={selectDate?.toString()} />
 				)}
+				moreLinkContent={(arg) => `${arg.num}개 일정 더보기 +`}
 				eventTimeFormat={{
 					hour: 'numeric',
 					minute: '2-digit',

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -291,6 +291,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 						currentView={currentView}
 						today={today.toDateString()}
 						selectDate={selectDate?.toString()}
+						handleChangeDate={handleChangeDate}
 					/>
 				)}
 				viewDidMount={handleViewChange}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -8,6 +8,7 @@ import { useState, useRef, useEffect } from 'react';
 
 import DateCorrectionModal from '../datePicker/DateCorrectionModal';
 import ModalDeleteDetail from '../modal/ModalDeleteDetail';
+import CalendarSettingDropdown from '../v2/dropdown/CalendarSettingDropdown';
 
 import CalendarHeader from './CalendarHeader';
 import CustomDayCellContent from './CustomDayCellContent';
@@ -42,6 +43,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 	const [modalTimeBlockId, setModalTimeBlockId] = useState<number | null>(null);
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
+	const [isFilterPopupOpen, setFilterPopupOpen] = useState(false);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -202,6 +204,10 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 		setCalendarPopupOpen((prev) => !prev);
 	};
 
+	const handleFilterPopup = () => {
+		setFilterPopupOpen((prev) => !prev);
+	};
+
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>
 			<CalendarHeader
@@ -209,6 +215,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				date={date}
 				isActive={isCalendarPopupOpen}
 				handleCalendarPopup={handleCalendarPopup}
+				handleFilterPopup={handleFilterPopup}
 			/>
 			<FullCalendar
 				height="100%"
@@ -277,6 +284,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				// Todo: date props 실제값으로 변경 필요
 				<DateCorrectionModal date={new Date().toISOString()} onClick={handleCalendarPopup} top={9.8} right={0.8} />
 			)}
+			{isFilterPopupOpen && <CalendarSettingDropdown top={9.8} right={0.8} />}
 			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
 				<ModalDeleteDetail top={top} left={left} onClose={closeModal} onDelete={handleDelete} />
 			)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -6,6 +6,7 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import { DateSelectArg, EventResizeDoneArg } from 'fullcalendar/index.js';
 import { useState, useRef, useEffect } from 'react';
 
+import DateCorrectionModal from '../datePicker/DateCorrectionModal';
 import ModalDeleteDetail from '../modal/ModalDeleteDetail';
 
 import CalendarHeader from './CalendarHeader';
@@ -40,6 +41,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 	const [modalTaskId, setModalTaskId] = useState<number | null>(null);
 	const [modalTimeBlockId, setModalTimeBlockId] = useState<number | null>(null);
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
+	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -196,9 +198,18 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 		setModalOpen(false);
 	};
 
+	const handleCalendarPopup = () => {
+		setCalendarPopupOpen((prev) => !prev);
+	};
+
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>
-			<CalendarHeader size={size} date={date} />
+			<CalendarHeader
+				size={size}
+				date={date}
+				isActive={isCalendarPopupOpen}
+				handleCalendarPopup={handleCalendarPopup}
+			/>
 			<FullCalendar
 				height="100%"
 				ref={calendarRef}
@@ -262,6 +273,10 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				eventDrop={updateEvent} // 기존 이벤트 드래그 수정 핸들러
 				eventResize={updateEvent} // 기존 이벤트 리사이즈 수정 핸들러
 			/>
+			{isCalendarPopupOpen && (
+				// Todo: date props 실제값으로 변경 필요
+				<DateCorrectionModal date={new Date().toISOString()} onClick={handleCalendarPopup} top={9.8} right={0.8} />
+			)}
 			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
 				<ModalDeleteDetail top={top} left={left} onClose={closeModal} onDelete={handleDelete} />
 			)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -1,4 +1,4 @@
-import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg, MoreLinkContentArg } from '@fullcalendar/core';
+import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { EventReceiveArg } from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
@@ -28,9 +28,10 @@ interface FullCalendarBoxProps {
 	size: 'small' | 'big';
 	selectDate?: Date | null;
 	selectedTarget?: TaskType | null;
+	handleChangeDate: (target: Date) => void;
 }
 
-function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxProps) {
+function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }: FullCalendarBoxProps) {
 	const today = useMemo(() => new Date(), []);
 	const todayDate = today.toISOString().split('T')[0];
 	const [currentView, setCurrentView] = useState('timeGridWeek');
@@ -294,6 +295,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget }: FullCalendarBoxPr
 				)}
 				viewDidMount={handleViewChange}
 				datesSet={handleDatesSet}
+				dateClick={(arg) => handleChangeDate(arg.date)}
 				dayCellContent={(arg) => (
 					<CustomDayCellContent arg={arg} today={today.toDateString()} selectDate={selectDate?.toString()} />
 				)}

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -202,6 +202,11 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		margin-top: 4rem;
 	}
 
+	.month-view .fc-daygrid-day-frame:active {
+		background-color: ${({ theme }) => theme.colorToken.Component.strong};
+		border: 1px solid ${({ theme }) => theme.colorToken.Outline.primaryStrong};
+	}
+
 	/* fc-daygrid-day-events: 종일 행(개별) */
 	.fc-daygrid-day-frame .fc-scrollgrid-sync-inner,
 	.fc-daygrid-day-events {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -231,13 +231,17 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		width: 100%;
 		height: 100%;
 		padding: 0.4rem 0.6rem;
+		overflow: hidden;
 
-		color: ${(color) => color.theme.palette.Grey.Grey8};
-
-		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
+		background-color: ${({ theme }) => theme.colorToken.Component.strong};
 		border: none;
 		border-radius: 4px;
-		${({ theme }) => theme.fontTheme.CAPTION_03};
+	}
+
+	/* fc-event-title이 더 위로 오도록  */
+	.fc-event-main-frame {
+		flex-direction: column-reverse;
+		gap: 4px;
 	}
 
 	/** 넘어가는 텍스트 처리 */
@@ -245,8 +249,15 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		flex-shrink: 1;
 		overflow: hidden;
 
+		color: ${({ theme }) => theme.colorToken.Text.neutralLight};
 		white-space: nowrap;
 		text-overflow: ellipsis;
+		${({ theme }) => theme.font.body05};
+	}
+
+	.fc-event-time {
+		color: ${({ theme }) => theme.colorToken.Text.assistive};
+		${({ theme }) => theme.font.caption02};
 	}
 
 	.fc-event-main .tasks {
@@ -280,7 +291,11 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	/* fc-timegrid-col-events : 주간 이벤트 , fc-daygrid-day-frame: 월간 이벤트 */
 	.fc .fc-timegrid-col-events .fc-event-main:hover {
-		background-color: ${({ theme }) => theme.palette.Blue.Blue3};
+		background-color: ${({ theme }) => theme.colorToken.Component.heavy};
+	}
+
+	.fc .fc-timegrid-col-events .fc-event-main:active {
+		background-color: ${({ theme }) => theme.colorToken.Component.accent};
 	}
 
 	.fc .fc-daygrid-day-frame .schedule .fc-event-main {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -147,7 +147,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc-daygrid-body {
 		width: 100% !important;
-		padding-right: 1rem;
 		overflow: hidden;
 
 		border: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong};
@@ -165,12 +164,20 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		height: 2rem;
 	}
 
+	.fc-col-header {
+		width: 100% !important;
+	}
+
 	.fc .fc-col-header-cell {
 		height: 2.4rem;
 		padding: 2.4rem 0.8rem 0.5rem;
 
 		border-right: none;
 		border-left: none;
+	}
+
+	.fc-scrollgrid-sync-table {
+		width: 100% !important;
 	}
 
 	/* 종일  - 타임그리드 셀 크기 고정 */
@@ -189,6 +196,13 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 전체 캘린더(주간) */
 	.fc-scrollgrid.fc-scrollgrid-liquid {
 		/* padding: 0 8px 0 0; */
+	}
+
+	/* .fc-daygrid-day-frame {
+		position: relative;
+	} */
+	.fc-daygrid-day-events {
+		margin-top: 4rem;
 	}
 
 	/* fc-daygrid-day-events: 종일 행(개별) */
@@ -218,6 +232,11 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 타임그리드 테두리 */
 	.fc .fc-scrollgrid-section-body table,
 	.fc .fc-scrollgrid-section-footer table {
+		${({ currentView }) =>
+			currentView === 'dayGridMonth' &&
+			`
+			border: none
+  	`}
 		border-right: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong};
 		border-bottom-style: hidden;
 	}
@@ -461,6 +480,8 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc .fc-daygrid-event {
 		margin: 0;
+
+		text-overflow: ellipsis;
 	}
 
 	.fc .fc-cell-shaded {
@@ -501,7 +522,8 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		display: flex;
 		gap: 4px;
 		align-items: center;
-		width: 12.4rem;
+		width: 12rem;
+		width: ${({ size }) => (size === 'big' ? '17.5rem' : '12rem')};
 		height: 2rem;
 		padding: 0 4px 0 8px;
 

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -25,6 +25,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	/* Custom button styles */
 	.fc-toolbar-chunk .fc-button {
+		z-index: 1;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -146,6 +147,18 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc-daygrid-body {
 		width: 100% !important;
+		padding-right: 1rem;
+		overflow: hidden;
+
+		border: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong};
+		border-radius: 12px;
+
+		${({ currentView }) =>
+			currentView === 'timeGridWeekCustom' &&
+			`
+    border-left: none;
+		border-radius: 0
+  	`}
 	}
 
 	.fc-event-allday {
@@ -364,21 +377,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 월간뷰 스크롤 제거 */
 	.month-view .fc-scroller {
 		overflow: hidden !important;
-	}
-
-	.fc-daygrid-body {
-		padding-right: 1rem;
-		overflow: hidden;
-
-		border: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong};
-		border-radius: 12px;
-
-		${({ currentView }) =>
-			currentView === 'timeGridWeekCustom' &&
-			`
-    border-left: none;
-		border-radius: 0
-  `}
 	}
 
 	/* 15분 줄선 테두리 */

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -482,6 +482,10 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		border-radius: 4px;
 	}
 
+	.fc-daygrid-event .fc-event-time {
+		display: none;
+	}
+
 	.fc .fc-daygrid-dot-event {
 		padding: 0.4rem 0.6rem;
 
@@ -494,7 +498,15 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	}
 
 	.fc .fc-daygrid-dot-event.tasks {
-		background-color: ${({ theme }) => theme.palette.Blue.Blue2};
+		display: flex;
+		gap: 4px;
+		align-items: center;
+		width: 12.4rem;
+		height: 2rem;
+		padding: 0 4px 0 8px;
+
+		background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
+		border-radius: 4px;
 	}
 
 	/* 월간 이벤트 호버 효과 */
@@ -503,15 +515,20 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	}
 
 	.fc .fc-daygrid-dot-event.tasks:hover {
-		background-color: ${({ theme }) => theme.palette.Blue.Blue3};
+		background-color: ${({ theme }) => theme.colorToken.Neutral.strong};
+	}
+
+	.fc .fc-daygrid-dot-event.tasks:active {
+		background-color: ${({ theme }) => theme.colorToken.Neutral.heavy};
 	}
 
 	.fc .fc-h-event {
 		border: none;
 	}
 
+	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
 	.fc-daygrid-event-dot {
-		display: none;
+		border-color: ${({ theme }) => theme.colorToken.Text.assistive};
 	}
 
 	.fc .fc-timegrid-axis-frame {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -198,9 +198,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		/* padding: 0 8px 0 0; */
 	}
 
-	/* .fc-daygrid-day-frame {
-		position: relative;
-	} */
 	.fc-daygrid-day-events {
 		margin-top: 4rem;
 	}
@@ -523,7 +520,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		gap: 4px;
 		align-items: center;
 		width: 12rem;
-		width: ${({ size }) => (size === 'big' ? '17.5rem' : '12rem')};
+		width: ${({ size }) => (size === 'big' ? '18rem' : '12rem')};
 		height: 2rem;
 		padding: 0 4px 0 8px;
 
@@ -551,6 +548,21 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
 	.fc-daygrid-event-dot {
 		border-color: ${({ theme }) => theme.colorToken.Text.assistive};
+	}
+
+	/* Month view 중 이벤트 초과 안내 */
+	.fc-daygrid-more-link {
+		display: flex;
+		align-items: center;
+		width: ${({ size }) => (size === 'big' ? '18rem' : '12rem')};
+		height: 2rem;
+		padding: 0 4px 0 8px;
+
+		color: ${({ theme }) => theme.colorToken.Text.neutralLight};
+
+		background-color: ${({ theme }) => theme.colorToken.Component.strong};
+		${({ theme }) => theme.font.body05};
+		border-radius: 4px;
 	}
 
 	.fc .fc-timegrid-axis-frame {

--- a/src/components/common/fullCalendar/processEvents.tsx
+++ b/src/components/common/fullCalendar/processEvents.tsx
@@ -31,22 +31,25 @@ const processEvents = (timeBlockData: TimeBlockData): EventData[] => {
 		});
 	});
 
-	// googles 데이터 처리
-	timeBlockData.googles.forEach((google) => {
-		google.schedules.forEach((schedule) => {
-			events.push({
-				title: google.name,
-				start: schedule.startTime,
-				end: schedule.endTime,
-				allDay: schedule.allDay,
-				classNames: 'schedule',
-				extendedProps: {
-					taskId: -1, // 구글 캘린더 이벤트에는 taskId가 없으므로 -1로 설정
-					timeBlockId: null,
-				},
-			});
-		});
-	});
+	/**
+	 * TODO: 구글 캘린더 추후 다시 추가 예정
+	 */
+	// // googles 데이터 처리
+	// timeBlockData.googles.forEach((google) => {
+	// 	google.schedules.forEach((schedule) => {
+	// 		events.push({
+	// 			title: google.name,
+	// 			start: schedule.startTime,
+	// 			end: schedule.endTime,
+	// 			allDay: schedule.allDay,
+	// 			classNames: 'schedule',
+	// 			extendedProps: {
+	// 				taskId: -1, // 구글 캘린더 이벤트에는 taskId가 없으므로 -1로 설정
+	// 				timeBlockId: null,
+	// 			},
+	// 		});
+	// 	});
+	// });
 
 	return events;
 };

--- a/src/components/common/v2/TextBox/SubDate.tsx
+++ b/src/components/common/v2/TextBox/SubDate.tsx
@@ -22,9 +22,10 @@ interface SubDateProps {
 	day: string;
 	weekDay: string;
 	type: (typeof TYPE)[keyof typeof TYPE];
+	handleChangeDate?: (target: Date) => void;
 }
 
-function SubDate({ day, weekDay, type }: SubDateProps) {
+function SubDate({ day, weekDay, type, handleChangeDate }: SubDateProps) {
 	const [state, setState] = useState<StateType>(STATE.DEFAULT);
 
 	const handleStateChange = (newState: StateType) => () => {
@@ -39,6 +40,7 @@ function SubDate({ day, weekDay, type }: SubDateProps) {
 			onMouseLeave={handleStateChange(STATE.DEFAULT)}
 			onMouseDown={handleStateChange(STATE.PRESSED)}
 			onMouseUp={handleStateChange(STATE.DEFAULT)}
+			onClick={() => (handleChangeDate ?? (() => {}))(new Date())}
 		>
 			<span className="day">{day}</span>
 			<span className="week-day">{weekDay}</span>

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -4,7 +4,12 @@ import { useState } from 'react';
 import CheckButton from '@/components/common/v2/control/CheckButton';
 import { STATUS_OPTIONS } from '@/constants/statuses';
 
-function CalendarSettingDropdown() {
+type CalendarSettingDropdownProps = {
+	top?: number;
+	right?: number;
+};
+
+function CalendarSettingDropdown({ top = 0, right = 0 }: CalendarSettingDropdownProps) {
 	const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
 
 	const handleStatusChange = (status: string) => {
@@ -12,7 +17,7 @@ function CalendarSettingDropdown() {
 	};
 
 	return (
-		<CalendarSettingDropdownContainer>
+		<CalendarSettingDropdownContainer top={top} right={right}>
 			{STATUS_OPTIONS.map((option) => (
 				<CheckButton
 					key={option.value}
@@ -26,7 +31,12 @@ function CalendarSettingDropdown() {
 	);
 }
 
-const CalendarSettingDropdownContainer = styled.div`
+const CalendarSettingDropdownContainer = styled.div<{ top: number; right: number }>`
+	position: absolute;
+	top: ${({ top }) => top}rem;
+	right: ${({ right }) => right}rem;
+	z-index: 2;
+
 	display: flex;
 	flex-direction: column;
 	gap: 0.4rem;
@@ -35,6 +45,7 @@ const CalendarSettingDropdownContainer = styled.div`
 	height: 16rem;
 	padding: 1.6rem 0.8rem;
 
+	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-radius: 12px;
 	${({ theme }) => theme.shadow.FloatingAction3};
 `;

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -24,9 +24,10 @@ type TodoProps = {
 	deadlineTime?: string;
 	status: StatusType;
 	isStatusVisible?: boolean;
+	onClick: () => void;
 };
 
-function Todo({ title, deadlineDate, status: initStatus, isStatusVisible = true, deadlineTime }: TodoProps) {
+function Todo({ title, deadlineDate, status: initStatus, isStatusVisible = true, deadlineTime, onClick }: TodoProps) {
 	const { state, handleMouseEnter, handleMouseLeave, handleMouseDown, handleMouseUp, handleDragStart, handleDragEnd } =
 		useTodoEventHandler();
 
@@ -48,6 +49,7 @@ function Todo({ title, deadlineDate, status: initStatus, isStatusVisible = true,
 			onDragStart={handleDragStart}
 			onDragEnd={handleDragEnd}
 			draggable
+			onClick={onClick}
 		>
 			<TodoWrapper>
 				<span className="todo-title">{title}</span>
@@ -84,7 +86,7 @@ const stateStyles = ({ theme, state, isCompleted }: { theme: Theme; state: TodoE
 		case TODO_EVENT_STATE.PRESSED:
 			return css`
 				background-color: ${theme.colorToken.Component.strong};
-				border-color: ${theme.colorToken.Outline.primaryStrong};
+				border: 1px solid ${theme.colorToken.Outline.primaryStrong};
 			`;
 		case TODO_EVENT_STATE.FLOATED:
 			return css`
@@ -93,7 +95,11 @@ const stateStyles = ({ theme, state, isCompleted }: { theme: Theme; state: TodoE
 					0 16px 20px rgb(0 0 0 / 12%),
 					0 8px 16px rgb(0 0 0 / 8%),
 					0 0 8px rgb(0 0 0 / 8%);
-				border-color: ${theme.colorToken.Outline.primaryStrong};
+				border: 1px solid ${theme.colorToken.Outline.primaryStrong};
+			`;
+		case TODO_EVENT_STATE.HOVER:
+			return css`
+				border: ${isCompleted ? '1px' : '2px'} solid ${theme.colorToken.Outline.primaryStrong};
 			`;
 		default:
 			return css`
@@ -129,11 +135,6 @@ const TodoContainer = styled.div<{ isCompleted: boolean; state: TodoEventState }
 	${({ theme }) => baseStyles({ theme })}
 	${({ theme, isCompleted }) => textStyles({ theme, isCompleted })}
 	${({ theme, state, isCompleted }) => stateStyles({ theme, state, isCompleted })}
-
-	&:hover {
-		border-color: ${({ theme }) => theme.colorToken.Outline.primaryStrong};
-		border-width: ${({ isCompleted }) => (isCompleted ? '1px' : '2px')};
-	}
 `;
 
 const TodoWrapper = styled.div`

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable as FullCalendarDraggable } from 'fullcalendar/index.js';
+import { useEffect } from 'react';
+import { Draggable as BeautifulDnDDraggable } from 'react-beautiful-dnd';
 
 import BtnTaskContainer from '../common/BtnTaskContainer';
 import EmptyContainer from '../common/EmptyContainer';
@@ -16,9 +18,36 @@ interface TargetTaskSectionProps {
 }
 function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, targetDate }: TargetTaskSectionProps) {
 	// TODO: 추후에 해당 로직을 연결해야 합니다.
-	console.log(handleSelectedTarget, selectedTarget, targetDate);
+	// console.log(handleSelectedTarget, selectedTarget, targetDate);
+
+	useEffect(() => {
+		const container = document.getElementById('task-container');
+
+		if (container) {
+			const draggable = new FullCalendarDraggable(container, {
+				itemSelector: '.todo-item', // 드래그 가능한 요소
+				eventData: () => {
+					if (selectedTarget) {
+						return {
+							id: selectedTarget.id.toString(),
+							title: selectedTarget.name,
+						};
+					}
+					return null;
+				},
+			});
+
+			// 컴포넌트 언마운트 시 FullCalendarDraggable 정리
+			return () => {
+				draggable.destroy?.();
+			};
+		}
+
+		return undefined;
+	}, [selectedTarget]);
+
 	return (
-		<BtnTaskContainer type="target">
+		<BtnTaskContainer id="task-container" type="target">
 			{tasks.length === 0 ? (
 				<EmptyLayout>
 					<EmptyContainer />
@@ -26,7 +55,7 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 			) : (
 				<>
 					{tasks.map((task: TaskType, index: number) => (
-						<Draggable key={task.id} draggableId={task.id.toString()} index={index}>
+						<BeautifulDnDDraggable key={task.id} draggableId={task.id.toString()} index={index}>
 							{(provided) => (
 								<TodoSizedWrapper
 									ref={provided.innerRef}
@@ -34,23 +63,28 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 									{...provided.dragHandleProps}
 									style={provided.draggableProps.style}
 								>
-									<Todo
-										// location="target"
-										key={task.id}
-										title={task.name}
-										deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
-										deadlineTime={task.deadLine?.time || undefined}
-										status={task.status}
-										// id={task.id}
-										// handleSelectedTarget={handleSelectedTarget}
-										// selectedTarget={selectedTarget}
-										// isDragging={snapshot.isDragging}
-										// targetDate={targetDate}
-										// dashBoardInprogress={false}
-									/>
+									<div
+										className="todo-item" // FullCalendarDraggable 대상
+									>
+										<Todo
+											// location="target"
+											key={task.id}
+											title={task.name}
+											deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
+											deadlineTime={task.deadLine?.time || undefined}
+											status={task.status}
+											onClick={() => handleSelectedTarget(task)}
+											// id={task.id}
+											// handleSelectedTarget={handleSelectedTarget}
+											// selectedTarget={selectedTarget}
+											// isDragging={snapshot.isDragging}
+											// targetDate={targetDate}
+											// dashBoardInprogress={false}
+										/>
+									</div>
 								</TodoSizedWrapper>
 							)}
-						</Draggable>
+						</BeautifulDnDDraggable>
 					))}
 				</>
 			)}
@@ -59,6 +93,7 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 }
 
 export default TargetTaskSection;
+
 const TodoSizedWrapper = styled.div`
 	width: 100%;
 `;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -18,10 +18,10 @@ interface TargetTaskSectionProps {
 }
 function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, targetDate }: TargetTaskSectionProps) {
 	// TODO: 추후에 해당 로직을 연결해야 합니다.
-	// console.log(handleSelectedTarget, selectedTarget, targetDate);
+	console.log(handleSelectedTarget, selectedTarget, targetDate);
 
 	useEffect(() => {
-		const container = document.getElementById('task-container');
+		const container = document.getElementById('todolist-task-container');
 
 		if (container) {
 			const draggable = new FullCalendarDraggable(container, {
@@ -47,7 +47,7 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 	}, [selectedTarget]);
 
 	return (
-		<BtnTaskContainer id="task-container" type="target">
+		<BtnTaskContainer id="todolist-task-container" type="target">
 			{tasks.length === 0 ? (
 				<EmptyLayout>
 					<EmptyContainer />

--- a/src/hooks/useTodoEventHandler.ts
+++ b/src/hooks/useTodoEventHandler.ts
@@ -22,9 +22,7 @@ function useTodoEventHandler() {
 	};
 
 	const handleMouseUp = () => {
-		if (state === TODO_EVENT_STATE.PRESSED) {
-			setState(TODO_EVENT_STATE.DEFAULT);
-		}
+		setState(TODO_EVENT_STATE.DEFAULT);
 	};
 
 	const handleDragStart = () => {

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -16,6 +16,11 @@ function Calendar() {
 	const onClickDate = (date: Date | null) => {
 		setSelectDate(date);
 	};
+
+	const handleChangeDate = (target: Date) => {
+		setSelectDate(target);
+	};
+
 	const { data, isLoading } = useGetCategory();
 	if (isLoading) {
 		return <LoadingSpinner />;
@@ -40,7 +45,7 @@ function Calendar() {
 			</LeftSection>
 			<RightSection>
 				<FullCalendarBoxWapper>
-					<FullCalendarBox size="big" selectDate={selectDate} />
+					<FullCalendarBox size="big" selectDate={selectDate} handleChangeDate={handleChangeDate} />
 				</FullCalendarBoxWapper>
 			</RightSection>
 		</CalendarLayout>

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -11,7 +11,6 @@ import NavBar from '@/components/common/NavBar';
 import StagingArea from '@/components/common/StagingArea/StagingArea';
 import TargetArea from '@/components/targetArea/TargetArea';
 import { SortOrderType } from '@/constants/sortType';
-import { AreaType } from '@/types/area/areaType';
 import { TaskType } from '@/types/tasks/taskType';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
@@ -21,7 +20,6 @@ function Today() {
 	const [sortOrder, setSortOrder] = useState<SortOrderType>('CUSTOM_ORDER');
 	const [selectedDate, setTargetDate] = useState(new Date());
 	const targetDate = formatDatetoLocalDate(selectedDate);
-	const [selectedArea, setSelectedArea] = useState<AreaType>(null);
 	const [isDumpAreaOpen, setDumpAreaOpen] = useState(true);
 
 	// Task 목록 Get
@@ -33,6 +31,9 @@ function Today() {
 		setDumpAreaOpen((prev) => !prev);
 	};
 
+	console.log('stagingData', stagingData);
+	console.log('targetData', targetData);
+
 	/** isTotal 핸들링 함수 */
 	const handleTextBtnClick = (button: '전체' | '지연') => {
 		setActiveButton(button);
@@ -42,9 +43,8 @@ function Today() {
 		setSortOrder(order);
 	};
 
-	const handleSelectedTarget = (task: TaskType | null, area: AreaType) => {
+	const handleSelectedTarget = (task: TaskType | null) => {
 		setSelectedTarget(task);
-		setSelectedArea(area);
 	};
 
 	const handlePrevBtn = () => {
@@ -146,7 +146,7 @@ function Today() {
 			<NavBar isOpen={isDumpAreaOpen} handleSideBar={handleSidebar} />
 			<DragDropContext onDragEnd={handleDragEnd}>
 				<StagingArea
-					handleSelectedTarget={(task) => handleSelectedTarget(task, 'staging')}
+					handleSelectedTarget={(task) => handleSelectedTarget(task)}
 					selectedTarget={selectedTarget}
 					tasks={stagingData}
 					handleSortOrder={handleSortOrder}
@@ -161,7 +161,7 @@ function Today() {
 					<BtnTaskContainer type="target" />
 				) : (
 					<TargetArea
-						handleSelectedTarget={(task) => handleSelectedTarget(task, 'target')}
+						handleSelectedTarget={(task) => handleSelectedTarget(task)}
 						selectedTarget={selectedTarget}
 						tasks={targetData}
 						onClickPrevDate={handlePrevBtn}
@@ -173,11 +173,7 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox
-					size="small"
-					selectedTarget={selectedArea === 'target' ? selectedTarget : null}
-					selectDate={selectedDate}
-				/>
+				<FullCalendarBox size="small" selectedTarget={selectedTarget} selectDate={selectedDate} />
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -173,7 +173,12 @@ function Today() {
 				)}
 			</DragDropContext>
 			<CalendarWrapper>
-				<FullCalendarBox size="small" selectedTarget={selectedTarget} selectDate={selectedDate} />
+				<FullCalendarBox
+					size="small"
+					selectedTarget={selectedTarget}
+					selectDate={selectedDate}
+					handleChangeDate={handleChangeDate}
+				/>
 			</CalendarWrapper>
 		</TodayLayout>
 	);

--- a/src/stories/Common/Button/Todo.stories.tsx
+++ b/src/stories/Common/Button/Todo.stories.tsx
@@ -31,5 +31,6 @@ export const Default: Story = {
 		deadlineDate: '2024년 12월 31일',
 		deadlineTime: '오후 6시 40분 까지',
 		status: '미완료',
+		onClick: () => {},
 	},
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 캘린더에 연결할 모달(미니캘린더, 조회필터링) 뷰 연결해두었습니다. (기능 추가는 api 나오면 진행 예정입니다!)
- src/apis/timeBlocks/getTimeBlock/ 파일들 수정
빠진 내용(: google calendar 연결) 코드 상에서 제외하였습니다. -> 이거때문에 캘린더 오류났던거!
- timeblock 스타일 수정하였습니다. ~~(월간 캘린더 스타일 수정은 올려두고 진행할게요) -> 수정 완료~~
- 캘린더 헤더 날짜와 실제 ref 값 안맞는 부분 수정하였습니다. 
- FullCalendar의 Draggable 기능 이용하여 todo박스 드래그앤드롭 통해 timeblock 생성 가능하도록 변경
-> 이제 dumping area / todo list 제한없이 timeblock 생성 가능!

- 드래그 시 todo박스가 다시 제자리로 돌아가는 현상, 드래그 스무스하지 못한 점 등은 해당 이슈에서 브랜치 새로 파서 반영할게요 🥺 
#350 


## 알게된 점 :rocket:

> 기록하며 개발하기!

- FullCalendar 드래그랑 react-beautiful-dnd 드래그랑 겹쳐서 사용 가능하다는 것 알게되었습니당

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 생성 시간대 등 오류 없는 지 확인 부탁드립니다! 
- 드래그 어색한 건 주말에 개선하겠습니다

## 관련 이슈

close #336 

## 스크린샷 (선택)
<img width="757" alt="스크린샷 2025-01-18 03 44 37" src="https://github.com/user-attachments/assets/5ef8e0e4-7f53-4ed4-b25b-b18cf8331833" />
