### PR TITLE
[FEAT] TimeBlock 종일이벤트 추가 

### DIFF
--- a/src/apis/timeBlocks/getTimeBlock/GetTimeBlock.ts
+++ b/src/apis/timeBlocks/getTimeBlock/GetTimeBlock.ts
@@ -4,6 +4,7 @@ interface TimeBlock {
 	id: number;
 	startTime: string;
 	endTime: string;
+	isAllTime: boolean;
 }
 
 interface Schedule {

--- a/src/apis/timeBlocks/postTimeBlock/PostTimeBlockType.ts
+++ b/src/apis/timeBlocks/postTimeBlock/PostTimeBlockType.ts
@@ -2,4 +2,5 @@ export interface PostTimeBlokType {
 	taskId: number;
 	startTime: string;
 	endTime: string;
+	isAllTime: boolean;
 }

--- a/src/apis/timeBlocks/postTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/postTimeBlock/axios.ts
@@ -10,11 +10,13 @@ const CreateTimeBlock = async ({
 	taskId,
 	startTime,
 	endTime,
+	isAllTime,
 }: PostTimeBlokType): Promise<TimeBlockResponse | undefined> => {
 	try {
 		const response = await privateInstance.post(`/api/tasks/${taskId}/time-blocks`, {
 			startTime,
 			endTime,
+			isAllTime,
 		});
 		return {
 			code: response.data.code,

--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -10,8 +10,8 @@ const usePostTimeBlock = () => {
 	const { addToast } = useToast();
 
 	const { mutate, isError } = useMutation({
-		mutationFn: async ({ taskId, startTime, endTime }: PostTimeBlokType) => {
-			const response = await CreateTimeBlock({ taskId, startTime, endTime });
+		mutationFn: async ({ taskId, startTime, endTime, isAllTime }: PostTimeBlokType) => {
+			const response = await CreateTimeBlock({ taskId, startTime, endTime, isAllTime });
 			/** response.code가 'conflict'일 때 타임블록 에러 토스트 출력 */
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);

--- a/src/apis/timeBlocks/updateTimeBlock/PatchTimeBlockType.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/PatchTimeBlockType.ts
@@ -3,4 +3,5 @@ export interface PatchTimeBlokType {
 	timeBlockId: number;
 	startTime: string;
 	endTime: string;
+	isAllTime: boolean;
 }

--- a/src/apis/timeBlocks/updateTimeBlock/axios.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/axios.ts
@@ -11,11 +11,13 @@ const PatchTimeBlock = async ({
 	timeBlockId,
 	startTime,
 	endTime,
+	isAllTime,
 }: PatchTimeBlokType): Promise<TimeBlockResponse | undefined> => {
 	try {
 		const response = await privateInstance.patch(`/api/tasks/${taskId}/time-blocks/${timeBlockId}`, {
 			startTime,
 			endTime,
+			isAllTime,
 		});
 		return {
 			code: response.data.code,

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -4,6 +4,7 @@ import PatchTimeBlock from './axios';
 import { PatchTimeBlokType } from './PatchTimeBlockType';
 
 import { useToast } from '@/components/toast/ToastContext';
+import { formatDateToLocal } from '@/utils/formatDateTime';
 
 const usePatchTimeBlock = () => {
 	const queryClient = useQueryClient();
@@ -11,6 +12,15 @@ const usePatchTimeBlock = () => {
 
 	const mutation = useMutation({
 		mutationFn: async ({ taskId, timeBlockId, startTime, endTime, isAllTime }: PatchTimeBlokType) => {
+			if (!endTime) {
+				const startDate = new Date(startTime); // startTime을 Date 객체로 변환
+				startDate.setHours(startDate.getHours() + 1); // 1시간 추가
+				// eslint-disable-next-line no-param-reassign
+				endTime = formatDateToLocal(startDate);
+			}
+
+			console.log('usePatchTimeBlock ', taskId, timeBlockId, startTime, endTime, isAllTime);
+
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime, isAllTime });
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -10,8 +10,8 @@ const usePatchTimeBlock = () => {
 	const { addToast } = useToast();
 
 	const mutation = useMutation({
-		mutationFn: async ({ taskId, timeBlockId, startTime, endTime }: PatchTimeBlokType) => {
-			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime });
+		mutationFn: async ({ taskId, timeBlockId, startTime, endTime, isAllTime }: PatchTimeBlokType) => {
+			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime, isAllTime });
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);
 				throw new Error('error');

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -199,10 +199,18 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const updateEvent = (info: EventDropArg | EventResizeDoneArg) => {
 		const { event } = info;
 		const { taskId, timeBlockId } = event.extendedProps;
-
+		console.log('updateEvent EventDropArg | EventResizeDoneArg', event.startStr);
+		console.log('updateEvent EventDropArg | EventResizeDoneArg', info);
 		if (taskId && taskId !== -1) {
-			const startStr = removeTimezone(event.startStr);
-			const endStr = removeTimezone(event.endStr);
+			let startStr = removeTimezone(event.startStr);
+			let endStr = removeTimezone(event.endStr);
+
+			if (info.event.allDay) {
+				startStr += 'T00:00';
+				endStr = startStr;
+			}
+
+			console.log('updateMutate ', taskId, timeBlockId, startStr, endStr, info.event.allDay);
 
 			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: info.event.allDay });
 		} else {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -204,7 +204,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			const startStr = removeTimezone(event.startStr);
 			const endStr = removeTimezone(event.endStr);
 
-			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: false });
+			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: info.event.allDay });
 		} else {
 			info.revert();
 		}
@@ -320,6 +320,13 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	};
 
 	const handleEventDidMount = (arg: EventMountArg) => {
+		if (arg.event.allDay) {
+			arg.el.classList.add('fc-all-day-event');
+			const eventMainElement = arg.el.querySelector('.fc-event-main');
+			if (eventMainElement) {
+				eventMainElement.classList.add('fc-all-day-event-main');
+			}
+		}
 		handleCompletedTask(arg);
 		// 우클릭 시
 		arg.el.addEventListener('contextmenu', (event) => handleRightClick(arg, event));

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -26,7 +26,7 @@ import customSlotLabelContent from '@/components/common/fullCalendar/fullCalenda
 import MODAL from '@/constants/modalLocation';
 import { STATUSES } from '@/constants/statuses';
 import { StatusType, TaskType } from '@/types/tasks/taskType';
-import { formatDatetoLocalDate } from '@/utils/formatDateTime';
+import { formatDateToLocal, formatDatetoLocalDate } from '@/utils/formatDateTime';
 
 interface FullCalendarBoxProps {
 	size: 'small' | 'big';
@@ -259,11 +259,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 	const handleFilterPopup = () => {
 		setFilterPopupOpen((prev) => !prev);
-	};
-
-	const formatDateToLocal = (inputDate: Date): string => {
-		const adjustedDate = new Date(inputDate.getTime() - inputDate.getTimezoneOffset() * 60000);
-		return adjustedDate.toISOString().slice(0, 16);
 	};
 
 	// 드래그해서 timeblock 추가

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -451,6 +451,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					targetDate={selectdTimeBlockDate ? formatDatetoLocalDate(selectdTimeBlockDate) : formatDatetoLocalDate(today)}
 					timeBlockId={selectedTimeBlockId}
 					isDeadlineBoxOpen={isDeadlineBoxOpen}
+					isAllTime={calendarEvents.find((event) => event.extendedProps.taskId === selectedTaskId)?.allDay || false}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -181,7 +181,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			const startStr = removeTimezone(selectInfo.startStr);
 			const endStr = removeTimezone(selectInfo.endStr);
 
-			createMutate({ taskId: selectedTarget.id, startTime: startStr, endTime: endStr });
+			createMutate({ taskId: selectedTarget.id, startTime: startStr, endTime: endStr, isAllTime: false });
 		}
 	};
 
@@ -204,7 +204,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			const startStr = removeTimezone(event.startStr);
 			const endStr = removeTimezone(event.endStr);
 
-			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr });
+			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: false });
 		} else {
 			info.revert();
 		}
@@ -285,7 +285,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		console.log('드롭된 task id', Number(info.event.id));
 
 		createMutate(
-			{ taskId: Number(info.event.id), startTime: start, endTime: end },
+			{ taskId: Number(info.event.id), startTime: start, endTime: end, isAllTime: false },
 			{
 				onSuccess: () => {
 					if (clickedEvent) {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -211,7 +211,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	.fc-daygrid-day-frame .fc-scrollgrid-sync-inner,
 	.fc-daygrid-day-events {
 		width: ${({ size }) => (size === 'big' ? '17.6rem' : '16.8rem')};
-		height: 4.4rem;
+		min-height: 4.4rem;
 	}
 
 	.fc-timegrid-slot .fc-timegrid-slot-label .fc-scrollgrid-shrink {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -308,10 +308,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		background-color: ${({ theme }) => theme.colorToken.Component.strong} !important;
 	}
 
-	.fc-all-day-event .fc-event-main :active {
-		background-color: ${({ theme }) => theme.colorToken.Outline.primaryStrong} !important;
-	}
-
 	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
 	.fc-daygrid-event-dot {
 		border-color: ${({ theme }) => theme.colorToken.Text.assistive};

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -303,6 +303,15 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		color: ${({ theme }) => theme.colorToken.Text.assistiveLight};
 	}
 
+	/* TimeGrid(주간) all-day-event(종일) */
+	.fc-all-day-event .fc-event-main {
+		background-color: ${({ theme }) => theme.colorToken.Component.strong} !important;
+	}
+
+	.fc-all-day-event .fc-event-main :active {
+		background-color: ${({ theme }) => theme.colorToken.Outline.primaryStrong} !important;
+	}
+
 	/** TODO: category 추가 시 해당 부분에서 카테고리 색 적용하면 됨 */
 	.fc-daygrid-event-dot {
 		border-color: ${({ theme }) => theme.colorToken.Text.assistive};
@@ -582,6 +591,16 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc .fc-h-event {
 		border: none;
+	}
+
+	/* TimeGrid(주간) all-day-event(종일) */
+
+	.fc-all-day-event {
+		width: 95%;
+	}
+
+	.month-view .fc-all-day-event {
+		width: 72%;
 	}
 
 	/* Month view 중 이벤트 초과 안내 */

--- a/src/components/common/fullCalendar/processEvents.tsx
+++ b/src/components/common/fullCalendar/processEvents.tsx
@@ -26,6 +26,7 @@ const processEvents = (timeBlockData: TimeBlockData, selectedStatuses: string[])
 					title: task.name,
 					start: timeBlock.startTime,
 					end: timeBlock.endTime,
+					allDay: timeBlock.isAllTime,
 					classNames: task.status === STATUSES.COMPLETED ? 'tasks completed' : 'tasks',
 					extendedProps: {
 						taskId: task.id,

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -100,7 +100,7 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, locat
 		if (taskId && startTime && endTime) {
 			const formattedStartTime = `${targetDate}T${startTime}`;
 			const formattedEndTime = `${targetDate}T${endTime}`;
-			createMutate({ taskId, startTime: formattedStartTime, endTime: formattedEndTime });
+			createMutate({ taskId, startTime: formattedStartTime, endTime: formattedEndTime, isAllTime: false });
 		} else {
 			console.log('taskId, startTime, endTime가 모두 존재하지 않습니다.');
 		}

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -85,18 +85,12 @@ function MainSettingModal({
 		setTaskStatus(status);
 	}, [status]);
 
-	useEffect(() => {
-		console.log('onStartTimeChange', startTime);
-		console.log('onEndTimeChange', endTime);
-	}, [startTime, endTime]);
-
 	const handleDeadlineDate = (date: Date | null) => {
 		setDeadlineDate(date);
 	};
 
 	const handleTimeBlockDate = (date: Date | null) => {
 		setTimeBlockDate(date);
-		console.log('timeBlockDate', timeBlockDate);
 		handleStartTime(`${formatDatetoString(timeBlockDate)}T00:00`);
 		handleEndTime(`${formatDatetoString(timeBlockDate)}T00:00`);
 	};
@@ -138,18 +132,13 @@ function MainSettingModal({
 
 	// 수정 이벤트 핸들러
 	const handleTimeBlockUpdate = () => {
-		if (!timeBlockId) {
-			console.log('타임블록 아이디없어서 리턴');
-			return;
-		}
+		if (!timeBlockId) return;
 		const formattedStartTime = isAllDay
 			? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : startTime.split('T')[0]}T00:00`
 			: startTime;
 		const formattedEndTime = isAllDay
 			? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : endTime.split('T')[0]}T00:00`
 			: endTime;
-
-		console.log('formattedTime', formattedStartTime, formattedEndTime);
 
 		updateTimeBlockMutate({
 			taskId,

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -85,6 +85,10 @@ function MainSettingModal({
 		setTaskStatus(status);
 	}, [status]);
 
+	useEffect(() => {
+		console.log('onStartTimeChange', startTime);
+	}, [startTime]);
+
 	const handleDeadlineDate = (date: Date | null) => {
 		setDeadlineDate(date);
 	};

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -87,7 +87,8 @@ function MainSettingModal({
 
 	useEffect(() => {
 		console.log('onStartTimeChange', startTime);
-	}, [startTime]);
+		console.log('onEndTimeChange', endTime);
+	}, [startTime, endTime]);
 
 	const handleDeadlineDate = (date: Date | null) => {
 		setDeadlineDate(date);

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import useDeleteTask from '@/apis/tasks/deleteTask/query';
 import usePatchTaskDescription from '@/apis/tasks/editTask/query';
 import useTaskDescription from '@/apis/tasks/taskDescription/query';
+import useUpdateTimeBlock from '@/apis/timeBlocks/updateTimeBlock/query';
 import Button from '@/components/common/v2/button/Button';
 import DropdownButton from '@/components/common/v2/control/DropdownButton';
 import IconButton from '@/components/common/v2/IconButton';
@@ -12,7 +13,7 @@ import PopUp from '@/components/common/v2/TextBox/PopUp';
 import useInput from '@/hooks/useInput';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { StatusType } from '@/types/tasks/taskType';
-import { formatDatetoLocalDate } from '@/utils/formatDateTime';
+import { formatDatetoString, formatDatetoLocalDate } from '@/utils/formatDateTime';
 
 interface MainSettingModalProps {
 	isOpen: boolean;
@@ -25,6 +26,7 @@ interface MainSettingModalProps {
 	targetDate: string;
 	timeBlockId?: number;
 	isDeadlineBoxOpen?: boolean;
+	isAllTime?: boolean;
 }
 
 function MainSettingModal({
@@ -38,10 +40,13 @@ function MainSettingModal({
 	targetDate,
 	timeBlockId,
 	isDeadlineBoxOpen = false,
+	isAllTime = false,
 }: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutate: editMutate } = usePatchTaskDescription();
+	const { mutate: updateTimeBlockMutate } = useUpdateTimeBlock();
 	const [taskStatus, setTaskStatus] = useState(status);
+	const [isAllDay, setIsAllDay] = useState(isAllTime);
 	const {
 		data: taskDetailData,
 		isLoading: isTaskDetailLoading,
@@ -61,6 +66,7 @@ function MainSettingModal({
 	const { content: startTime, handleContent: handleStartTime } = useInput('');
 	const { content: endTime, handleContent: handleEndTime } = useInput('');
 	const [deadlineDate, setDeadlineDate] = useState<Date | null>(null);
+	const [timeBlockDate, setTimeBlockDate] = useState<Date | null>(null);
 
 	useEffect(() => {
 		if (isTaskDetailFetched) {
@@ -70,6 +76,7 @@ function MainSettingModal({
 			handleDeadlineTime(taskDetailData?.deadLine.time || '');
 			handleStartTime(taskDetailData?.timeBlock?.startTime || '');
 			handleEndTime(taskDetailData?.timeBlock?.endTime || '');
+			setIsAllDay(isAllDay || false);
 		}
 	}, [isTaskDetailFetched]);
 	const modalRef = useOutsideClick<HTMLDivElement>({ onClose });
@@ -81,9 +88,17 @@ function MainSettingModal({
 	const handleDeadlineDate = (date: Date | null) => {
 		setDeadlineDate(date);
 	};
+
+	const handleTimeBlockDate = (date: Date | null) => {
+		setTimeBlockDate(date);
+		console.log('timeBlockDate', timeBlockDate);
+		handleStartTime(`${formatDatetoString(timeBlockDate)}T00:00`);
+		handleEndTime(`${formatDatetoString(timeBlockDate)}T00:00`);
+	};
 	const handleConfirm = () => {
 		handleStatusEdit(taskStatus);
 		handleEdit();
+		handleTimeBlockUpdate();
 		onClose();
 	};
 
@@ -114,6 +129,35 @@ function MainSettingModal({
 		}
 		// 임시 리턴
 		return '06:00pm';
+	};
+
+	// 수정 이벤트 핸들러
+	const handleTimeBlockUpdate = () => {
+		if (!timeBlockId) {
+			console.log('타임블록 아이디없어서 리턴');
+			return;
+		}
+		const formattedStartTime = isAllDay
+			? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : startTime.split('T')[0]}T00:00`
+			: startTime;
+		const formattedEndTime = isAllDay
+			? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : endTime.split('T')[0]}T00:00`
+			: endTime;
+
+		console.log('formattedTime', formattedStartTime, formattedEndTime);
+
+		updateTimeBlockMutate({
+			taskId,
+			timeBlockId,
+			startTime: formattedStartTime,
+			endTime: formattedEndTime,
+			isAllTime: isAllDay,
+		});
+	};
+
+	// 하루종일 버튼 상태 변경 핸들러
+	const handleAllDayToggle = () => {
+		setIsAllDay((prev) => !prev);
 	};
 
 	if (!isOpen) return null;
@@ -154,6 +198,11 @@ function MainSettingModal({
 						endTime={formatTimeWithAmPm(endTime) || '06:00pm'}
 						label="진행 기간"
 						isDueDate={isDeadlineBoxOpen}
+						isAllDay={isAllDay}
+						onAllDayToggle={handleAllDayToggle}
+						onStartTimeChange={handleStartTime}
+						onEndTimeChange={handleEndTime}
+						handleTimeBlockDate={handleTimeBlockDate}
 					/>
 				)}
 			</MainSettingModalBodyLayout>

--- a/src/components/common/v2/modal/TimeBlockDeleteModal.tsx
+++ b/src/components/common/v2/modal/TimeBlockDeleteModal.tsx
@@ -26,7 +26,7 @@ const TimeBlockDeleteModalContainer = styled.div<{ top: number; left: number }>`
 	position: fixed;
 	top: ${({ top }) => top}px;
 	left: ${({ left }) => left}px;
-	z-index: 1;
+	z-index: 2;
 
 	display: flex;
 	padding: 8px;

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -13,6 +13,7 @@ interface DateTimeBtnProps {
 	onClick: () => void;
 	handleDueDateModalDate?: (date: Date) => void;
 	handleDueDateModalTime?: (time: string) => void;
+	handleTimeBlockDate?: (date: Date) => void;
 }
 
 function DateTimeBtn({
@@ -24,6 +25,7 @@ function DateTimeBtn({
 	onClick,
 	handleDueDateModalDate = () => {},
 	handleDueDateModalTime = () => {},
+	handleTimeBlockDate = () => {},
 }: DateTimeBtnProps) {
 	// ~~여기에 상태 있어야하는지 의문~~
 	const [startTime, setStartTime] = useState(initStartTime);
@@ -43,6 +45,7 @@ function DateTimeBtn({
 	const updateDate = (newDate: Date) => {
 		setDate(newDate);
 		handleDueDateModalDate(newDate);
+		handleTimeBlockDate(newDate);
 	};
 
 	return isSetDate ? (

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -15,7 +15,7 @@ interface DateTimeBtnProps {
 	handleDueDateModalDate?: (date: Date) => void;
 	handleDueDateModalTime?: (time: string) => void;
 	handleTimeBlockDate?: (date: Date) => void;
-	onStartTimeChange?: (time: string) => void; // 시작 시간 변경 핸들러
+	onStartTimeChange?: (time: string) => void;
 	onEndTimeChange?: (time: string) => void;
 }
 
@@ -32,12 +32,6 @@ function DateTimeBtn({
 	onStartTimeChange = () => {},
 	onEndTimeChange = () => {},
 }: DateTimeBtnProps) {
-	// ~~여기에 상태 있어야하는지 의문~~
-	// const [startTime, setStartTime] = useState(initStartTime);
-	// const [endTime, setEndTime] = useState(initEndTime);
-	// const [date, setDate] = useState(initDate);
-	// ~~~~
-
 	const updateStartTime = (newTime: string) => {
 		onStartTimeChange(`${formatDatetoLocalDate(date)}T${newTime.slice(0, 5)}`);
 	};

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 
 import DateBtn from '@/components/common/v2/popup/DateBtn';
 import TimeBtn from '@/components/common/v2/popup/TimeBtn';
-import { formatDateToLocal, formatDatetoLocalDate } from '@/utils/formatDateTime';
+import { formatDatetoLocalDate } from '@/utils/formatDateTime';
 
 interface DateTimeBtnProps {
 	date: Date;

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import DateBtn from '@/components/common/v2/popup/DateBtn';
 import TimeBtn from '@/components/common/v2/popup/TimeBtn';
+import { formatDateToLocal, formatDatetoLocalDate } from '@/utils/formatDateTime';
 
 interface DateTimeBtnProps {
 	date: Date;
@@ -14,36 +15,40 @@ interface DateTimeBtnProps {
 	handleDueDateModalDate?: (date: Date) => void;
 	handleDueDateModalTime?: (time: string) => void;
 	handleTimeBlockDate?: (date: Date) => void;
+	onStartTimeChange?: (time: string) => void; // 시작 시간 변경 핸들러
+	onEndTimeChange?: (time: string) => void;
 }
 
 function DateTimeBtn({
-	date: initDate,
-	startTime: initStartTime,
-	endTime: initEndTime,
+	date,
+	startTime,
+	endTime,
 	isSetDate,
 	isAllday = false,
 	onClick,
 	handleDueDateModalDate = () => {},
 	handleDueDateModalTime = () => {},
 	handleTimeBlockDate = () => {},
+	onStartTimeChange = () => {},
+	onEndTimeChange = () => {},
 }: DateTimeBtnProps) {
 	// ~~여기에 상태 있어야하는지 의문~~
-	const [startTime, setStartTime] = useState(initStartTime);
-	const [endTime, setEndTime] = useState(initEndTime);
-	const [date, setDate] = useState(initDate);
+	// const [startTime, setStartTime] = useState(initStartTime);
+	// const [endTime, setEndTime] = useState(initEndTime);
+	// const [date, setDate] = useState(initDate);
 	// ~~~~
 
 	const updateStartTime = (newTime: string) => {
-		setStartTime(newTime);
+		onStartTimeChange(`${formatDatetoLocalDate(date)}T${newTime.slice(0, 5)}`);
 	};
 
 	const updateEndTime = (newTime: string) => {
-		setEndTime(newTime);
+		onEndTimeChange(`${formatDatetoLocalDate(date)}T${newTime.slice(0, 5)}`);
 		handleDueDateModalTime(newTime.slice(0, 5));
 	};
 
 	const updateDate = (newDate: Date) => {
-		setDate(newDate);
+		// setDate(newDate);
 		handleDueDateModalDate(newDate);
 		handleTimeBlockDate(newDate);
 	};

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -11,12 +11,12 @@ interface DeadlineBoxProps {
 	endTime: string;
 	label: string;
 	isDueDate?: boolean;
-	isAllDay?: boolean; // 부모로부터 전달받은 하루종일 상태
+	isAllDay?: boolean;
 	handleDueDateModalTime?: (time: string) => void;
 	handleDueDateModalDate?: (date: Date) => void;
 	handleTimeBlockDate?: (date: Date) => void;
-	onAllDayToggle?: (isAllDay: boolean) => void; // 하루종일 상태 변경 핸들러
-	onStartTimeChange?: (time: string) => void; // 시작 시간 변경 핸들러
+	onAllDayToggle?: (isAllDay: boolean) => void;
+	onStartTimeChange?: (time: string) => void;
 	onEndTimeChange?: (time: string) => void;
 }
 
@@ -36,11 +36,9 @@ function DeadlineBox({
 }: DeadlineBoxProps) {
 	const [isSettingActive, setIsSettingActive] = useState(isAllDay);
 	const [isClicked, setIsClicked] = useState(isDueDate);
-	const [isAllday, setIsAllday] = useState(isAllDay); // 내부 상태로 초기화
+	const [isAllday, setIsAllday] = useState(isAllDay);
 
 	const containerRef = useRef(null);
-
-	console.log('DeadlineBox 진행기간', isAllDay);
 
 	const handlePlusBtnClick = () => {
 		setIsClicked((prev) => !prev);
@@ -48,7 +46,7 @@ function DeadlineBox({
 	};
 	const handleCheckBtnClick = () => {
 		const newIsAllDay = !isAllday;
-		setIsAllday(newIsAllDay); // 내부 상태 업데이트
+		setIsAllday(newIsAllDay);
 		onAllDayToggle(newIsAllDay);
 
 		if (newIsAllDay) {
@@ -65,7 +63,7 @@ function DeadlineBox({
 	const handleXBtnClick = () => {
 		setIsSettingActive(false);
 		setIsClicked((prev) => !prev);
-		setIsAllday(false); // 내부 상태 초기화
+		setIsAllday(false);
 		onAllDayToggle(false);
 	};
 

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -46,9 +46,6 @@ function DeadlineBox({
 		setIsClicked((prev) => !prev);
 		setIsSettingActive(false);
 	};
-	const removeTime = () => {
-		handleDueDateModalTime('');
-	};
 	const handleCheckBtnClick = () => {
 		const newIsAllDay = !isAllday;
 		setIsAllday(newIsAllDay); // 내부 상태 업데이트
@@ -60,8 +57,8 @@ function DeadlineBox({
 			onEndTimeChange(`${date.toISOString().split('T')[0]}T00:00`);
 		} else {
 			// 하루종일 해제 시 시간 비우기
-			onStartTimeChange('');
-			onEndTimeChange('');
+			onStartTimeChange(startTime || '06:00');
+			onEndTimeChange(endTime);
 		}
 	};
 
@@ -121,6 +118,8 @@ function DeadlineBox({
 							handleDueDateModalDate={handleDueDateModalDate}
 							handleDueDateModalTime={handleDueDateModalTime}
 							handleTimeBlockDate={handleTimeBlockDate}
+							onStartTimeChange={onStartTimeChange}
+							onEndTimeChange={onStartTimeChange}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -119,7 +119,7 @@ function DeadlineBox({
 							handleDueDateModalTime={handleDueDateModalTime}
 							handleTimeBlockDate={handleTimeBlockDate}
 							onStartTimeChange={onStartTimeChange}
-							onEndTimeChange={onStartTimeChange}
+							onEndTimeChange={onEndTimeChange}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -11,8 +11,13 @@ interface DeadlineBoxProps {
 	endTime: string;
 	label: string;
 	isDueDate?: boolean;
+	isAllDay?: boolean; // 부모로부터 전달받은 하루종일 상태
 	handleDueDateModalTime?: (time: string) => void;
 	handleDueDateModalDate?: (date: Date) => void;
+	handleTimeBlockDate?: (date: Date) => void;
+	onAllDayToggle?: (isAllDay: boolean) => void; // 하루종일 상태 변경 핸들러
+	onStartTimeChange?: (time: string) => void; // 시작 시간 변경 핸들러
+	onEndTimeChange?: (time: string) => void;
 }
 
 function DeadlineBox({
@@ -21,14 +26,21 @@ function DeadlineBox({
 	endTime,
 	label,
 	isDueDate = false,
+	isAllDay = false,
 	handleDueDateModalTime = () => {},
 	handleDueDateModalDate = () => {},
+	handleTimeBlockDate = () => {},
+	onAllDayToggle = () => {},
+	onStartTimeChange = () => {},
+	onEndTimeChange = () => {},
 }: DeadlineBoxProps) {
-	const [isSettingActive, setIsSettingActive] = useState(false);
+	const [isSettingActive, setIsSettingActive] = useState(isAllDay);
 	const [isClicked, setIsClicked] = useState(isDueDate);
-	const [isAllday, setIsAllday] = useState(false);
+	const [isAllday, setIsAllday] = useState(isAllDay); // 내부 상태로 초기화
 
 	const containerRef = useRef(null);
+
+	console.log('DeadlineBox 진행기간', isAllDay);
 
 	const handlePlusBtnClick = () => {
 		setIsClicked((prev) => !prev);
@@ -38,16 +50,26 @@ function DeadlineBox({
 		handleDueDateModalTime('');
 	};
 	const handleCheckBtnClick = () => {
-		setIsAllday((prev) => !prev);
+		const newIsAllDay = !isAllday;
+		setIsAllday(newIsAllDay); // 내부 상태 업데이트
+		onAllDayToggle(newIsAllDay);
 
-		// 하루종일 선택시 기존 time 제거
-		removeTime();
+		if (newIsAllDay) {
+			// 하루종일 선택 시 시간을 기본 값으로 설정
+			onStartTimeChange(`${date.toISOString().split('T')[0]}T00:00`);
+			onEndTimeChange(`${date.toISOString().split('T')[0]}T00:00`);
+		} else {
+			// 하루종일 해제 시 시간 비우기
+			onStartTimeChange('');
+			onEndTimeChange('');
+		}
 	};
 
 	const handleXBtnClick = () => {
 		setIsSettingActive(false);
 		setIsClicked((prev) => !prev);
-		setIsAllday(false);
+		setIsAllday(false); // 내부 상태 초기화
+		onAllDayToggle(false);
 	};
 
 	const handleClickOutside = (event: MouseEvent) => {
@@ -98,6 +120,7 @@ function DeadlineBox({
 							onClick={handleClickModify}
 							handleDueDateModalDate={handleDueDateModalDate}
 							handleDueDateModalTime={handleDueDateModalTime}
+							handleTimeBlockDate={handleTimeBlockDate}
 						/>
 						{!isSettingActive && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />

--- a/src/types/tasks/taskType.ts
+++ b/src/types/tasks/taskType.ts
@@ -26,5 +26,6 @@ export interface DetailedTaskType {
 		id: number;
 		startTime: string;
 		endTime: string;
+		isAllTime: boolean;
 	};
 }

--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -111,3 +111,13 @@ export const formatTimeToDueTime = (time: string) => {
 
 	return `${period} ${adjustedHours}시 ${minutes}분 까지`;
 };
+
+/**
+ *
+ * @param inputDate
+ * @returns 'yyyy-mm-ddThh:mm'
+ */
+export const formatDateToLocal = (inputDate: Date): string => {
+	const adjustedDate = new Date(inputDate.getTime() - inputDate.getTimezoneOffset() * 60000);
+	return adjustedDate.toISOString().slice(0, 16);
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- TimeBlock post, patch api에 requestBody: isAllTime 추가
- 관련 TimeBlock 타입들에도 isAllTime 추가
- FullCalendar 종일이벤트 스타일링

- 메인 모달, 풀캘린더 값 연동
- 타임그리드 상에서(주간캘린더) 드래그 통해 종일이벤트 <-> 특정 시간대 이벤트 수정
- 메인모달 통해 종일이벤트 <-> 특정 시간대 이벤트 수정

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 최대한 다 체크하긴 했는데.. 혹시 수정 중 에러터지는 동작 있는 지 체크 부탁드립니다! 

## 관련 이슈

close #371 

## 스크린샷 (선택)
![Jan-25-2025 05-44-45](https://github.com/user-attachments/assets/7e97b433-0396-4619-bf9a-028b0cfeec96)
