### PR TITLE
[FIX] staging area order 모달 위치

### DIFF
--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -46,6 +46,7 @@ function StagingArea(props: StagingAreaProps) {
 					onClick={handleArrangeBtnClick}
 					dot={isIconBtnDotted}
 				/>
+				{isSortModalOpen && <SortingDropdown handleSortOrder={handleSortOrder} />}
 			</IconContainer>
 
 			<BottomContainer>
@@ -63,7 +64,6 @@ function StagingArea(props: StagingAreaProps) {
 					)}
 				</Droppable>
 			</BottomContainer>
-			{isSortModalOpen && <SortingDropdown handleSortOrder={handleSortOrder} />}
 			{isSortModalOpen && <ModalBackdrop onClick={handleCloseModal} />}
 		</StagingAreaLayout>
 	);

--- a/src/components/common/v2/dropdown/SortingDropdown.tsx
+++ b/src/components/common/v2/dropdown/SortingDropdown.tsx
@@ -35,6 +35,7 @@ const btnCustomWidth = css`
 `;
 const SortingDropdownContainer = styled.div`
 	position: absolute;
+	left: 44.6rem;
 	z-index: 4;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

![image](https://github.com/user-attachments/assets/ce6a0d1b-92f6-4725-9ae9-eae2de2eb813)

적당한 데에다가 달았는데 얘는 클릭하면 그 옆에 뜨는 게 아니라서 걍 값으로 박았습니다.
근데 todo area 에서 또 연결한다 하면 고쳐야할듯

## 관련 이슈

close #390

## 스크린샷 (선택)
