### PR TITLE
[FEAT] Task 상세 조회, 수정 기능 연결

### DIFF
--- a/src/apis/tasks/editTask/query.ts
+++ b/src/apis/tasks/editTask/query.ts
@@ -9,7 +9,10 @@ const usePatchTaskDescription = () => {
 	const mutation = useMutation({
 		mutationFn: ({ taskId, name, description, deadLine: { date, time } }: EditTaskDescriptionType) =>
 			editTaskDescription({ taskId, name, description, deadLine: { date, time } }),
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['today'] }),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({ queryKey: ['today'] });
+			queryClient.invalidateQueries({ queryKey: ['taskDesc', variables.taskId] });
+		},
 	});
 	return { mutate: mutation.mutate };
 };

--- a/src/apis/tasks/taskDescription/axios.ts
+++ b/src/apis/tasks/taskDescription/axios.ts
@@ -1,14 +1,15 @@
 import { TaskDescriptionType } from './TaskDescriptionType';
 
 import { privateInstance } from '@/apis/instance';
+import { DetailedTaskType } from '@/types/tasks/taskType';
 
-const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType) => {
+const taskDescription = async ({ taskId, targetDate }: TaskDescriptionType): Promise<DetailedTaskType> => {
 	const { data } = await privateInstance.get(`/api/tasks/${taskId}`, {
 		params: {
 			targetDate,
 		},
 	});
-	return data;
+	return data.data;
 };
 
 export default taskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -4,10 +4,11 @@ import taskDescription from './axios';
 import { TaskDescriptionType } from './TaskDescriptionType';
 
 // Task 상세 설명 조회
-const useTaskDescription = ({ taskId, targetDate }: TaskDescriptionType) => {
+const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType) => {
 	const data = useQuery({
-		queryKey: ['today', 'taskDesc', taskId, targetDate],
+		queryKey: ['taskDesc', taskId, targetDate],
 		queryFn: () => taskDescription({ taskId, targetDate }),
+		enabled: isOpen,
 	});
 
 	return data;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -4,11 +4,10 @@ import taskDescription from './axios';
 import { TaskDescriptionType } from './TaskDescriptionType';
 
 // Task 상세 설명 조회
-const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType) => {
+const useTaskDescription = ({ taskId, targetDate }: TaskDescriptionType) => {
 	const data = useQuery({
 		queryKey: ['today', 'taskDesc', taskId, targetDate],
 		queryFn: () => taskDescription({ taskId, targetDate }),
-		enabled: isOpen,
 	});
 
 	return data;

--- a/src/apis/tasks/updateTaskStatus/query.ts
+++ b/src/apis/tasks/updateTaskStatus/query.ts
@@ -11,9 +11,8 @@ const useUpdateTaskStatus = (handleIconMouseLeave: (() => void) | null) => {
 
 	const mutation = useMutation({
 		mutationFn: (updateData: UpdateTaskStatusType) => updateTaskStatus(updateData),
-		onSuccess: (data, updateData) => {
+		onSuccess: (_, updateData) => {
 			addToast('변경사항이 적용되었어요', 'success');
-			console.log(data);
 			queryClient.invalidateQueries({ queryKey: ['today'] }).then(() => {
 				if (handleIconMouseLeave) {
 					handleIconMouseLeave();

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -77,8 +77,8 @@ function StagingAreaTaskContainer({
 													deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
 													deadlineTime={task.deadLine?.time || undefined}
 													isStatusVisible={false}
-                          taskId={task.id}
-                          targetDate={targetDate}
+													taskId={task.id}
+													targetDate={targetDate}
 													onClick={() => handleSelectedTarget(task)}
 												/>
 											</div>

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -40,10 +40,10 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, locat
 
 	useEffect(() => {
 		if (isFetched && data) {
-			setTaskName(data.data.name);
-			setDesc(data.data.description);
-			setDeadLineDate(data.data.deadLine.date);
-			setDeadLineTime(data.data.deadLine.time);
+			setTaskName(data.name);
+			setDesc(data.description);
+			setDeadLineDate(data.deadLine.date || '');
+			setDeadLineTime(data.deadLine.time || '');
 
 			setStartTime('');
 			setEndTime('');

--- a/src/components/common/v2/TextBox/PopUp.tsx
+++ b/src/components/common/v2/TextBox/PopUp.tsx
@@ -13,12 +13,17 @@ const TYPE = {
 type PopUpProps = {
 	type: (typeof TYPE)[keyof typeof TYPE];
 	defaultValue?: string;
+	onChange?: (e: React.FocusEvent<HTMLInputElement>) => void;
 };
 
-function PopUp({ type, defaultValue }: PopUpProps) {
+function PopUp({ type, defaultValue, onChange = () => {} }: PopUpProps) {
 	const { state, handleFocus, handleBlur, handleChange } = useInputHandler();
 	const placeholder = type === TYPE.TITLE ? '제목을 입력하세요' : '설명을 추가하세요';
 
+	const handlePopUpChange = (e: React.FocusEvent<HTMLInputElement>) => {
+		onChange(e);
+		handleChange(e);
+	};
 	return (
 		<PopUpContainer>
 			{type === TYPE.DESC && state === INPUT_STATE.DEFAULT && <Icon name="IcnDescription" size="tiny" />}
@@ -28,7 +33,7 @@ function PopUp({ type, defaultValue }: PopUpProps) {
 				placeholder={placeholder}
 				onFocus={handleFocus}
 				onBlur={handleBlur}
-				onChange={handleChange}
+				onChange={handlePopUpChange}
 				defaultValue={defaultValue}
 			/>
 		</PopUpContainer>

--- a/src/components/common/v2/TextBox/PopUp.tsx
+++ b/src/components/common/v2/TextBox/PopUp.tsx
@@ -12,9 +12,10 @@ const TYPE = {
 
 type PopUpProps = {
 	type: (typeof TYPE)[keyof typeof TYPE];
+	defaultValue?: string;
 };
 
-function PopUp({ type }: PopUpProps) {
+function PopUp({ type, defaultValue }: PopUpProps) {
 	const { state, handleFocus, handleBlur, handleChange } = useInputHandler();
 	const placeholder = type === TYPE.TITLE ? '제목을 입력하세요' : '설명을 추가하세요';
 
@@ -28,6 +29,7 @@ function PopUp({ type }: PopUpProps) {
 				onFocus={handleFocus}
 				onBlur={handleBlur}
 				onChange={handleChange}
+				defaultValue={defaultValue}
 			/>
 		</PopUpContainer>
 	);

--- a/src/components/common/v2/TextBox/PopUp.tsx
+++ b/src/components/common/v2/TextBox/PopUp.tsx
@@ -13,14 +13,14 @@ const TYPE = {
 type PopUpProps = {
 	type: (typeof TYPE)[keyof typeof TYPE];
 	defaultValue?: string;
-	onChange?: (e: React.FocusEvent<HTMLInputElement>) => void;
+	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 function PopUp({ type, defaultValue, onChange = () => {} }: PopUpProps) {
 	const { state, handleFocus, handleBlur, handleChange } = useInputHandler();
 	const placeholder = type === TYPE.TITLE ? '제목을 입력하세요' : '설명을 추가하세요';
 
-	const handlePopUpChange = (e: React.FocusEvent<HTMLInputElement>) => {
+	const handlePopUpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		onChange(e);
 		handleChange(e);
 	};
@@ -33,7 +33,9 @@ function PopUp({ type, defaultValue, onChange = () => {} }: PopUpProps) {
 				placeholder={placeholder}
 				onFocus={handleFocus}
 				onBlur={handleBlur}
-				onChange={handlePopUpChange}
+				onChange={(e) => {
+					handlePopUpChange(e);
+				}}
 				defaultValue={defaultValue}
 			/>
 		</PopUpContainer>

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -23,7 +23,7 @@ function DropdownButton({ status, handleStatusChange, handleStatusEdit, isModalO
 	// 필요하면 위치 변경 등 추가 작업 자유롭게 하세요
 	const [isOpen, setOpen] = useState(false);
 
-	const handleMouseDown = (e: React.MouseEvent<HTMLButtonElement>) => {
+	const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
 		e.stopPropagation();
 	};
 	const handleOpen = (e: React.MouseEvent<HTMLElement>) => {
@@ -61,19 +61,21 @@ function DropdownButton({ status, handleStatusChange, handleStatusEdit, isModalO
 
 	const iconType = isOpen ? 'IcnUp' : 'IcnDown';
 	return (
-		<DropdownWrapper>
-			<button type="button" onMouseDown={handleMouseDown}>
-				<Button
-					type={getDropdownBtnType()}
-					label={status}
-					size="medium"
-					disabled={false}
-					rightIcon={iconType}
-					additionalCss={customStyle}
-					onClick={handleOpen}
-				/>
-				{isOpen && <StatusDropdown currentStatus={status} handleStatusChange={handleStatus} />}
-			</button>
+		<DropdownWrapper
+			onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => {
+				handleMouseDown(e);
+			}}
+		>
+			<Button
+				type={getDropdownBtnType()}
+				label={status}
+				size="medium"
+				disabled={false}
+				rightIcon={iconType}
+				additionalCss={customStyle}
+				onClick={handleOpen}
+			/>
+			{isOpen && <StatusDropdown currentStatus={status} handleStatusChange={handleStatus} />}
 		</DropdownWrapper>
 	);
 }

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -96,7 +96,7 @@ function MainSettingModal({
 
 	return (
 		<ModalBackdrop onClick={onClose}>
-			<MainSettingModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()} className="non-draggable">
+			<MainSettingModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
 				<MainSettingModalHeadLayout>
 					<ModalTopButtonBox>
 						<DropdownButton

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -45,11 +45,12 @@ function MainSettingModal({
 
 	// === useInput ===
 	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
-	const { content: descriptionContent, onChange: onDescriptionChange } = useInput('');
+	const { content: descriptionContent, onChange: onDescriptionChange, handleContent: handleDesc } = useInput('');
 
 	useEffect(() => {
 		if (isTaskDetailFetched) {
 			handleTitle(taskDetailData?.name || '');
+			handleDesc(taskDetailData?.description || '');
 		}
 	}, [isTaskDetailFetched]);
 

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -48,13 +48,13 @@ function MainSettingModal({
 	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
 	const { content: descriptionContent, onChange: onDescriptionChange, handleContent: handleDesc } = useInput('');
 	const { content: deadlineTime, handleContent: handleDeadlineTime } = useInput('');
-	const [deadlineDate, setDeadlineDate] = useState<Date>();
+	const [deadlineDate, setDeadlineDate] = useState<Date | null>(null);
 
 	useEffect(() => {
 		if (isTaskDetailFetched) {
 			handleTitle(taskDetailData?.name || '');
 			handleDesc(taskDetailData?.description || '');
-			handleDeadlineDate(taskDetailData?.deadLine.date ? new Date(taskDetailData?.deadLine.date) : new Date());
+			handleDeadlineDate(taskDetailData?.deadLine.date ? new Date(taskDetailData?.deadLine.date) : null);
 			handleDeadlineTime(taskDetailData?.deadLine.time || '');
 		}
 	}, [isTaskDetailFetched]);
@@ -63,7 +63,7 @@ function MainSettingModal({
 		setTaskStatus(status);
 	}, [status]);
 
-	const handleDeadlineDate = (date: Date) => {
+	const handleDeadlineDate = (date: Date | null) => {
 		setDeadlineDate(date);
 	};
 	const handleConfirm = () => {

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -12,6 +12,7 @@ import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
 import PopUp from '@/components/common/v2/TextBox/PopUp';
 import useInput from '@/hooks/useInput';
 import { StatusType } from '@/types/tasks/taskType';
+import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface MainSettingModalProps {
 	isOpen: boolean;
@@ -46,11 +47,15 @@ function MainSettingModal({
 	// === useInput ===
 	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
 	const { content: descriptionContent, onChange: onDescriptionChange, handleContent: handleDesc } = useInput('');
+	const { content: deadlineTime, handleContent: handleDeadlineTime } = useInput('');
+	const [deadlineDate, setDeadlineDate] = useState<Date>();
 
 	useEffect(() => {
 		if (isTaskDetailFetched) {
 			handleTitle(taskDetailData?.name || '');
 			handleDesc(taskDetailData?.description || '');
+			handleDeadlineDate(taskDetailData?.deadLine.date ? new Date(taskDetailData?.deadLine.date) : new Date());
+			handleDeadlineTime(taskDetailData?.deadLine.time || '');
 		}
 	}, [isTaskDetailFetched]);
 
@@ -58,6 +63,9 @@ function MainSettingModal({
 		setTaskStatus(status);
 	}, [status]);
 
+	const handleDeadlineDate = (date: Date) => {
+		setDeadlineDate(date);
+	};
 	const handleConfirm = () => {
 		handleStatusEdit(taskStatus);
 		handleEdit();
@@ -76,7 +84,7 @@ function MainSettingModal({
 			taskId,
 			name: titleContent,
 			description: descriptionContent,
-			deadLine: { date: '2025-01-21', time: '' },
+			deadLine: { date: deadlineDate ? formatDatetoLocalDate(deadlineDate) : null, time: deadlineTime },
 		});
 	};
 	const handleTaskStatusChange = (newStatus: StatusType) => {
@@ -106,14 +114,10 @@ function MainSettingModal({
 				</MainSettingModalHeadLayout>
 				<MainSettingModalBodyLayout>
 					<DeadlineBox
-						date={
-							taskDetailData?.deadLine && taskDetailData?.deadLine.date
-								? new Date(taskDetailData.deadLine.date)
-								: new Date()
-						}
-						endTime={
-							taskDetailData?.deadLine && taskDetailData?.deadLine.time ? taskDetailData.deadLine.time : '06:00pm'
-						}
+						date={deadlineDate ? new Date(deadlineDate) : new Date()}
+						endTime={deadlineTime || '06:00pm'}
+						handleDueDateModalDate={handleDeadlineDate}
+						handleDueDateModalTime={handleDeadlineTime}
 						label="마감 기간"
 					/>
 					<PopUpTitleBox>

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -37,9 +37,21 @@ function MainSettingModal({
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutate: editMutate } = usePatchTaskDescription();
 	const [taskStatus, setTaskStatus] = useState(status);
-	const { data: taskDetailData, isLoading: isTaskDetailLoading } = useTaskDescription({ taskId, targetDate, isOpen });
-	const { content: titleContent, onChange: onTitleChange } = useInput('');
+	const {
+		data: taskDetailData,
+		isLoading: isTaskDetailLoading,
+		isFetched: isTaskDetailFetched,
+	} = useTaskDescription({ taskId, targetDate, isOpen });
+
+	// === useInput ===
+	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
 	const { content: descriptionContent, onChange: onDescriptionChange } = useInput('');
+
+	useEffect(() => {
+		if (isTaskDetailFetched) {
+			handleTitle(taskDetailData?.name || '');
+		}
+	}, [isTaskDetailFetched]);
 
 	useEffect(() => {
 		setTaskStatus(status);
@@ -71,7 +83,8 @@ function MainSettingModal({
 	};
 
 	if (!isOpen) return null;
-	if (isTaskDetailLoading) return <>loading</>;
+	if (isTaskDetailLoading) return <div />;
+
 	return (
 		<ModalBackdrop onClick={onClose}>
 			<MainSettingModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()} className="non-draggable">
@@ -92,8 +105,14 @@ function MainSettingModal({
 				</MainSettingModalHeadLayout>
 				<MainSettingModalBodyLayout>
 					<DeadlineBox
-						date={taskDetailData.data.deadline ? new Date(taskDetailData.data.deadline.date) : new Date()}
-						endTime={taskDetailData.data.deadline ? taskDetailData.data.deadline.time : '06:00pm'}
+						date={
+							taskDetailData?.deadLine && taskDetailData?.deadLine.date
+								? new Date(taskDetailData.deadLine.date)
+								: new Date()
+						}
+						endTime={
+							taskDetailData?.deadLine && taskDetailData?.deadLine.time ? taskDetailData.deadLine.time : '06:00pm'
+						}
 						label="마감 기간"
 					/>
 					<PopUpTitleBox>

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
 import useDeleteTask from '@/apis/tasks/deleteTask/query';
+import useTaskDescription from '@/apis/tasks/taskDescription/query';
 import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
 import Button from '@/components/common/v2/button/Button';
 import DropdownButton from '@/components/common/v2/control/DropdownButton';
@@ -18,12 +19,22 @@ interface MainSettingModalProps {
 	onClose: () => void;
 	status: StatusType;
 	handleStatusEdit: (newStatus: StatusType) => void;
+	targetDate: string;
 }
 
-function MainSettingModal({ isOpen, top, left, taskId, onClose, status, handleStatusEdit }: MainSettingModalProps) {
+function MainSettingModal({
+	isOpen,
+	top,
+	left,
+	taskId,
+	onClose,
+	status,
+	handleStatusEdit,
+	targetDate,
+}: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
 	const [taskStatus, setTaskStatus] = useState(status);
-
+	const { data: taskDetailData } = useTaskDescription({ taskId, targetDate });
 	useEffect(() => {
 		setTaskStatus(status);
 	}, [status]);
@@ -62,12 +73,16 @@ function MainSettingModal({ isOpen, top, left, taskId, onClose, status, handleSt
 							<IconButton iconName="IcnX" type="normal" size="small" onClick={onClose} />
 						</ButtonBox>
 					</ModalTopButtonBox>
-					<PopUp type="title" />
+					<PopUp type="title" defaultValue={taskDetailData.data.name} />
 				</MainSettingModalHeadLayout>
 				<MainSettingModalBodyLayout>
-					<DeadlineBox date={new Date()} endTime="06:00pm" label="마감 기간" />
+					<DeadlineBox
+						date={taskDetailData.data.deadline ? new Date(taskDetailData.data.deadline.date) : new Date()}
+						endTime={taskDetailData.data.deadline ? taskDetailData.data.deadline.time : '06:00pm'}
+						label="마감 기간"
+					/>
 					<PopUpTitleBox>
-						<PopUp type="description" />
+						<PopUp type="description" defaultValue={taskDetailData.data.description} />
 					</PopUpTitleBox>
 					<DeadlineBox date={new Date()} startTime="11:00am" endTime="06:00pm" label="진행 기간" />
 				</MainSettingModalBodyLayout>

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -88,38 +88,40 @@ function Todo({
 
 	return (
 		<>
-			<TodoContainer
-				isCompleted={isCompleted}
-				state={state}
-				onDoubleClick={handleDoubleClick}
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
-				onMouseDown={handleMouseDown}
-				onMouseUp={handleMouseUp}
-				onDragStart={handleDragStart}
-				onDragEnd={handleDragEnd}
-				draggable
-				onClick={onClick}
-			>
-				<TodoWrapper>
-					<span className="todo-title">{title}</span>
-					{deadlineDate && (
-						<span className="todo-deadline">
-							{deadlineDate} / {deadlineTime}
-						</span>
+			<div className="todo-item">
+				<TodoContainer
+					isCompleted={isCompleted}
+					state={state}
+					onDoubleClick={handleDoubleClick}
+					onMouseEnter={handleMouseEnter}
+					onMouseLeave={handleMouseLeave}
+					onMouseDown={handleMouseDown}
+					onMouseUp={handleMouseUp}
+					onDragStart={handleDragStart}
+					onDragEnd={handleDragEnd}
+					draggable
+					onClick={onClick}
+				>
+					<TodoWrapper>
+						<span className="todo-title">{title}</span>
+						{deadlineDate && (
+							<span className="todo-deadline">
+								{deadlineDate} / {deadlineTime}
+							</span>
+						)}
+					</TodoWrapper>
+					{isStatusVisible && (
+						<DropdownWrapper>
+							<DropdownButton
+								status={status}
+								handleStatusChange={handleStatusChange}
+								handleStatusEdit={handleStatusEdit}
+								isModalOpen
+							/>
+						</DropdownWrapper>
 					)}
-				</TodoWrapper>
-				{isStatusVisible && (
-					<DropdownWrapper>
-						<DropdownButton
-							status={status}
-							handleStatusChange={handleStatusChange}
-							handleStatusEdit={handleStatusEdit}
-							isModalOpen
-						/>
-					</DropdownWrapper>
-				)}
-			</TodoContainer>
+				</TodoContainer>
+			</div>
 			<MainSettingModal
 				isOpen={isModalOpen}
 				top={top}

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -128,6 +128,7 @@ function Todo({
 				taskId={taskId}
 				status={status}
 				handleStatusEdit={handleStatusEdit}
+				targetDate={targetDate}
 			/>
 		</>
 	);

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -22,7 +22,7 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 
 		if (container) {
 			const draggable = new FullCalendarDraggable(container, {
-				itemSelector: '.todo-item', // 드래그 가능한 요소
+				itemSelector: '.todo-item',
 				eventData: () => {
 					if (selectedTarget) {
 						return {
@@ -60,27 +60,23 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 									{...provided.dragHandleProps}
 									style={provided.draggableProps.style}
 								>
-									<div
-										className="todo-item" // FullCalendarDraggable 대상
-									>
-										<Todo
-											// location="target"
-											key={task.id}
-											title={task.name}
-											deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
-											deadlineTime={task.deadLine?.time || undefined}
-											taskId={task.id}
-											targetDate={targetDate}
-											onClick={() => handleSelectedTarget(task)}
-											status={task.status}
+									<Todo
+										// location="target"
+										key={task.id}
+										title={task.name}
+										deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
+										deadlineTime={task.deadLine?.time || undefined}
+										taskId={task.id}
+										targetDate={targetDate}
+										onClick={() => handleSelectedTarget(task)}
+										status={task.status}
 
-											// handleSelectedTarget={handleSelectedTarget}
-											// selectedTarget={selectedTarget}
-											// isDragging={snapshot.isDragging}
-											// targetDate={targetDate}
-											// dashBoardInprogress={false}
-										/>
-									</div>
+										// handleSelectedTarget={handleSelectedTarget}
+										// selectedTarget={selectedTarget}
+										// isDragging={snapshot.isDragging}
+										// targetDate={targetDate}
+										// dashBoardInprogress={false}
+									/>
 								</TodoSizedWrapper>
 							)}
 						</BeautifulDnDDraggable>

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -17,8 +17,6 @@ interface TargetTaskSectionProps {
 	targetDate: string;
 }
 function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, targetDate }: TargetTaskSectionProps) {
-	// TODO: 추후에 해당 로직을 연결해야 합니다.
-
 	useEffect(() => {
 		const container = document.getElementById('todolist-task-container');
 

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+const useInput = (defaultValue?: string) => {
+	const [content, setContent] = useState<string>(defaultValue || '');
+	const onChange = (e: React.FocusEvent<HTMLInputElement>) => {
+		if (!e.target.value) {
+			setContent(e.target.value);
+		}
+	};
+	return { content, onChange };
+};
+export default useInput;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -2,11 +2,14 @@ import { useState } from 'react';
 
 const useInput = (defaultValue?: string) => {
 	const [content, setContent] = useState<string>(defaultValue || '');
-	const onChange = (e: React.FocusEvent<HTMLInputElement>) => {
-		if (!e.target.value) {
+	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		if (e.target.value) {
 			setContent(e.target.value);
 		}
 	};
-	return { content, onChange };
+	const handleContent = (data: string) => {
+		setContent(data);
+	};
+	return { content, onChange, handleContent };
 };
 export default useInput;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -31,9 +31,6 @@ function Today() {
 		setDumpAreaOpen((prev) => !prev);
 	};
 
-	console.log('stagingData', stagingData);
-	console.log('targetData', targetData);
-
 	/** isTotal 핸들링 함수 */
 	const handleTextBtnClick = (button: '전체' | '지연') => {
 		setActiveButton(button);

--- a/src/stories/modal/MainSettingModal.stories.ts
+++ b/src/stories/modal/MainSettingModal.stories.ts
@@ -24,5 +24,6 @@ export const Default: Story = {
 		onClose: () => {},
 		status: '진행중',
 		handleStatusEdit: () => {},
+		targetDate: '2025-01-22',
 	},
 };

--- a/src/types/tasks/taskType.ts
+++ b/src/types/tasks/taskType.ts
@@ -14,3 +14,17 @@ export interface TaskType {
 	};
 	status: StatusType;
 }
+export interface DetailedTaskType {
+	name: string;
+	description: string;
+	deadLine: {
+		date: string | null;
+		time: string | null;
+	};
+	status: StatusType;
+	timeBlock: {
+		id: number;
+		startTime: string;
+		endTime: string;
+	};
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:


[feat: 태스크 상세 조회 api 연결](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/8d0e47f3786758e159b6161a5435b27d7ea6fb02)

[fix: useTaskDescription isopen 추가, 쿼리키 today 제거](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/fede4df899f303132afed0c1efe540a7f7901b83)

[feat: add onChange to PopUp](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/b0a284f6c099cca986b8e4f9f1cd2c287a84f25e)

[feat: useInput](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/2fcfe0a6d598c43cc993d1fb117dd8d8539ddc42)

[feat: add DetailedTaskType](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/00351b002e63468a41293fabd189a51c4540b592)

[feat: add description related apis](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/fb3ff2972c1083df22bd7e935640226ad60205b7)

[fix: change event type, link event to handler](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/798f34a592febc7ff2f2fe9aabda89a228198239)

[fix: 반환타입지정](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/41017148a12c6964c4e88fbb319468b84f447977)

[fix: change event type, add handleContent](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/81d33ee40d57bb21def991b55b4af41a142943b2)

[feat: description 값 읽어와서 상태 (훅) 에 저장](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/9da5f0382caa683612b87d124bb2862b08302d52)

[feat: deadline 연결](https://github.com/TEAM-DAWM/NUTSHELL-FE/commit/59502ad3f283c3c40939aa8a848f4a566bcf0a19)


## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

더 해야하는 거
- 모달 위치
```tsx
	useEffect(() => {
		const container = document.getElementById('todolist-task-container');

		if (container) {
			const draggable = new FullCalendarDraggable(container, {
				itemSelector: '.todo-item', // 드래그 가능한 요소
				eventData: () => {
					if (selectedTarget) {
						return {
							id: selectedTarget.id.toString(),
							title: selectedTarget.name,
						};
					}
					return null;
				},
			});

			// 컴포넌트 언마운트 시 FullCalendarDraggable 정리
			return () => {
				draggable.destroy?.();
			};
		}

		return undefined;
	}, [selectedTarget]);
```

이부분 이슈로 인풋창 작동안됨  
`itemSelector: '.todo-item',` 으로 이 밑이 다 잡혀서 그런 것 같은데 class 제외 이런 거 해도 안됨 -> 좀 더 봐야함  
- deadline이나 타임블럭쪽.. date, time 쪽 인풋 문제있을 수 있음 고치겠습니다
- 수정하면 먹혔다 안먹혔다 하는 것 같은데 반영이 느린듯..?\
- 그리고 디자인상으로는 수정 모달에 타임블럭 수동으로 지정할 수 있게 되어있는데 api 명세서상에는 이 부분이 없음
- useInput 훅을 만들었는데 string 으로만 대응해서 date 를 Date 오브젝트로 받기로 했던 것 같아 상태를 일단 따로 만듦.

## 관련 이슈

close #347 #348 

## 스크린샷 (선택)
