### PR TITLE
[FIX] 앰티뷰 위치 수정

### DIFF
--- a/src/components/common/EmptyViewStaging.tsx
+++ b/src/components/common/EmptyViewStaging.tsx
@@ -13,10 +13,13 @@ function EmptyViewStaging() {
 export default EmptyViewStaging;
 
 const EmptyView = styled.div`
+	position: absolute;
+	inset: -0.8rem 10.4rem 34rem;
 	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 24rem;
 	height: 52rem;
-	margin-top: 4rem;
 `;
 
 const EmptyImg = styled.img`

--- a/src/components/common/EmptyViewToday.tsx
+++ b/src/components/common/EmptyViewToday.tsx
@@ -13,9 +13,13 @@ function EmptyViewToday() {
 export default EmptyViewToday;
 
 const EmptyView = styled.div`
+	position: absolute;
 	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 20.772rem;
 	margin-top: 22.7rem;
+	inset: 22.5rem 10.4rem 34rem;
 `;
 
 const EmptyImg = styled.img`

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -112,6 +112,7 @@ const TaskWrapper = styled.div`
 	width: 100%;
 `;
 const StagingAreaTaskContainerLayout = styled.div`
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -114,6 +114,7 @@ const TargetAreaWrapper = styled.div`
 	padding-bottom: 2.8rem;
 `;
 const EmptyLayout = styled.div`
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 또 별거없는 사소한 피알
- 앰티뷰 두개 높이가 달라서 피그마 + 눈코딩으로 조정함!
- 피그마대로 위치 조정했는데 미세하게 안맞아서 눈코딩을 가미함 그래서 혹시 내 컴에선 이상하다 하면 알려주세요
- 별거 아니라 이상 없음 머지할게요

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex1) 관련 파일은 노션 참고해주세요!
- ex2

## 관련 이슈

close #389

## 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/870fba68-8dc6-409e-9ce9-045847006d1b)

