### PR TITLE
[FEAT] 캘린더 드롭 이벤트 생성 + 모달 타임블록 데이터 반영

### DIFF
--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -12,14 +12,9 @@ const usePostTimeBlock = () => {
 	const { mutate, isError } = useMutation({
 		mutationFn: async ({ taskId, startTime, endTime }: PostTimeBlokType) => {
 			const response = await CreateTimeBlock({ taskId, startTime, endTime });
-			/** response.code가 error일 때 타임블록 에러 토스트 출력 */
-			if (response && response.code === 'error') {
-				addToast(response.message, response.code);
-				throw new Error('error');
-			}
 			/** response.code가 'conflict'일 때 타임블록 에러 토스트 출력 */
 			if (response && response.code === 'conflict') {
-				addToast(response.message, 'error');
+				addToast(response.message, response.code);
 				throw new Error('error');
 			}
 			return response;

--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -17,6 +17,11 @@ const usePostTimeBlock = () => {
 				addToast(response.message, response.code);
 				throw new Error('error');
 			}
+			/** response.code가 'conflict'일 때 타임블록 에러 토스트 출력 */
+			if (response && response.code === 'conflict') {
+				addToast(response.message, 'error');
+				throw new Error('error');
+			}
 			return response;
 		},
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -12,12 +12,8 @@ const usePatchTimeBlock = () => {
 	const mutation = useMutation({
 		mutationFn: async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime });
-			if (response && response.code === 'error') {
-				addToast(response.message, response.code);
-				throw new Error('error');
-			}
 			if (response && response.code === 'conflict') {
-				addToast(response.message, 'error');
+				addToast(response.message, response.code);
 				throw new Error('error');
 			}
 			return response;

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -16,6 +16,10 @@ const usePatchTimeBlock = () => {
 				addToast(response.message, response.code);
 				throw new Error('error');
 			}
+			if (response && response.code === 'conflict') {
+				addToast(response.message, 'error');
+				throw new Error('error');
+			}
 			return response;
 		},
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -46,6 +46,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [left, setLeft] = useState(0);
 	const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
 	const [selectedTimeBlockId, setSelectedTimeBlockId] = useState<number | null>(null);
+	const [selectdTimeBlockDate, setSelectdTimeBlockDate] = useState<string | null>(null);
+
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
 	const [isFilterPopupOpen, setFilterPopupOpen] = useState(false);
@@ -122,11 +124,12 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		setTop(adjustedTop);
 		setLeft(rect.left - MODAL.TASK_MODAL_WIDTH - 50);
 
-		const clickedEvent = info.event.extendedProps;
+		const clickedEvent = info.event;
 
 		if (clickedEvent) {
-			setSelectedTaskId(clickedEvent.taskId);
-			setSelectedTimeBlockId(clickedEvent.timeBlockId);
+			setSelectedTaskId(clickedEvent.extendedProps.taskId);
+			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
+			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
 			setMainModalOpen(true);
 		}
 	};
@@ -232,11 +235,12 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		setTop(adjustedTop);
 		setLeft(rect.left - MODAL.TASK_DELETE_WIDTH - 8);
 
-		const clickedEvent = info.event.extendedProps;
+		const clickedEvent = info.event;
 
 		if (clickedEvent) {
-			setSelectedTaskId(clickedEvent.taskId);
-			setSelectedTimeBlockId(clickedEvent.timeBlockId);
+			setSelectedTaskId(clickedEvent.extendedProps.taskId);
+			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
+			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
 			setDeleteModalOpen(true);
 		}
 	};
@@ -287,6 +291,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					if (clickedEvent) {
 						setSelectedTaskId(Number(info.event.id));
 						setSelectedTimeBlockId(clickedEvent.timeBlockId);
+						setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
 						setMainModalOpen(true);
 						setDeadlineBoxOpen(true);
 					}
@@ -436,7 +441,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					status="미완료"
 					taskId={selectedTaskId}
 					handleStatusEdit={handleStatusEdit}
-					targetDate={selectDate ? formatDatetoLocalDate(selectDate) : formatDatetoLocalDate(today)}
+					targetDate={selectdTimeBlockDate ? formatDatetoLocalDate(selectdTimeBlockDate) : formatDatetoLocalDate(today)}
 					timeBlockId={selectedTimeBlockId}
 					isDeadlineBoxOpen={isDeadlineBoxOpen}
 				/>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -41,8 +41,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
 	const [top, setTop] = useState(0);
 	const [left, setLeft] = useState(0);
-	const [modalTaskId, setModalTaskId] = useState<number | null>(null);
-	const [modalTimeBlockId, setModalTimeBlockId] = useState<number | null>(null);
+	const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+	const [selectedTimeBlockId, setSelectedTimeBlockId] = useState<number | null>(null);
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
 	const [isFilterPopupOpen, setFilterPopupOpen] = useState(false);
@@ -50,6 +50,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		Object.values(STATUSES)
 	);
 	const [isFilterPopupDot, setIsFilterPopupDot] = useState(false);
+	const [isMainModalOpen, setMainModalOpen] = useState(false);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -121,16 +122,16 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		// const clickedEvent = info.event.extendedProps;
 
 		// if (clickedEvent) {
-		// 	setModalTaskId(clickedEvent.taskId);
-		// 	setModalTimeBlockId(clickedEvent.timeBlockId);
+		// 	setSelectedTaskId(clickedEvent.taskId);
+		// 	setSelectedTimeBlockId(clickedEvent.timeBlockId);
 		// 	setDeleteModalOpen(true);
 		// }
 	};
 
 	const closeModal = () => {
 		setDeleteModalOpen(false);
-		setModalTaskId(null);
-		setModalTimeBlockId(null);
+		setSelectedTaskId(null);
+		setSelectedTimeBlockId(null);
 	};
 
 	const removeTimezone = (str: string) => str.replace(/:\d{2}[+-]\d{2}:\d{2}$/, '');
@@ -194,10 +195,10 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const isSelectable = !!selectedTarget;
 
 	const handleDelete = () => {
-		console.log('taskId, timeBlockId', modalTaskId, modalTimeBlockId);
+		console.log('taskId, timeBlockId', selectedTaskId, selectedTimeBlockId);
 
-		if (modalTaskId && modalTimeBlockId) {
-			deleteMutate({ taskId: modalTaskId, timeBlockId: modalTimeBlockId });
+		if (selectedTaskId && selectedTimeBlockId) {
+			deleteMutate({ taskId: selectedTaskId, timeBlockId: selectedTimeBlockId });
 		} else {
 			console.error('taskId 또는 timeBlockId가 존재하지 않습니다.');
 		}
@@ -219,8 +220,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		const clickedEvent = info.event.extendedProps;
 
 		if (clickedEvent) {
-			setModalTaskId(clickedEvent.taskId);
-			setModalTimeBlockId(clickedEvent.timeBlockId);
+			setSelectedTaskId(clickedEvent.taskId);
+			setSelectedTimeBlockId(clickedEvent.timeBlockId);
 			setDeleteModalOpen(true);
 		}
 	};
@@ -371,7 +372,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					handleStatusChange={handleStatusChange}
 				/>
 			)}
-			{isDeleteModalOpen && modalTaskId !== null && modalTimeBlockId !== null && (
+			{isDeleteModalOpen && selectedTaskId !== null && selectedTimeBlockId !== null && (
 				<TimeBlockDeleteModal top={top} left={left} onClose={closeModal} onDelete={handleDelete} />
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -139,6 +139,11 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		setMainModalOpen(false);
 		setSelectedTaskId(null);
 		setSelectedTimeBlockId(null);
+
+		/** TODO:
+		 * 닫힐 때 이벤트 생성하기
+		 * createMutate({ taskId: Number(info.event.id), startTime: start, endTime: end });
+		 * */
 	};
 
 	const removeTimezone = (str: string) => str.replace(/:\d{2}[+-]\d{2}:\d{2}$/, '');
@@ -257,7 +262,31 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		endDate.setHours(endDate.getHours() + 1);
 		const end = formatDateToLocal(endDate);
 
-		createMutate({ taskId: Number(info.event.id), startTime: start, endTime: end });
+		const el = info.draggedEl;
+		const clickedEvent = info.event.extendedProps;
+
+		const rect = el.getBoundingClientRect();
+		const calculatedTop = rect.top;
+		const screenHeight = window.innerHeight;
+		const adjustedTop = Math.min(calculatedTop, screenHeight - MODAL.TIMEBLOCK_MONTH.HEIGHT);
+
+		const adjustedLeft = rect.left - MODAL.TIMEBLOCK_MONTH.SMALL_WIDTH * 2;
+
+		setTop(adjustedTop);
+		setLeft(adjustedLeft);
+
+		if (clickedEvent) {
+			setSelectedTaskId(clickedEvent.taskId);
+			setSelectedTimeBlockId(clickedEvent.timeBlockId);
+			setMainModalOpen(true);
+		}
+
+		createMutate(
+			{ taskId: Number(info.event.id), startTime: start, endTime: end },
+			{
+				onError: () => closeMainModal(),
+			}
+		);
 	};
 
 	// CalendarSettingDropdown handler
@@ -400,6 +429,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					status="미완료"
 					taskId={selectedTaskId}
 					handleStatusEdit={handleStatusEdit}
+					targetDate={selectDate ? selectDate.toDateString() : todayDate}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -26,6 +26,7 @@ import customSlotLabelContent from '@/components/common/fullCalendar/fullCalenda
 import MODAL from '@/constants/modalLocation';
 import { STATUSES } from '@/constants/statuses';
 import { StatusType, TaskType } from '@/types/tasks/taskType';
+import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
@@ -53,6 +54,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	);
 	const [isFilterPopupDot, setIsFilterPopupDot] = useState(false);
 	const [isMainModalOpen, setMainModalOpen] = useState(false);
+	const [isDeadlineBoxOpen, setDeadlineBoxOpen] = useState(false);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -137,6 +139,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 	const closeMainModal = () => {
 		setMainModalOpen(false);
+		setDeadlineBoxOpen(false);
 		setSelectedTaskId(null);
 		setSelectedTimeBlockId(null);
 
@@ -275,15 +278,19 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		setTop(adjustedTop);
 		setLeft(adjustedLeft);
 
-		if (clickedEvent) {
-			setSelectedTaskId(clickedEvent.taskId);
-			setSelectedTimeBlockId(clickedEvent.timeBlockId);
-			setMainModalOpen(true);
-		}
+		console.log('드롭된 task id', Number(info.event.id));
 
 		createMutate(
 			{ taskId: Number(info.event.id), startTime: start, endTime: end },
 			{
+				onSuccess: () => {
+					if (clickedEvent) {
+						setSelectedTaskId(Number(info.event.id));
+						setSelectedTimeBlockId(clickedEvent.timeBlockId);
+						setMainModalOpen(true);
+						setDeadlineBoxOpen(true);
+					}
+				},
 				onError: () => closeMainModal(),
 			}
 		);
@@ -429,7 +436,9 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					status="미완료"
 					taskId={selectedTaskId}
 					handleStatusEdit={handleStatusEdit}
-					targetDate={selectDate ? selectDate.toDateString() : todayDate}
+					targetDate={selectDate ? formatDatetoLocalDate(selectDate) : formatDatetoLocalDate(today)}
+					timeBlockId={selectedTimeBlockId}
+					isDeadlineBoxOpen={isDeadlineBoxOpen}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -551,7 +551,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		display: flex;
 		gap: 4px;
 		align-items: center;
-		width: 12rem;
 		width: ${({ size }) => (size === 'big' ? '18rem' : '12rem')};
 		height: 2rem;
 		padding: 0 4px 0 8px;

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -23,6 +23,8 @@ interface MainSettingModalProps {
 	status: StatusType;
 	handleStatusEdit: (newStatus: StatusType) => void;
 	targetDate: string;
+	timeBlockId?: number;
+	isDeadlineBoxOpen: boolean;
 }
 
 function MainSettingModal({
@@ -34,6 +36,8 @@ function MainSettingModal({
 	status,
 	handleStatusEdit,
 	targetDate,
+	timeBlockId,
+	isDeadlineBoxOpen,
 }: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutate: editMutate } = usePatchTaskDescription();
@@ -43,6 +47,15 @@ function MainSettingModal({
 		isLoading: isTaskDetailLoading,
 		isFetched: isTaskDetailFetched,
 	} = useTaskDescription({ taskId, targetDate, isOpen });
+
+	if (isTaskDetailFetched) {
+		console.log('taskDetailData', taskDetailData);
+		if (!timeBlockId) {
+			// eslint-disable-next-line no-param-reassign
+			timeBlockId = taskDetailData?.timeBlock?.id;
+		}
+	}
+	console.log('taskId, targetDate, timeblockId', taskId, targetDate, timeBlockId);
 
 	// === useInput ===
 	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
@@ -123,7 +136,15 @@ function MainSettingModal({
 				<PopUpTitleBox>
 					<PopUp type="description" defaultValue={descriptionContent} onChange={onDescriptionChange} />
 				</PopUpTitleBox>
-				<DeadlineBox date={new Date()} startTime="11:00am" endTime="06:00pm" label="진행 기간" />
+				{timeBlockId && (
+					<DeadlineBox
+						date={new Date()}
+						startTime="11:00am"
+						endTime="06:00pm"
+						label="진행 기간"
+						isDueDate={isDeadlineBoxOpen}
+					/>
+				)}
 			</MainSettingModalBodyLayout>
 			<MainSettingModalButtonLayout>
 				<Button type="solid" size="medium" label="확인" onClick={handleConfirm} />

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -61,6 +61,8 @@ function MainSettingModal({
 	const { content: titleContent, onChange: onTitleChange, handleContent: handleTitle } = useInput('');
 	const { content: descriptionContent, onChange: onDescriptionChange, handleContent: handleDesc } = useInput('');
 	const { content: deadlineTime, handleContent: handleDeadlineTime } = useInput('');
+	const { content: startTime, handleContent: handleStartTime } = useInput('');
+	const { content: endTime, handleContent: handleEndTime } = useInput('');
 	const [deadlineDate, setDeadlineDate] = useState<Date | null>(null);
 
 	useEffect(() => {
@@ -69,6 +71,8 @@ function MainSettingModal({
 			handleDesc(taskDetailData?.description || '');
 			handleDeadlineDate(taskDetailData?.deadLine.date ? new Date(taskDetailData?.deadLine.date) : null);
 			handleDeadlineTime(taskDetailData?.deadLine.time || '');
+			handleStartTime(taskDetailData?.timeBlock.startTime || '');
+			handleEndTime(taskDetailData?.timeBlock.endTime || '');
 		}
 	}, [isTaskDetailFetched]);
 	const modalRef = useOutsideClick<HTMLDivElement>({ onClose });
@@ -104,6 +108,14 @@ function MainSettingModal({
 	const handleTaskStatusChange = (newStatus: StatusType) => {
 		setTaskStatus(newStatus);
 	};
+	const formatTimeWithAmPm = (time: string) => {
+		if (time) {
+			const onlyTime = time.split('T')[1];
+			const [hour, minute] = onlyTime.split(':').map(Number);
+			const period = hour >= 12 ? 'pm' : 'am';
+			return `${hour}:${minute.toString().padStart(2, '0')} ${period}`;
+		}
+	};
 
 	if (!isOpen) return null;
 	if (isTaskDetailLoading) return <div />;
@@ -138,9 +150,9 @@ function MainSettingModal({
 				</PopUpTitleBox>
 				{timeBlockId && (
 					<DeadlineBox
-						date={new Date()}
-						startTime="11:00am"
-						endTime="06:00pm"
+						date={new Date(targetDate)}
+						startTime={formatTimeWithAmPm(startTime) || '06:00pm'}
+						endTime={formatTimeWithAmPm(endTime) || '06:00pm'}
 						label="진행 기간"
 						isDueDate={isDeadlineBoxOpen}
 					/>

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -4,13 +4,13 @@ import { useEffect, useState } from 'react';
 import useDeleteTask from '@/apis/tasks/deleteTask/query';
 import usePatchTaskDescription from '@/apis/tasks/editTask/query';
 import useTaskDescription from '@/apis/tasks/taskDescription/query';
-import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
 import Button from '@/components/common/v2/button/Button';
 import DropdownButton from '@/components/common/v2/control/DropdownButton';
 import IconButton from '@/components/common/v2/IconButton';
 import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
 import PopUp from '@/components/common/v2/TextBox/PopUp';
 import useInput from '@/hooks/useInput';
+import useOutsideClick from '@/hooks/useOutsideClick';
 import { StatusType } from '@/types/tasks/taskType';
 import formatDatetoLocalDate from '@/utils/formatDatetoLocalDate';
 
@@ -58,6 +58,7 @@ function MainSettingModal({
 			handleDeadlineTime(taskDetailData?.deadLine.time || '');
 		}
 	}, [isTaskDetailFetched]);
+	const modalRef = useOutsideClick<HTMLDivElement>({ onClose });
 
 	useEffect(() => {
 		setTaskStatus(status);
@@ -95,41 +96,39 @@ function MainSettingModal({
 	if (isTaskDetailLoading) return <div />;
 
 	return (
-		<ModalBackdrop onClick={onClose}>
-			<MainSettingModalLayout top={top} left={left} onClick={(e) => e.stopPropagation()}>
-				<MainSettingModalHeadLayout>
-					<ModalTopButtonBox>
-						<DropdownButton
-							status={taskStatus}
-							handleStatusChange={handleTaskStatusChange}
-							handleStatusEdit={handleStatusEdit}
-							isModalOpen={isOpen}
-						/>
-						<ButtonBox>
-							<IconButton iconName="IcnDelete" type="normal" size="small" onClick={handleDelete} />
-							<IconButton iconName="IcnX" type="normal" size="small" onClick={onClose} />
-						</ButtonBox>
-					</ModalTopButtonBox>
-					<PopUp type="title" defaultValue={titleContent} onChange={onTitleChange} />
-				</MainSettingModalHeadLayout>
-				<MainSettingModalBodyLayout>
-					<DeadlineBox
-						date={deadlineDate ? new Date(deadlineDate) : new Date()}
-						endTime={deadlineTime || '06:00pm'}
-						handleDueDateModalDate={handleDeadlineDate}
-						handleDueDateModalTime={handleDeadlineTime}
-						label="마감 기간"
+		<MainSettingModalLayout ref={modalRef} top={top} left={left} onClick={(e) => e.stopPropagation()}>
+			<MainSettingModalHeadLayout>
+				<ModalTopButtonBox>
+					<DropdownButton
+						status={taskStatus}
+						handleStatusChange={handleTaskStatusChange}
+						handleStatusEdit={handleStatusEdit}
+						isModalOpen={isOpen}
 					/>
-					<PopUpTitleBox>
-						<PopUp type="description" defaultValue={descriptionContent} onChange={onDescriptionChange} />
-					</PopUpTitleBox>
-					<DeadlineBox date={new Date()} startTime="11:00am" endTime="06:00pm" label="진행 기간" />
-				</MainSettingModalBodyLayout>
-				<MainSettingModalButtonLayout>
-					<Button type="solid" size="medium" label="확인" onClick={handleConfirm} />
-				</MainSettingModalButtonLayout>
-			</MainSettingModalLayout>
-		</ModalBackdrop>
+					<ButtonBox>
+						<IconButton iconName="IcnDelete" type="normal" size="small" onClick={handleDelete} />
+						<IconButton iconName="IcnX" type="normal" size="small" onClick={onClose} />
+					</ButtonBox>
+				</ModalTopButtonBox>
+				<PopUp type="title" defaultValue={titleContent} onChange={onTitleChange} />
+			</MainSettingModalHeadLayout>
+			<MainSettingModalBodyLayout>
+				<DeadlineBox
+					date={deadlineDate ? new Date(deadlineDate) : new Date()}
+					endTime={deadlineTime || '06:00pm'}
+					handleDueDateModalDate={handleDeadlineDate}
+					handleDueDateModalTime={handleDeadlineTime}
+					label="마감 기간"
+				/>
+				<PopUpTitleBox>
+					<PopUp type="description" defaultValue={descriptionContent} onChange={onDescriptionChange} />
+				</PopUpTitleBox>
+				<DeadlineBox date={new Date()} startTime="11:00am" endTime="06:00pm" label="진행 기간" />
+			</MainSettingModalBodyLayout>
+			<MainSettingModalButtonLayout>
+				<Button type="solid" size="medium" label="확인" onClick={handleConfirm} />
+			</MainSettingModalButtonLayout>
+		</MainSettingModalLayout>
 	);
 }
 

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -24,7 +24,7 @@ interface MainSettingModalProps {
 	handleStatusEdit: (newStatus: StatusType) => void;
 	targetDate: string;
 	timeBlockId?: number;
-	isDeadlineBoxOpen: boolean;
+	isDeadlineBoxOpen?: boolean;
 }
 
 function MainSettingModal({
@@ -37,7 +37,7 @@ function MainSettingModal({
 	handleStatusEdit,
 	targetDate,
 	timeBlockId,
-	isDeadlineBoxOpen,
+	isDeadlineBoxOpen = false,
 }: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutate: editMutate } = usePatchTaskDescription();

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -49,7 +49,7 @@ const ToastMessage = styled.div<{ code: string }>`
 	align-items: center;
 	justify-content: space-between;
 	box-sizing: border-box;
-	width: 44rem;
+	min-width: 44rem;
 	height: 6.4rem;
 	padding: 1.6rem;
 
@@ -94,7 +94,7 @@ const TextLayout = styled.div`
 	display: flex;
 	gap: 0.8rem;
 	align-items: center;
-	width: 26.8rem;
+	min-width: 26.8rem;
 
 	svg {
 		width: 2.4rem;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -11,7 +11,7 @@ const toastIcon: Record<ToastType, { icon: JSX.Element }> = {
 	error: {
 		icon: <Icon name="IcnDelete" />,
 	},
-	info: {
+	conflict: {
 		icon: <Icon name="IcnAlert" />,
 	},
 };

--- a/src/constants/modalLocation.ts
+++ b/src/constants/modalLocation.ts
@@ -23,6 +23,13 @@ const MODAL = {
 			left: -20.2,
 		},
 	},
+
+	// timeBlock 월간이벤트 크기
+	TIMEBLOCK_MONTH: {
+		HEIGHT: 20,
+		SMALL_WIDTH: 120,
+		BIG_WIDTH: 180,
+	},
 };
 
 export default MODAL;

--- a/src/stories/Common/toast/Toast.stories.tsx
+++ b/src/stories/Common/toast/Toast.stories.tsx
@@ -37,6 +37,6 @@ export const InfoToast: Story = {
 	args: {
 		message: '할 일을 완료했어요',
 		onClose: fn(),
-		code: 'info',
+		code: 'success',
 	},
 };

--- a/src/types/toastType.ts
+++ b/src/types/toastType.ts
@@ -1,1 +1,1 @@
-export type ToastType = 'success' | 'error' | 'info';
+export type ToastType = 'success' | 'error' | 'conflict';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 캘린더에 메인모달 연결
  - 타임블록 드롭생성 시 자동으로 모달 열리고, 그 안에서 시간 지정하도록 설정
- 메인모달 위치, 진행시간 지정 여부 등에 따라 뷰 조정 
- response.code === 'conflict' 일 때 토스트 띄우기
- 토스트 타입 수정 ('info' -> 'conflict')

## 알게된 점 :rocket:

> 기록하며 개발하기!

- ㅜㅜㅜ

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 서버 측에서 사용자에게 보여야 할 오류 메세지는 'conflict'코드로 보내준다고 하여, 'info' -> 'conflict' 으로 변경하였습니다! 
- 드롭 생성 시 자동으로 열리는 모달이 드롭 위치를 기준으로 모달이 열려서, 위치에 있어 조금씩 차이가 납니다. 
- 드롭 생성 시 자동으로 새벽 12-1시 사이에 생성되는데, 만약 이 시간대에 이미 이벤트가 있다면 드롭으로 생성이 불가합니다(현재는)
요거 어케 고칠 지 서버+디쟌이랑 이야기해봐야합니다ㅜ

## 관련 이슈

close #353 

## 스크린샷 (선택)
<img width="429" alt="스크린샷 2025-01-23 19 18 05" src="https://github.com/user-attachments/assets/1796fbf3-751b-4507-8b2b-d24964936a10" />

