### PR TITLE
[FEAT] 캘린더 내부 미니캘린더 기능 연결

### DIFF
--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -9,6 +9,7 @@ import Button from '../v2/button/Button';
 import CorrectionCustomHeader from './CorrectionCustomHeader';
 import CalendarStyle from './DatePickerStyle';
 
+import useOutsideClick from '@/hooks/useOutsideClick';
 import formatDatetoString from '@/utils/formatDatetoString';
 import { blurRef } from '@/utils/refStatus';
 
@@ -43,8 +44,11 @@ function DateCorrectionModal({ top = 0, left, right, date, onClick, handleCurren
 	const onClose = () => {
 		onClick();
 	};
+
+	const modalRef = useOutsideClick<HTMLDivElement>({ onClose });
+
 	return (
-		<DateCorrectionModalLayout top={top} left={left} right={right} onClick={(e) => e.stopPropagation()}>
+		<DateCorrectionModalLayout ref={modalRef} top={top} left={left} right={right} onClick={(e) => e.stopPropagation()}>
 			<DatePicker
 				locale={ko}
 				selected={currentDate}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -67,18 +67,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		// updateRange(view.view.type);
 	};
 
-	// 오늘 날짜를 기준으로 가운데 조정
-	useEffect(() => {
-		if (calendarRef.current) {
-			const calendarApi = calendarRef.current.getApi();
-			const adjustedDate = new Date(today);
-
-			adjustedDate.setDate(adjustedDate.getDate() - (size === 'big' ? 3 : 2));
-
-			calendarApi.gotoDate(adjustedDate);
-		}
-	}, [today, size]);
-
 	const handleDatesSet = (dateInfo: DatesSetArg) => {
 		const currentViewType = dateInfo.view.type;
 		const newStartDate = new Date(dateInfo.start);

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -314,8 +314,13 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				eventReceive={(info) => handleEventReceive(info)}
 			/>
 			{isCalendarPopupOpen && (
-				// Todo: date props 실제값으로 변경 필요
-				<DateCorrectionModal date={new Date().toISOString()} onClick={handleCalendarPopup} top={9.8} right={0.8} />
+				<DateCorrectionModal
+					date={new Date().toISOString()}
+					onClick={handleCalendarPopup}
+					top={9.8}
+					right={0.8}
+					handleCurrentDate={handleChangeDate}
+				/>
 			)}
 			{isFilterPopupOpen && <CalendarSettingDropdown top={9.8} right={0.8} />}
 			{isModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -8,26 +8,14 @@ const useOutsideClick = <T extends HTMLElement>({ onClose }: OutsideClickHandler
 	const ref = useRef<T>(null);
 
 	useEffect(() => {
-		const overlay = document.createElement('div');
-		overlay.style.position = 'fixed';
-		overlay.style.top = '0';
-		overlay.style.left = '0';
-		overlay.style.width = '100%';
-		overlay.style.height = '100%';
-		overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
-		overlay.style.zIndex = '3';
-		document.body.appendChild(overlay);
-
 		const handleClickOutside = (event: MouseEvent) => {
 			if (ref.current && !ref.current.contains(event.target as Node)) {
-				onClose(); // 외부 클릭 시 모달 닫기
-				document.body.removeChild(overlay); // 배경 제거
+				onClose();
 			}
 		};
 
 		document.addEventListener('mousedown', handleClickOutside);
 
-		// 컴포넌트 언마운트 시 배경 및 이벤트 제거
 		return () => {
 			document.removeEventListener('mousedown', handleClickOutside);
 		};

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+type OutsideClickHandler = {
+	onClose: () => void;
+};
+
+const useOutsideClick = <T extends HTMLElement>({ onClose }: OutsideClickHandler) => {
+	const ref = useRef<T>(null);
+
+	useEffect(() => {
+		const overlay = document.createElement('div');
+		overlay.style.position = 'fixed';
+		overlay.style.top = '0';
+		overlay.style.left = '0';
+		overlay.style.width = '100%';
+		overlay.style.height = '100%';
+		overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
+		overlay.style.zIndex = '3';
+		document.body.appendChild(overlay);
+
+		const handleClickOutside = (event: MouseEvent) => {
+			if (ref.current && !ref.current.contains(event.target as Node)) {
+				onClose(); // 외부 클릭 시 모달 닫기
+				document.body.removeChild(overlay); // 배경 제거
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+
+		// 컴포넌트 언마운트 시 배경 및 이벤트 제거
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [onClose]);
+
+	return ref;
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 캘린더 헤더의 아이콘 클릭 시 띄워지는 미니캘린더 연결
- 기존엔 뷰만 연결해둬서 값 연결 및 외부영역 클릭 시 닫히도록 구현하였습니다.
- 외부영역 클릭 시 닫히도록 돕는 useOutSideClick 훅 생성 

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 모달 외부영역을 굳이 컨테이너로 만들어주는 게 아니라(이걸 fixed로 만들며 따라오는 위치조절 불편함땜에..) 그냥 **모달 ref의 외부 영역 클릭 이벤트 발생 시 닫히도록** 하는 방법으로 있더라고요..! 훨씬 간단하네요
- https://jamong.tistory.com/7 블로그 참고

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 정상동작하는 지 확인해주세요!

## 관련 이슈

close #359 

## 스크린샷 (선택)
![Jan-21-2025 00-28-10](https://github.com/user-attachments/assets/903684d1-e22a-4399-84be-f2a6a18200d5)

