### PR TITLE
[FEAT] 조회 필터링 기능 추가

### DIFF
--- a/src/apis/timeBlocks/getTimeBlock/GetTimeBlock.ts
+++ b/src/apis/timeBlocks/getTimeBlock/GetTimeBlock.ts
@@ -1,3 +1,5 @@
+import { STATUSES } from '@/constants/statuses';
+
 interface TimeBlock {
 	id: number;
 	startTime: string;
@@ -14,6 +16,7 @@ interface Schedule {
 interface Task {
 	id: number;
 	name: string;
+	status: (typeof STATUSES)[keyof typeof STATUSES];
 	timeBlocks: TimeBlock[];
 }
 

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -10,9 +10,17 @@ type CalendarHeaderProps = {
 	isActive: boolean;
 	handleCalendarPopup: () => void;
 	handleFilterPopup: () => void;
+	isFilterPopupDot: boolean;
 };
 
-function CalendarHeader({ size, date, isActive, handleCalendarPopup, handleFilterPopup }: CalendarHeaderProps) {
+function CalendarHeader({
+	size,
+	date,
+	isActive,
+	handleCalendarPopup,
+	handleFilterPopup,
+	isFilterPopupDot,
+}: CalendarHeaderProps) {
 	const { color } = useTheme();
 
 	const activeButtonStyle = css`
@@ -47,6 +55,7 @@ function CalendarHeader({ size, date, isActive, handleCalendarPopup, handleFilte
 					iconName="IcnFilter"
 					onClick={handleFilterPopup}
 					additionalCss={isActive ? activeButtonStyle : undefined}
+					dot={isFilterPopupDot}
 				/>
 			</CalendarHeaderWrapper>
 		</CalendarHeaderContainer>

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -7,7 +7,8 @@ import MainDate from '../v2/TextBox/MainDate';
 type CalendarHeaderProps = {
 	size: 'small' | 'big';
 	date: { year: number; month: number };
-	isActive: boolean;
+	isCalendarPopupActive: boolean;
+	isFilterPopupActive: boolean;
 	handleCalendarPopup: () => void;
 	handleFilterPopup: () => void;
 	isFilterPopupDot: boolean;
@@ -16,7 +17,8 @@ type CalendarHeaderProps = {
 function CalendarHeader({
 	size,
 	date,
-	isActive,
+	isCalendarPopupActive,
+	isFilterPopupActive,
 	handleCalendarPopup,
 	handleFilterPopup,
 	isFilterPopupDot,
@@ -28,7 +30,7 @@ function CalendarHeader({
 
 		background-color: ${color.Grey.Grey3};
 
-		${isActive &&
+		${(isCalendarPopupActive || isFilterPopupActive) &&
 		css`
 			:hover {
 				color: ${color.Grey.Grey5};
@@ -47,14 +49,14 @@ function CalendarHeader({
 					size="small"
 					iconName="IcnCalendar"
 					onClick={handleCalendarPopup}
-					additionalCss={isActive ? activeButtonStyle : undefined}
+					additionalCss={isCalendarPopupActive ? activeButtonStyle : undefined}
 				/>
 				<IconButton
 					type="normal"
 					size="small"
 					iconName="IcnFilter"
 					onClick={handleFilterPopup}
-					additionalCss={isActive ? activeButtonStyle : undefined}
+					additionalCss={isFilterPopupActive ? activeButtonStyle : undefined}
 					dot={isFilterPopupDot}
 				/>
 			</CalendarHeaderWrapper>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -46,8 +46,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
 	const [isFilterPopupOpen, setFilterPopupOpen] = useState(false);
-	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>(
-		Object.keys(STATUSES) as (keyof typeof STATUSES)[]
+	const [selectedStatuses, setSelectedStatuses] = useState<(typeof STATUSES)[keyof typeof STATUSES][]>(
+		Object.values(STATUSES)
 	);
 	const [isFilterPopupDot, setIsFilterPopupDot] = useState(false);
 
@@ -244,25 +244,14 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	};
 
 	// CalendarSettingDropdown handler
-	const handleStatusChange = (status: keyof typeof STATUSES) => {
+	const handleStatusChange = (status: (typeof STATUSES)[keyof typeof STATUSES]) => {
 		setSelectedStatuses((prev) => {
 			const updatedStatuses = prev.includes(status) ? prev.filter((s) => s !== status) : [...prev, status];
-			setIsFilterPopupDot(updatedStatuses.length !== Object.keys(STATUSES).length);
+			setIsFilterPopupDot(updatedStatuses.length !== Object.values(STATUSES).length);
 
 			return updatedStatuses;
 		});
 	};
-
-	/** TODO: get api 연결하면 됨. */
-	// const { mutate: getMutate } = useGetTimeBlock();
-	//
-	// useEffect(() => {
-	// 	** get api 요청 **
-	// 	useGetTimeBlock()
-	// 	if (selectedStatuses.length > 0) {
-	// 		fetchData();
-	// 	}
-	// }, [selectedStatuses]);
 
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -22,6 +22,7 @@ import DayHeaderContent from '@/components/common/fullCalendar/DayHeaderContent'
 import FullCalendarLayout from '@/components/common/fullCalendar/FullCalendarStyle';
 import customSlotLabelContent from '@/components/common/fullCalendar/fullCalendarUtils';
 import MODAL from '@/constants/modalLocation';
+import { STATUSES } from '@/constants/statuses';
 import { TaskType } from '@/types/tasks/taskType';
 
 interface FullCalendarBoxProps {
@@ -45,6 +46,9 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
 	const [isFilterPopupOpen, setFilterPopupOpen] = useState(false);
+	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>(
+		Object.keys(STATUSES) as (keyof typeof STATUSES)[]
+	);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -238,6 +242,25 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		createMutate({ taskId: Number(info.event.id), startTime: start, endTime: end });
 	};
 
+	// CalendarSettingDropdown handler
+	const handleStatusChange = (status: keyof typeof STATUSES) => {
+		setSelectedStatuses((prev) => {
+			const updatedStatuses = prev.includes(status) ? prev.filter((s) => s !== status) : [...prev, status];
+			return updatedStatuses;
+		});
+	};
+
+	/** TODO: get api 연결하면 됨. */
+	// const { mutate: getMutate } = useGetTimeBlock();
+	//
+	// useEffect(() => {
+	// 	** get api 요청 **
+	// 	useGetTimeBlock()
+	// 	if (selectedStatuses.length > 0) {
+	// 		fetchData();
+	// 	}
+	// }, [selectedStatuses]);
+
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>
 			<CalendarHeader
@@ -317,7 +340,14 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				// Todo: date props 실제값으로 변경 필요
 				<DateCorrectionModal date={new Date().toISOString()} onClick={handleCalendarPopup} top={9.8} right={0.8} />
 			)}
-			{isFilterPopupOpen && <CalendarSettingDropdown top={9.8} right={0.8} />}
+			{isFilterPopupOpen && (
+				<CalendarSettingDropdown
+					top={9.8}
+					right={0.8}
+					selectedStatuses={selectedStatuses}
+					handleStatusChange={handleStatusChange}
+				/>
+			)}
 			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
 				<ModalDeleteDetail top={top} left={left} onClose={closeModal} onDelete={handleDelete} />
 			)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -58,7 +58,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const { mutate: updateMutate } = useUpdateTimeBlock();
 	const { mutate: deleteMutate } = useDeleteTimeBlock();
 
-	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data) : [];
+	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data, selectedStatuses) : [];
 
 	useEffect(() => {
 		if (selectDate && calendarRef.current) {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -269,7 +269,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			<CalendarHeader
 				size={size}
 				date={date}
-				isActive={isCalendarPopupOpen}
+				isCalendarPopupActive={isCalendarPopupOpen}
+				isFilterPopupActive={isFilterPopupOpen}
 				handleCalendarPopup={handleCalendarPopup}
 				handleFilterPopup={handleFilterPopup}
 				isFilterPopupDot={isFilterPopupDot}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -1,4 +1,4 @@
-import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg } from '@fullcalendar/core';
+import { ViewMountArg, DatesSetArg, EventClickArg, EventDropArg, EventMountArg } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { EventReceiveArg } from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
@@ -253,6 +253,14 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		});
 	};
 
+	// 완료 task 스타일링 위한 클래스명 추가 (주간)
+	const handleCompletedTask = (arg: EventMountArg) => {
+		const weekElement = arg.el.querySelector('.fc-event-main');
+		if (weekElement && arg.event.extendedProps.isCompleted) {
+			weekElement.classList.add('completed');
+		}
+	};
+
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>
 			<CalendarHeader
@@ -285,6 +293,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				nowIndicator
 				dayMaxEvents
 				events={calendarEvents}
+				eventDidMount={(arg) => handleCompletedTask(arg)}
 				buttonText={{
 					month: '월',
 					timeGridWeekCustom: '주',

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -49,6 +49,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>(
 		Object.keys(STATUSES) as (keyof typeof STATUSES)[]
 	);
+	const [isFilterPopupDot, setIsFilterPopupDot] = useState(false);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -246,6 +247,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const handleStatusChange = (status: keyof typeof STATUSES) => {
 		setSelectedStatuses((prev) => {
 			const updatedStatuses = prev.includes(status) ? prev.filter((s) => s !== status) : [...prev, status];
+			setIsFilterPopupDot(updatedStatuses.length !== Object.keys(STATUSES).length);
+
 			return updatedStatuses;
 		});
 	};
@@ -269,6 +272,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				isActive={isCalendarPopupOpen}
 				handleCalendarPopup={handleCalendarPopup}
 				handleFilterPopup={handleFilterPopup}
+				isFilterPopupDot={isFilterPopupDot}
 			/>
 			<FullCalendar
 				height="100%"

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -259,6 +259,13 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		border-radius: 4px;
 	}
 
+	.fc-event-main.completed {
+		color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
+		text-decoration: line-through;
+
+		background-color: ${({ theme }) => theme.colorToken.Component.assistive};
+	}
+
 	/* fc-event-title이 더 위로 오도록  */
 	.fc-event-main-frame {
 		flex-direction: column-reverse;
@@ -273,12 +280,36 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		color: ${({ theme }) => theme.colorToken.Text.neutralLight};
 		white-space: nowrap;
 		text-overflow: ellipsis;
+
 		${({ theme }) => theme.font.body05};
 	}
 
 	.fc-event-time {
 		color: ${({ theme }) => theme.colorToken.Text.assistive};
 		${({ theme }) => theme.font.caption02};
+	}
+
+	.fc-daygrid-event .fc-event-time {
+		display: none;
+	}
+
+	.fc-event-main.completed .fc-event-title,
+	.fc-event-main.completed .fc-event-time {
+		color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
+	}
+
+	.fc-daygrid-dot-event.completed .fc-event-title,
+	.fc-daygrid-dot-event.completed .fc-event-time {
+		color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
+	}
+
+	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
+	.fc-daygrid-event-dot {
+		border-color: ${({ theme }) => theme.colorToken.Text.assistive};
+	}
+
+	.fc-daygrid-dot-event.completed .fc-daygrid-event-dot {
+		border-color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
 	}
 
 	.fc-event-main .tasks {
@@ -505,10 +536,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		border-radius: 4px;
 	}
 
-	.fc-daygrid-event .fc-event-time {
-		display: none;
-	}
-
 	.fc .fc-daygrid-dot-event {
 		padding: 0.4rem 0.6rem;
 
@@ -533,6 +560,14 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		border-radius: 4px;
 	}
 
+	.fc .fc-daygrid-dot-event.tasks.completed {
+		color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
+		text-decoration: line-through;
+
+		background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
+		border-radius: 4px;
+	}
+
 	/* 월간 이벤트 호버 효과 */
 	.fc .fc-daygrid-dot-event.schedule:hover {
 		background-color: ${({ theme }) => theme.palette.Grey.Grey3};
@@ -548,11 +583,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc .fc-h-event {
 		border: none;
-	}
-
-	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
-	.fc-daygrid-event-dot {
-		border-color: ${({ theme }) => theme.colorToken.Text.assistive};
 	}
 
 	/* Month view 중 이벤트 초과 안내 */

--- a/src/components/common/fullCalendar/processEvents.tsx
+++ b/src/components/common/fullCalendar/processEvents.tsx
@@ -12,24 +12,26 @@ interface EventData {
 	};
 }
 
-const processEvents = (timeBlockData: TimeBlockData): EventData[] => {
+const processEvents = (timeBlockData: TimeBlockData, selectedStatuses: string[]): EventData[] => {
 	const events: EventData[] = [];
 
-	// tasks 데이터 처리
-	timeBlockData.tasks.forEach((task) => {
-		task.timeBlocks.forEach((timeBlock) => {
-			events.push({
-				title: task.name,
-				start: timeBlock.startTime,
-				end: timeBlock.endTime,
-				classNames: 'tasks',
-				extendedProps: {
-					taskId: task.id,
-					timeBlockId: timeBlock.id,
-				},
+	// tasks 데이터 처리 + 상태 필터링
+	timeBlockData.tasks
+		.filter((task) => selectedStatuses.includes(task.status))
+		.forEach((task) => {
+			task.timeBlocks.forEach((timeBlock) => {
+				events.push({
+					title: task.name,
+					start: timeBlock.startTime,
+					end: timeBlock.endTime,
+					classNames: 'tasks',
+					extendedProps: {
+						taskId: task.id,
+						timeBlockId: timeBlock.id,
+					},
+				});
 			});
 		});
-	});
 
 	/**
 	 * TODO: 구글 캘린더 추후 다시 추가 예정

--- a/src/components/common/fullCalendar/processEvents.tsx
+++ b/src/components/common/fullCalendar/processEvents.tsx
@@ -1,4 +1,5 @@
 import { TimeBlockData } from '@/apis/timeBlocks/getTimeBlock/GetTimeBlock';
+import { STATUSES } from '@/constants/statuses';
 
 interface EventData {
 	title: string;
@@ -9,6 +10,7 @@ interface EventData {
 	extendedProps: {
 		taskId: number;
 		timeBlockId: number | null;
+		isCompleted: boolean;
 	};
 }
 
@@ -24,10 +26,11 @@ const processEvents = (timeBlockData: TimeBlockData, selectedStatuses: string[])
 					title: task.name,
 					start: timeBlock.startTime,
 					end: timeBlock.endTime,
-					classNames: 'tasks',
+					classNames: task.status === STATUSES.COMPLETED ? 'tasks completed' : 'tasks',
 					extendedProps: {
 						taskId: task.id,
 						timeBlockId: timeBlock.id,
+						isCompleted: task.status === STATUSES.COMPLETED,
 					},
 				});
 			});

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -12,6 +12,17 @@ type CalendarSettingDropdownProps = {
 function CalendarSettingDropdown({ top = 0, right = 0 }: CalendarSettingDropdownProps) {
 	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>([]);
 
+	/** TODO: get api 연결하면 됨. */
+	// const { mutate: getMutate } = useGetTimeBlock();
+	//
+	// useEffect(() => {
+	// 	** get api 요청 **
+	// 	useGetTimeBlock()
+	// 	if (selectedStatuses.length > 0) {
+	// 		fetchData();
+	// 	}
+	// }, [selectedStatuses]);
+
 	const handleStatusChange = (status: keyof typeof STATUSES) => {
 		setSelectedStatuses((prevStatuses) =>
 			prevStatuses.includes(status) ? prevStatuses.filter((s) => s !== status) : [...prevStatuses, status]

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 
 import CheckButton from '@/components/common/v2/control/CheckButton';
-import { STATUS_OPTIONS } from '@/constants/statuses';
+import { STATUS_OPTIONS, STATUSES } from '@/constants/statuses';
 
 type CalendarSettingDropdownProps = {
 	top?: number;
@@ -10,10 +10,12 @@ type CalendarSettingDropdownProps = {
 };
 
 function CalendarSettingDropdown({ top = 0, right = 0 }: CalendarSettingDropdownProps) {
-	const [selectedStatus, setSelectedStatus] = useState<string | null>(null);
+	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>([]);
 
-	const handleStatusChange = (status: string) => {
-		setSelectedStatus(status === selectedStatus ? null : status);
+	const handleStatusChange = (status: keyof typeof STATUSES) => {
+		setSelectedStatuses((prevStatuses) =>
+			prevStatuses.includes(status) ? prevStatuses.filter((s) => s !== status) : [...prevStatuses, status]
+		);
 	};
 
 	return (
@@ -22,9 +24,9 @@ function CalendarSettingDropdown({ top = 0, right = 0 }: CalendarSettingDropdown
 				<CheckButton
 					key={option.value}
 					label={option.label}
-					onClick={() => handleStatusChange(option.value)}
+					onClick={() => handleStatusChange(option.value as keyof typeof STATUSES)}
 					size="large"
-					checked={selectedStatus === option.value}
+					checked={selectedStatuses.includes(option.value as keyof typeof STATUSES)}
 				/>
 			))}
 		</CalendarSettingDropdownContainer>
@@ -42,7 +44,7 @@ const CalendarSettingDropdownContainer = styled.div<{ top: number; right: number
 	gap: 0.4rem;
 	box-sizing: border-box;
 	width: 16.8rem;
-	height: 16rem;
+	height: auto;
 	padding: 1.6rem 0.8rem;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 
 import CheckButton from '@/components/common/v2/control/CheckButton';
 import { STATUS_OPTIONS, STATUSES } from '@/constants/statuses';
@@ -7,28 +6,16 @@ import { STATUS_OPTIONS, STATUSES } from '@/constants/statuses';
 type CalendarSettingDropdownProps = {
 	top?: number;
 	right?: number;
+	selectedStatuses: (keyof typeof STATUSES)[];
+	handleStatusChange: (status: keyof typeof STATUSES) => void;
 };
 
-function CalendarSettingDropdown({ top = 0, right = 0 }: CalendarSettingDropdownProps) {
-	const [selectedStatuses, setSelectedStatuses] = useState<(keyof typeof STATUSES)[]>([]);
-
-	/** TODO: get api 연결하면 됨. */
-	// const { mutate: getMutate } = useGetTimeBlock();
-	//
-	// useEffect(() => {
-	// 	** get api 요청 **
-	// 	useGetTimeBlock()
-	// 	if (selectedStatuses.length > 0) {
-	// 		fetchData();
-	// 	}
-	// }, [selectedStatuses]);
-
-	const handleStatusChange = (status: keyof typeof STATUSES) => {
-		setSelectedStatuses((prevStatuses) =>
-			prevStatuses.includes(status) ? prevStatuses.filter((s) => s !== status) : [...prevStatuses, status]
-		);
-	};
-
+function CalendarSettingDropdown({
+	top = 0,
+	right = 0,
+	selectedStatuses,
+	handleStatusChange,
+}: CalendarSettingDropdownProps) {
 	return (
 		<CalendarSettingDropdownContainer top={top} right={right}>
 			{STATUS_OPTIONS.map((option) => (

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -6,8 +6,8 @@ import { STATUS_OPTIONS, STATUSES } from '@/constants/statuses';
 type CalendarSettingDropdownProps = {
 	top?: number;
 	right?: number;
-	selectedStatuses: (keyof typeof STATUSES)[];
-	handleStatusChange: (status: keyof typeof STATUSES) => void;
+	selectedStatuses: (typeof STATUSES)[keyof typeof STATUSES][];
+	handleStatusChange: (status: (typeof STATUSES)[keyof typeof STATUSES]) => void;
 };
 
 function CalendarSettingDropdown({
@@ -22,9 +22,9 @@ function CalendarSettingDropdown({
 				<CheckButton
 					key={option.value}
 					label={option.label}
-					onClick={() => handleStatusChange(option.value as keyof typeof STATUSES)}
+					onClick={() => handleStatusChange(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
 					size="large"
-					checked={selectedStatuses.includes(option.value as keyof typeof STATUSES)}
+					checked={selectedStatuses.includes(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
 				/>
 			))}
 		</CalendarSettingDropdownContainer>

--- a/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
+++ b/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
@@ -15,4 +15,11 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+	args: {
+		top: 0,
+		right: 0,
+		selectedStatuses: ['미완료', '진행중'],
+		handleStatusChange: () => {},
+	},
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 상태(완료, 미완료, 진행중)에 따른 조회 필터링 기능을 추가했습니다
- 상태가 완료인 task의 timeblock은 스타일링이 달라서, 해당 부분도 추가하였습니다!

## 알게된 점 :rocket:

> 기록하며 개발하기!

- FullCalendar 클래스명 커스텀 방법

```ts
eventDidMount={(arg) => handleCompletedTask(arg)}
// 완료 task 스타일링 위한 클래스명 추가 (주간)
const handleCompletedTask = (arg: EventMountArg) => {
	const weekElement = arg.el.querySelector('.fc-event-main');
	if (weekElement && arg.event.extendedProps.isCompleted) {
		weekElement.classList.add('completed');
	}
};
```

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 서버측에 상태값 중 '진행 중' -> '진행중'으로 변경 요청해두었습니다! 

## 관련 이슈

close #352 

## 스크린샷 (선택)
<img width="206" alt="스크린샷 2025-01-20 02 24 55" src="https://github.com/user-attachments/assets/81bd07a9-b649-4baa-9f55-9c3d2f88b3a8" />

<img width="241" alt="스크린샷 2025-01-20 02 24 42" src="https://github.com/user-attachments/assets/10f3165e-bd85-4a9f-be29-893a4907492f" />
