### PR TITLE
[FIX] QA 대응 - 로그인 리다이렉트 및 데탑 뷰 대응

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -58,7 +58,7 @@ const NavBarLayout = styled.div`
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-between;
-	width: 8rem;
+	min-width: 8rem;
 	height: 100%;
 
 	background-color: ${({ theme }) => theme.palette.Grey.White};

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -53,14 +53,12 @@ function NavBar({ isOpen, handleSideBar }: NavBarProps) {
 	);
 }
 const NavBarLayout = styled.div`
-	position: absolute;
-	left: 0;
 	z-index: 2;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: space-between;
-	width: 7.2rem;
+	width: 8rem;
 	height: 100%;
 
 	background-color: ${({ theme }) => theme.palette.Grey.White};

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -102,7 +102,6 @@ const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 44.8rem;
-	height: 108rem;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -59,7 +59,7 @@ function StagingAreaTaskContainer({
 	return (
 		<StagingAreaTaskContainerLayout>
 			<BtnTaskContainer id="dumping-task-container" type="staging">
-				{tasks?.length === 0 || !tasks ? (
+				{!tasks || tasks?.length === 0 ? (
 					<EmptyViewStaging />
 				) : (
 					<TaskWrapper>

--- a/src/components/common/fullCalendar/CalendarHeader.tsx
+++ b/src/components/common/fullCalendar/CalendarHeader.tsx
@@ -68,20 +68,20 @@ export default CalendarHeader;
 
 const CalendarHeaderContainer = styled.div<{ size: string }>`
 	position: absolute;
-	top: 56px;
+	top: 5.6rem;
 	z-index: 1;
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
 	box-sizing: border-box;
 	width: 100%;
-	height: auto;
-	padding: ${({ size }) => (size === 'big' ? '0 2.4rem;' : '0 1.6rem 0 2.4rem;')};
+	min-height: 3.2rem;
+	padding: 0 2.4rem;
 `;
 
 const CalendarHeaderWrapper = styled.div`
 	display: flex;
-	gap: 194px;
+	gap: 17.8rem;
 	margin-top: 0.2rem;
 
 	color: ${({ theme }) => theme.colorToken.Icon.normal};

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -4,9 +4,9 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	position: relative;
 
 	box-sizing: border-box;
-	width: ${({ size }) => (size === 'big' ? '132rem' : '88.8rem')};
+	width: 100%;
 	height: 100%;
-	padding: 0 10px 8px;
+	padding: 8px;
 	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
@@ -154,10 +154,9 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 		${({ currentView }) =>
 			currentView === 'timeGridWeekCustom' &&
-			`
-    border-left: none;
-		border-radius: 0
-  	`}
+			`border-left: none;
+			border-radius: 0;
+			border-right: none;`}
 	}
 
 	.fc-event-allday {
@@ -182,7 +181,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	/* 종일  - 타임그리드 셀 크기 고정 */
 	.fc-scrollgrid-sync-table > colgroup > col {
-		width: 3rem !important;
+		width: 4rem !important;
 	}
 
 	.fc-timegrid-axis .fc-scrollgrid-shrink {
@@ -190,7 +189,16 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	}
 
 	.fc-timegrid-body .fc-timegrid-slots > colgroup > col {
-		width: 3rem;
+		width: 4rem;
+	}
+
+	/* 쏟아내기에 따라서 타임 그리드 width 유동적을 변하도록 설정  */
+	.fc-timegrid-body {
+		width: 100% !important;
+	}
+
+	.fc-scrollgrid-section-body table {
+		width: 100% !important;
 	}
 
 	/* 전체 캘린더(주간) */
@@ -210,7 +218,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* fc-daygrid-day-events: 종일 행(개별) */
 	.fc-daygrid-day-frame .fc-scrollgrid-sync-inner,
 	.fc-daygrid-day-events {
-		width: ${({ size }) => (size === 'big' ? '17.6rem' : '16.8rem')};
+		width: 100%;
 		min-height: 4.4rem;
 	}
 
@@ -470,7 +478,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	/** .fc-daygrid-day: 각 날짜 별 박스 */
 	.fc-daygrid-day {
-		width: ${({ size }) => (size === 'big' ? '13.2rem' : '12.4rem')};
+		width: 100%;
 		height: ${({ currentView }) => (currentView === 'timeGridWeekCustom' ? '0' : '15.2rem')};
 	}
 
@@ -556,7 +564,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		display: flex;
 		gap: 4px;
 		align-items: center;
-		width: ${({ size }) => (size === 'big' ? '18rem' : '12rem')};
 		height: 2rem;
 		padding: 0 4px 0 8px;
 
@@ -603,7 +610,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	.fc-daygrid-more-link {
 		display: flex;
 		align-items: center;
-		width: ${({ size }) => (size === 'big' ? '18rem' : '12rem')};
 		height: 2rem;
 		padding: 0 4px 0 8px;
 
@@ -649,7 +655,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 스크롤 커스텀 */
 
 	.fc-scrollgrid-liquid::-webkit-scrollbar {
-		width: 0.6rem;
+		width: 0.4rem;
 	}
 
 	.fc-scrollgrid-liquid::-webkit-scrollbar-thumb {

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -177,6 +177,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc-scrollgrid-sync-table {
 		width: 100% !important;
+		height: 4rem !important;
 	}
 
 	/* 종일  - 타임그리드 셀 크기 고정 */

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -6,7 +6,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
-	padding: 8px;
+	padding: 0 8px;
 	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -5,7 +5,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	box-sizing: border-box;
 	width: ${({ size }) => (size === 'big' ? '132rem' : '88.8rem')};
-	height: 106.4rem;
+	height: 100%;
 	padding: 0 10px 8px;
 	overflow: hidden;
 

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -6,7 +6,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
-	padding: 0 8px;
+	padding: 0 0.8rem 0.8rem;
 	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
@@ -16,6 +16,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	.fc .fc-toolbar.fc-header-toolbar {
 		display: flex;
 		align-items: flex-start;
+		height: 6.4rem;
 		margin: 2.4rem 0 0;
 	}
 
@@ -47,6 +48,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		position: absolute;
 		top: 0;
 		left: 50%;
+		height: 3.2rem;
 		overflow: hidden;
 
 		background: ${({ theme }) => theme.color.Grey.White};
@@ -90,15 +92,15 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc-toolbar-chunk {
 		display: flex;
-		gap: 8px;
+		gap: 0.8rem;
 		align-items: center;
-		margin-right: 7.2rem;
+		margin-right: 6rem;
 	}
 
 	/* 오늘 버튼 */
 	.fc-toolbar-chunk .fc-today-button {
 		display: flex;
-		gap: 8px;
+		gap: 0.8rem;
 		align-items: center;
 		justify-content: center;
 		margin: 3.4rem 0 0;
@@ -156,7 +158,8 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 			currentView === 'timeGridWeekCustom' &&
 			`border-left: none;
 			border-radius: 0;
-			border-right: none;`}
+			border-right: none;
+			`}
 	}
 
 	.fc-event-allday {
@@ -169,7 +172,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc .fc-col-header-cell {
 		height: 2.4rem;
-		padding: 2.4rem 0.8rem 0.5rem;
+		padding: 1.6rem 0.8rem 0;
 
 		border-right: none;
 		border-left: none;

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -123,7 +123,7 @@ const DumpingAreaContainer = styled.div`
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 0.8rem;
 	align-items: flex-start;
 `;
 
@@ -164,7 +164,7 @@ const DumpingAreaWrapper = styled.div<{ state: InputState }>`
 
 const IconTouchArea = styled.div`
 	display: flex;
-	gap: 8px;
+	gap: 0.8rem;
 	align-items: center;
 	padding: 8px 8px 8px 16px;
 

--- a/src/components/common/v2/control/DropdownButton.tsx
+++ b/src/components/common/v2/control/DropdownButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import Button from '../button/Button';
 
+import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
 import StatusDropdown from '@/components/common/v2/dropdown/StatusDropdown';
 
 // 추후 type 로 빼기
@@ -76,6 +77,7 @@ function DropdownButton({ status, handleStatusChange, handleStatusEdit, isModalO
 				onClick={handleOpen}
 			/>
 			{isOpen && <StatusDropdown currentStatus={status} handleStatusChange={handleStatus} />}
+			{isOpen && <ModalBackdrop onClick={handleOpen} />}
 		</DropdownWrapper>
 	);
 }

--- a/src/components/common/v2/dropdown/StatusDropdown.tsx
+++ b/src/components/common/v2/dropdown/StatusDropdown.tsx
@@ -33,7 +33,7 @@ const StatusDropdownContainer = styled.div`
 	position: absolute;
 	top: calc(100% + 4px);
 	left: 0;
-	z-index: 2;
+	z-index: 4;
 	display: flex;
 	flex-direction: column;
 	gap: 0.6rem;

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -92,14 +92,14 @@ function DeadlineBox({
 		<>
 			{!isDueDate && <Divder />}
 			<DeadlineBoxContainer ref={containerRef}>
-				<DeadlineBtnLayout>
+				<DeadlineBtnLayout onClick={isClicked ? handleXBtnClick : handlePlusBtnClick}>
 					<CategoryTitleStyle>{label}</CategoryTitleStyle>
 					{!isDueDate && (
 						<div>
 							{isClicked ? (
-								<Icon name="IcnX" size="tiny" color="strong" onClick={handleXBtnClick} isCursor />
+								<Icon name="IcnX" size="tiny" color="strong" isCursor />
 							) : (
-								<Icon name="IcnPlus" size="tiny" color="strong" onClick={handlePlusBtnClick} isCursor />
+								<Icon name="IcnPlus" size="tiny" color="strong" isCursor />
 							)}
 						</div>
 					)}
@@ -152,8 +152,10 @@ const DeadlineBtnLayout = styled.div`
 	display: flex;
 	gap: 0.8rem;
 	align-items: center;
-	width: 100%;
+	width: fit-content;
 	height: 2.4rem;
+
+	cursor: pointer;
 `;
 
 const CategoryTitleStyle = styled.div`

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -162,8 +162,7 @@ const TodoContainer = styled.div<{ isCompleted: boolean }>`
 		isCompleted ? theme.colorToken.Outline.neutralNormal : theme.colorToken.Outline.neutralStrong};
 
 	&:hover {
-		border: ${({ isCompleted }) => (isCompleted ? '1px' : '2px')} solid
-			${({ theme }) => theme.colorToken.Outline.primaryStrong};
+		border: 1px solid ${({ theme }) => theme.colorToken.Outline.primaryStrong};
 	}
 
 	&:active {
@@ -176,7 +175,7 @@ const TodoWrapper = styled.div`
 	display: flex;
 	flex: 1 0 0;
 	flex-direction: column;
-	gap: 4px;
+	gap: 0.4rem;
 	align-items: flex-start;
 	padding: 1rem 2.4rem 1.4rem;
 `;
@@ -184,10 +183,10 @@ const TodoWrapper = styled.div`
 const DropdownWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 0.8rem;
 	align-items: center;
 	justify-content: center;
 	box-sizing: border-box;
 	height: 6.4rem;
-	padding: 8px 8px 24px 0;
+	padding: 0.8rem 0.8rem 2.4rem 0;
 `;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -68,9 +68,8 @@ const TargetAreaLayout = styled.section`
 	flex-direction: column;
 	flex-shrink: 0;
 	align-items: flex-start;
-	box-sizing: border-box;
 	width: 47.2rem;
-	height: 108rem;
+	max-height: 106.4rem;
 	margin: 0.8rem;
 
 	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -69,7 +69,6 @@ const TargetAreaLayout = styled.section`
 	flex-shrink: 0;
 	align-items: flex-start;
 	width: 47.2rem;
-	max-height: 106.4rem;
 	margin: 0.8rem;
 
 	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};

--- a/src/components/targetArea/TargetControlSection.tsx
+++ b/src/components/targetArea/TargetControlSection.tsx
@@ -64,7 +64,7 @@ const TargetControlSectionLayout = styled.div`
 	box-sizing: border-box;
 	width: 100%;
 	height: 4.8rem;
-	padding: 0 1.6rem 0 2.8rem;
+	padding: 0.8rem 1.6rem 0.8rem 2.8rem;
 `;
 const BtnWrapper = styled.div`
 	display: flex;

--- a/src/components/targetArea/TargetFilterSection.tsx
+++ b/src/components/targetArea/TargetFilterSection.tsx
@@ -17,7 +17,7 @@ const TargetFilterSectionLayout = styled.div`
 	box-sizing: border-box;
 	width: 100%;
 	height: 4.8rem;
-	padding: 0 2rem;
+	padding: 0.8rem 1.6rem;
 
 	border-top: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralNormal};
 `;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -53,7 +53,7 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 
 	return (
 		<BtnTaskContainer id="todolist-task-container" type="target">
-			{tasks.length === 0 ? (
+			{!tasks || tasks?.length === 0 ? (
 				<EmptyLayout>
 					<EmptyViewToday />
 				</EmptyLayout>

--- a/src/hooks/useAuthRedirect.ts
+++ b/src/hooks/useAuthRedirect.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useAuthRedirect = () => {
+	const navigate = useNavigate();
+	const isAuthenticated = localStorage.getItem('accessToken');
+
+	useEffect(() => {
+		if (isAuthenticated) {
+			navigate('/today');
+		}
+	}, [isAuthenticated, navigate]);
+};
+
+export default useAuthRedirect;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import { GoogleOAuthProvider } from '@react-oauth/google';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Images from '@/assets/images';
 import GoogleLoginBtn from '@/components/loginPage/GoogleLoginBtn';
@@ -7,6 +9,14 @@ import LoginContainer from '@/components/loginPage/LoginContainer';
 
 function Login() {
 	const LOGIN_CLIENT_ID = import.meta.env.VITE_GOOGLE_LOGIN_CLIENT_ID;
+	const isAuthenticated = localStorage.getItem('accessToken');
+	const naviate = useNavigate();
+
+	useEffect(() => {
+		if (isAuthenticated) {
+			naviate('/today');
+		}
+	}, [isAuthenticated, naviate]);
 
 	return (
 		<GoogleOAuthProvider clientId={LOGIN_CLIENT_ID}>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -99,11 +99,10 @@ const LoginLayout = styled.div`
 	position: relative;
 	display: flex;
 	justify-content: space-between;
-	width: 192rem;
-	height: 108rem;
+	width: 100%;
+	height: 100vh;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
-	border-radius: 8px;
 
 	@media (width <= 900px) {
 		display: flex;
@@ -137,11 +136,7 @@ const LeftSection = styled.section`
 `;
 
 const LoginImg = styled.img`
-	width: 70%;
-	height: 100%;
-	object-fit: cover;
-
-	border-radius: 0 8px 8px 0;
+	object-fit: contain;
 
 	@media (width <= 900px) {
 		width: 100%;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,22 +1,14 @@
 import styled from '@emotion/styled';
 import { GoogleOAuthProvider } from '@react-oauth/google';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Images from '@/assets/images';
 import GoogleLoginBtn from '@/components/loginPage/GoogleLoginBtn';
 import LoginContainer from '@/components/loginPage/LoginContainer';
+import useAuthRedirect from '@/hooks/useAuthRedirect';
 
 function Login() {
 	const LOGIN_CLIENT_ID = import.meta.env.VITE_GOOGLE_LOGIN_CLIENT_ID;
-	const isAuthenticated = localStorage.getItem('accessToken');
-	const naviate = useNavigate();
-
-	useEffect(() => {
-		if (isAuthenticated) {
-			naviate('/today');
-		}
-	}, [isAuthenticated, naviate]);
+	useAuthRedirect();
 
 	return (
 		<GoogleOAuthProvider clientId={LOGIN_CLIENT_ID}>

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -10,12 +10,11 @@ function MainLayout() {
 }
 const MainLayOutContainer = styled.div`
 	position: relative;
-	width: 192rem;
-	height: 108rem;
-	padding-left: 7.2rem;
+
+	width: 100%;
+	height: 100vh;
 
 	background-color: ${({ theme }) => theme.colorToken.Component.strong};
-	border-radius: 8px;
 `;
 
 export default MainLayout;

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -39,7 +39,7 @@ export default Setting;
 
 const SettingLayout = styled.div`
 	display: flex;
-	height: 108rem;
+	height: 100vh;
 	overflow: hidden;
 `;
 

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -195,5 +195,6 @@ const CalendarWrapper = styled.div`
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: fit-content;
-	margin: 1rem 0;
+	width: 100%;
+	margin: 1rem 0.8rem 1rem 0;
 `;

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -171,7 +171,7 @@ function Today() {
 			</DragDropContext>
 			<CalendarWrapper>
 				<FullCalendarBox
-					size="small"
+					size={isDumpAreaOpen ? 'small' : 'big'}
 					selectedTarget={selectedTarget}
 					selectDate={selectedDate}
 					handleChangeDate={handleChangeDate}

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -185,7 +185,7 @@ export default Today;
 
 const TodayLayout = styled.div`
 	display: flex;
-	height: 108rem;
+	height: 100vh;
 	overflow: hidden;
 `;
 

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -147,7 +147,7 @@ const style = css`
 	}
 
 	html {
-		font-size: 62.5%;
+		font-size: 45%;
 	}
 
 	:root {

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -147,7 +147,13 @@ const style = css`
 	}
 
 	html {
-		font-size: 45%;
+		font-size: 62.5%;
+	}
+
+	@media (width <= 1440px) {
+		html {
+			font-size: 50%;
+		}
 	}
 
 	:root {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 로그인한 유저일 경우 /today로 리다이렉트 시키는 로직 추가하였습니다.
- 디자인이 1920px * 1080px로 이루어져  대부분의 작업 환경인 맥북 13인치와 맞지 않아 font-size를 45%로 수정하고 height는 view height 기준으로 늘어날 수 있게 하였습니다.
- 쏟아내기 on/off에 따라서 캘린더의 width를 남은 화면을 꽉 채울 수 있도록 수정하였습니다.
- todo의 진행 상태를 수정하는 토글 영역 밖을 누르면 해당 모달이 꺼지도록 수정하였습니다.
- 모달의 마감기간 터치영역이 아이콘으로 한정되어 있어서 해당 터치영역을 넓혔습니다.
- 캘린더의 종일 부분의 테두리가 약간 맞지 않아서 해당 부분도 함께 수정했습니다. 
- 캘린더 상단 버튼들이 일직선으로 있지 않아서 해당 부분 스타일도 수정하였습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 로그인 리다이렉트 관련 브랜치였으나 화면 크기가 맞지 않는게 너무 거슬려 함께 작업하였습니다 죄송함다.
- 간만에 한 캘린더 css 커스텀은 역시나 힘들었슴다. 코드가 몇개 수정되지 않았지만 찾는데 상당한 시간이 들었습니다 ,,
- 기본 폰트가 너무 작다고 생각되시면 말씀해주세요!! 

## 관련 이슈

close #401 

## 스크린샷 (선택)
- 캘린더 상단 버튼 정렬
<img width="698" alt="image" src="https://github.com/user-attachments/assets/dfa0b7ed-9ad8-43be-ab8b-44bf7ea41759" />

- 데탑 뷰 크기 대응
https://github.com/user-attachments/assets/e871b0a0-063a-4db8-9b45-bc9644c98d9c

